### PR TITLE
Align content inside of grid tile

### DIFF
--- a/app/assets/stylesheets/modules/search_result_grid.css.scss
+++ b/app/assets/stylesheets/modules/search_result_grid.css.scss
@@ -9,9 +9,12 @@
 .grid-tile {
   border: 1px solid $gray-lightest;
   box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
   margin-bottom: 10px;
   margin-right: 5px;
-  padding: 5px;
+  padding: 10px 5px 5px;
   position: relative;
   width: 140px;
 }
@@ -69,6 +72,10 @@
 }
 
 .no-js {
+  .grid-tile {
+    padding-top: 5px;
+  }
+
   .tile-actions-menu {
     position: relative;
     right: auto;


### PR DESCRIPTION
Thumbnails can vary in size. I’m using flexbox to keep the thumbnail at the top of the container and the caption at the bottom.