### PR TITLE
Hide modal dialog boxes on page load

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -19,7 +19,7 @@
  *= require_self
  */
 
-/* Inline form fields */
+// Inline form fields
 .control-group.inline input {
   padding-bottom:.1em;
   padding-top:.1em;
@@ -37,7 +37,7 @@
   display: none;
 }
 
-/* Modal dialog fix */
+// Modal dialog fix
 .js .modal {
   display: none;
 }

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -36,3 +36,8 @@
 .browse-everything {
   display: none;
 }
+
+/* Modal dialog fix */
+.js .modal {
+  display: none;
+}


### PR DESCRIPTION
Even though the modal dialog windows were marked as ARIA hidden the form
controls were still accessible. On the record show view this caused a
problem because form controls on the modal window overlapped with site
navigation elements.

The JavaScript sets explicit in-line styles to show or hide the modal
dialog when it is activated/deactivated.

This fixes #192