### PR TITLE
CSS changes for grid search result view

### DIFF
--- a/app/assets/stylesheets/modules/concerns.css.scss
+++ b/app/assets/stylesheets/modules/concerns.css.scss
@@ -14,7 +14,6 @@
   margin-top: 15px;
 
   a {
-    border: 1px solid $gray-lightest;
     display: block;
   }
 

--- a/app/assets/stylesheets/modules/search_result_grid.css.scss
+++ b/app/assets/stylesheets/modules/search_result_grid.css.scss
@@ -1,5 +1,8 @@
 .search-results-grid {
+  display: flex;
+  flex-wrap: wrap;
   float: left;
+  justify-content: flex-start;
   list-style: none;
   margin: 0;
   padding: 0;
@@ -8,11 +11,10 @@
 
 .grid-tile {
   border: 1px solid $gray-lightest;
-  box-sizing: border-box;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
-  margin-bottom: 10px;
+  justify-content: flex-start;
+  margin-bottom: 5px;
   margin-right: 5px;
   padding: 10px 5px 5px;
   position: relative;
@@ -21,14 +23,38 @@
 
 @media (min-width: 768px) {
   .grid-tile {
-    margin-right: 10px;
     width: 200px;
   }
 }
 
 .tile-thumbnail {
+  padding: 5px 0;
+
   a {
     display: inline-block;
+  }
+
+  .canonical-image {
+    max-height: 100%;
+    max-width: 100%;
+  }
+}
+
+// .thumbnail-wrapper is a fixed size because I couldn’t figure out how to make
+// a fluid container that supported vertical centering and still maintained the
+// image aspect ratio
+.thumbnail-wrapper {
+  align-items: center;
+  display: flex;
+  height: 140px;
+  justify-content: center;
+  width: 140px;
+}
+
+@media (min-width: 768px) {
+  .thumbnail-wrapper {
+    height: 200px;
+    width: 200px;
   }
 }
 
@@ -91,17 +117,13 @@
   }
 }
 
-.flexbox {
-  .search-results-grid {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: flex-start;
-  }
-}
-
 .no-flexbox {
   .grid-tile {
     display: inline-block;
+  }
+
+  .thumbnail-wrapper {
+    text-align: center;
   }
 }
 

--- a/app/assets/stylesheets/style/nd-theme.css.scss
+++ b/app/assets/stylesheets/style/nd-theme.css.scss
@@ -281,7 +281,7 @@ $logo-height: 48;
 }
 
 .help-report-a-problem {
-  margin:.5em .5em .5em 0;
+  margin: .5em .5em .5em 0;
 }
 
 @media (min-width: 768px) {

--- a/app/views/catalog/_index_partials/_thumbnail_display.html.erb
+++ b/app/views/catalog/_index_partials/_thumbnail_display.html.erb
@@ -1,10 +1,26 @@
 <% title_link_target ||= polymorphic_path([:curation_concern, document]) %>
-<%- if document.respond_to?(:representative_image_url) && document.representative_image_url.present? %>
-  <%= link_to(image_tag(document.representative_image_url, html_options = { class: "canonical-image"}), title_link_target )  %>
-<%- elsif document.respond_to?(:representative) && document.representative.present? %>
-  <%= link_to(image_tag(download_path(document.representative,  'thumbnail'), html_options = { class: "canonical-image" }), title_link_target)  %>
-<%- elsif document.persisted? -%>
-  <%= link_to(image_tag(download_path(document,  'thumbnail'), html_options = { class: "canonical-image"}), title_link_target)  %>
-<%- else -%>
-  <%= link_to('<span class="canonical-image"></span>'.html_safe, title_link_target) %>
-<%- end -%>
+<% if document.respond_to?(:representative_image_url) && document.representative_image_url.present? %>
+  <%= link_to title_link_target do %>
+    <div class="thumbnail-wrapper">
+      <%= image_tag(document.representative_image_url, html_options = { class: "canonical-image"}) %>
+    </div>
+  <% end %>
+<% elsif document.respond_to?(:representative) && document.representative.present? %>
+  <%= link_to title_link_target do  %>
+    <div class="thumbnail-wrapper">
+      <%= image_tag(download_path(document.representative,  'thumbnail'), html_options = { class: "canonical-image" }) %>
+    </div>
+  <% end %>
+<% elsif document.persisted? %>
+  <%= link_to title_link_target do  %>
+    <div class="thumbnail-wrapper">
+      <%= image_tag(download_path(document,  'thumbnail'), html_options = { class: "canonical-image"}) %>
+    </div>
+  <% end %>
+<% else %>
+  <%= link_to title_link_target do %>
+    <div class="thumbnail-wrapper">
+      <span class="canonical-image"></span>
+    </div>
+  <% end %>
+<% end %>


### PR DESCRIPTION
Thumbnails should remain centered regardless of size or aspect ratio.
Thumbnail images should not be cropped or stretched.