### PR TITLE
Add a content license modal popup

### DIFF
--- a/app/views/curation_concern/base/_form_content_license.html.erb
+++ b/app/views/curation_concern/base/_form_content_license.html.erb
@@ -3,9 +3,6 @@
   <p>
     What do you want others to be able to do with your work?
   </p>
-  <p>
-    <a href="http://creativecommons.org/licenses/" target="_blank">Here's some help</a> if you don't know which license to choose.
-  </p>
 
   <%= f.input :rights,
     as: :select,
@@ -13,4 +10,6 @@
     input_html: { class: 'input-xxlarge' },
     label: 'Content License'
   %>
+
+  <%=render :partial => "curation_concern/base/license_modal" %>
 </fieldset>

--- a/app/views/curation_concern/base/_license_modal.html.erb
+++ b/app/views/curation_concern/base/_license_modal.html.erb
@@ -1,0 +1,78 @@
+<!-- Button to trigger modal -->
+<div class="modal-div">
+  <a href="#licenseModal" role="button" class="btn fright" data-toggle="modal">License Descriptions</a>
+</div>
+
+<!-- Modal -->
+<div class="modal hide fade" id="licenseModal" tabindex="-1" role="dialog" aria-labelledby="License Descriptions" aria-hidden="true">
+  <div class="modal-header">
+    <h2><%= t('sufia.product_name') %> License Descriptions</h2>
+  </div>
+  <div class="modal-body" aria-hidden="true">
+    <p><%= t('sufia.product_name') %> offers the following licenses for deposited
+    items.
+    The majority come from the set of <a href="http://creativecommons.org/licenses/">Creative Commons licenses</a>.
+    See these <a href="https://creativecommons.org/examples">examples</a> of
+    uses of Creative Commons licenses.
+    </p>
+    <ul>
+    <li><b>Attribution 3.0: CC BY</b><br/>
+      With this license you allow others to "distribute, remix, tweak, and
+      build" on your deposited content—including for commercial purposes—provided
+      they attribute you as the original creator.
+    </li>
+    <li><b>Attribution-Share-Alike 3.0: CC BY-SA</b> <br/>
+      With this license you allow others to "remix, tweak, and build" on your
+      deposited content, including for commercial uses, provided they attribute
+      you as the original creator AND incorporate the same level of licensing
+      (i.e., CC BY-SA) for the newly resulting creation. "All new works based
+      on yours will carry the same license, so any derivatives will also allow
+      commercial use."
+    </li>
+    <li><b>Attribution-Non-Commercial 3.0: CC BY-NC</b><br/>
+      With this license you allow others to "remix, tweak, and build" on your
+      content in non-commercial ways. While they must credit you as the
+      original creator and while the remixed, tweaked, or expanded upon content
+      must remain non-commercial, they do not have to apply identical license
+      terms on the new content.
+    </li>
+    <li><b>Attribution-NoDerivs 3.0: CC BY-ND</b><br/>
+      With this license you permit "redistribution, commercial and
+      non-commercial," provided the content remains unaltered and intact (i.e.,
+      whole) and provided you are attributed as the original creator.
+    </li>
+    <li><b>Attribution-NonCommercial-NoDerivs 3.0 CC BY-NC-ND</b><br/>
+      With this license you share your work with others and allow them to
+      download your work, provided they attribute you as the creator and
+      refrain from changing the content in any way and from using it for
+      commercial means.
+    </li>
+    <li><b>Attribution-Non-Commercial-Share-Alike 3.0: CC BY-NC-SA</b><br/>
+      With this license you allow others to "remix, tweak, and build" on your
+      content in non-commercial ways, provided they give you credit (as the
+      original creator) and also apply the same license level to the newly
+      resulting creations.
+    </li>
+    <li><b>Public Domain Mark 1.0 </b><br/>
+      When content is in the public domain, it has no known copyright owner.
+    </li>
+    <li><b>CC0 1.0 Universal </b><br/>
+      With this license you are waiving your rights as copyright owner to the
+      content you upload. This means your content may be distributed and reused
+      without attribution, without restriction. CC0 is a license that one
+      applies to one's own work; rarely does one apply it to another's work,
+      unless one has the appropriate rights to do so.
+    </li>
+    <li><b>All rights reserved</b><br/>
+      With this license you—as the copyright holder—reserve all rights held
+      under copyright law, such as for distribution and creation of derivative
+      works. This means that no one can use your content in a work—such as a
+      presentation or article—or create derivatives from it without your
+      permission.
+    </li>
+    </ul>
+  </div>
+  <div class="modal-footer">
+    <button class="btn btn-primary" data-dismiss="modal" aria-hidden="true">Close</button>
+  </div>
+</div>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -43,7 +43,7 @@ en:
         repository_name: "The name of the organization or institution that holds the original physical object, if applicable."
         publisher: "An entity responsible for making the original resource available."
         source: "A related resource from which the described resource is derived. The described resource may be derived from the related resource in whole or in part. Recommended best practice is to identify the related resource by means of a string conforming to a formal identification system."
-        rights: "Information about rights to the content, such as copyright, contract, and privacy rights. Ownership of original physical item (book, print, etc) should be recorded in dc.contributor.repository, and does not apply here. Rights information can take the form of a copyright statement, a license, or terms of use. If the Rights element is absent, no assumptions may be made about any rights held in or over the resource."
+        rights: "Set the license which governs how others may use your files. The main questions are whether others can reuse your work in deritivies, and whether you want attribution as the original creator."
         contributor_institution: "A consistent reference to the Institution that contributes the material."
         format: "The media type of the item. The system stored and registered MIME type of the file uploaded. Comments: This is an automatically system generated field so it does not need to be filled in. The field is present here so that metadata contributor knows how it is captured."
         size: "Size or duration of the resource."


### PR DESCRIPTION
The modal contains a description of the content licenses available for
selection. The text is copied from VecNet, which came from Sufia, which
came from the creative commons website.

I'd appreciate any comments on my html and use of bootstrap.

Fixes #219 
