### PR TITLE
Renaming ETD label to Thesis or Dissertation

### DIFF
--- a/app/repository_models/etd.rb
+++ b/app/repository_models/etd.rb
@@ -1,0 +1,9 @@
+require Curate::Engine.root.join('app/repository_models/etd')
+
+class Etd
+  self.human_readable_short_description = "Deposit a master's thesis or dissertation."
+
+  def self.human_readable_type
+    'Thesis or Dissertation'
+  end
+end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -221,7 +221,6 @@ namespace :maintenance do
   task :orcid_migration, :roles => :app do
     run "cd #{current_path} && bundle exec rails runner -e #{rails_env} script/migrations/orcid_migration.rb"
   end
-
 end
 
 set(:secret_repo_name) {


### PR DESCRIPTION
We want to replace ETD with Theses or Dissertations;
However I'm going with the singular as that is what the others are
referencing.

Closes #216

As part of the deploy we will want to run `maintenance:reindex_solr`