### PR TITLE
Don’t allow anonymous user to add things to a collection

### DIFF
--- a/app/views/curation_concern/base/show.html.erb
+++ b/app/views/curation_concern/base/show.html.erb
@@ -6,7 +6,7 @@
 <% end %>
 
 <%
-  collector = can?(:collect, curation_concern)
+  collector = current_user.present?
   editor    = can?(:edit,    curation_concern)
 %>
 <% if collector || editor %>


### PR DESCRIPTION
The previous permission check was still returning true even when a patron was not logged in.