### PR TITLE
Increasing no items found text

### DIFF
--- a/.scss_lint.yml
+++ b/.scss_lint.yml
@@ -13,6 +13,7 @@ linters:
     exclude:
       - 'app/assets/stylesheets/global-variables.scss'
       - 'app/assets/stylesheets/layout/positioning.css.scss'
+      - 'app/assets/stylesheets/modules/pagination.css.scss'
   QualifyingElement:
     exclude: 'app/assets/stylesheets/style/nd-theme-print.css.scss'
   SelectorFormat:

--- a/app/assets/stylesheets/modules/pagination.css.scss
+++ b/app/assets/stylesheets/modules/pagination.css.scss
@@ -1,6 +1,49 @@
 @import 'global-variables';
 
-.pager .active a {
-  background-color: $pagination-border;
-  color: $pagination-background;
+.pager {
+  float: right;
+  margin-top: 0;
+  text-align: center;
+  width: 100%;
+
+  .active a {
+    background-color: $pagination-border;
+    color: $pagination-background;
+  }
+
+  .next-page,
+  .prev-page {
+    a,
+    span {
+      background-color: $white;
+      border: 1px solid $pagination-border;
+      border-radius: 15px;
+      display: inline-block;
+      padding: 5px 14px;
+    }
+  }
+
+  .page_links {
+    display: block;
+  }
+
+  .page_entries {
+    display: block;
+    text-align: right;
+
+    .no-items-found {
+      display: block;
+      font-size: 1.33em;
+      font-style: italic;
+      font-weight: normal;
+      margin-bottom: 2em;
+      text-align: center;
+    }
+  }
+}
+
+@media (min-width: 768px) {
+  .pager .page_entries .no-items-found {
+    text-align: left;
+  }
 }

--- a/app/assets/stylesheets/modules/pagination.css.scss
+++ b/app/assets/stylesheets/modules/pagination.css.scss
@@ -30,15 +30,20 @@
   .page_entries {
     display: block;
     text-align: right;
+  }
 
-    .no-items-found {
-      display: block;
-      font-size: 1.33em;
-      font-style: italic;
-      font-weight: normal;
-      margin-bottom: 2em;
-      text-align: center;
-    }
+  .no-items-found {
+    display: block;
+    font-size: 1.33em;
+    font-style: italic;
+    font-weight: normal;
+    line-height: 1.5;
+    margin-bottom: 2em;
+    text-align: center;
+  }
+
+  .new-search-from-no-results {
+    font-style: normal;
   }
 }
 

--- a/app/assets/stylesheets/modules/search_results.css.scss
+++ b/app/assets/stylesheets/modules/search_results.css.scss
@@ -1,12 +1,5 @@
 @import 'global-variables';
 
-.page_entries {
-  .no-items-found {
-    font-size: 1.33em;
-    font-weight: bold;
-  }
-}
-
 .search-results-list {
   list-style-type: none;
   margin: 0;

--- a/app/assets/stylesheets/modules/search_results.css.scss
+++ b/app/assets/stylesheets/modules/search_results.css.scss
@@ -1,5 +1,12 @@
 @import 'global-variables';
 
+.page_entries {
+  .no-items-found {
+    font-size: 1.33em;
+    font-weight: bold;
+  }
+}
+
 .search-results-list {
   list-style-type: none;
   margin: 0;

--- a/app/assets/stylesheets/style/search.css.scss
+++ b/app/assets/stylesheets/style/search.css.scss
@@ -20,25 +20,6 @@
   }
 }
 
-.pager {
-  display: inline-block;
-  float: right;
-  margin-top: 0;
-  text-align: right;
-
-  .next-page,
-  .prev-page {
-    a,
-    span {
-      background-color: $white;
-      border: 1px solid $pagination-border;
-      border-radius: 15px;
-      display: inline-block;
-      padding: 5px 14px;
-    }
-  }
-}
-
 .search-result:first-child {
   clear: both;
 }

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -2,7 +2,7 @@ en:
   blacklight:
     search:
       pagination_info:
-        no_items_found: "<span class='no-items-found'>No entries matched your search criteria</span>"
+        no_items_found: '<p class="no-items-found">Your search yielded no results.<br /><a href="/catalog" class="new-search-from-no-results">Start a new search</a></p>'
   sufia:
     product_name:        "CurateND"
     account_name:        "Notre Dame NetID"

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -1,4 +1,8 @@
 en:
+  blacklight:
+    search:
+      pagination_info:
+        no_items_found: "<span class='no-items-found'>No entries matched your search criteria</span>"
   sufia:
     product_name:        "CurateND"
     account_name:        "Notre Dame NetID"


### PR DESCRIPTION
Why:

* At present the "No entries found" was getting lost in the chatter of
  the page.

This change addresses the need by:

* Increasing the font-size and font-weight of the "no search items"
  result. Note: This value piggy backs on the paging response for a
  search query (and not the search result area). In other words, if
  there are no items in the result set; Instead of rendering a "no
  items in the result set" section within the search results area,
  Blacklight renders a "no_items_found" I18n value in the pagination
  area.

As per the ticket, I'd like to move the result to the left, however,
due to the parent container's lack of a modifying class, I can' remove
or as easily target and adjust the parent `.pager { float: right; }`
directive.

Closes #221