### PR TITLE
Adding container caching for Bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,6 @@ bundler_args: --without headless debug
 
 before_install:
   - gem install bundler
+
+cache: bundler
+sudo: false


### PR DESCRIPTION
So long as we are not running sudo commands, we can cache the
container for later reference.

http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/