### PR TITLE
Locking browse-everything version to known-good state

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ group :default do
   gem 'nokogiri', "~>1.6.0"
   gem 'jettywrapper'
   gem 'jquery-rails'
+  gem 'browse-everything', '0.8.2'
   gem 'decent_exposure'
   gem 'devise_cas_authenticatable'
   gem 'devise_masquerade'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,7 +168,7 @@ GEM
       activesupport
       rack
     breadcrumbs_on_rails (2.3.1)
-    browse-everything (0.9.0)
+    browse-everything (0.8.2)
       bootstrap-sass
       dropbox-sdk (>= 1.6.2)
       font-awesome-rails
@@ -277,7 +277,7 @@ GEM
     factory_girl_rails (4.2.1)
       factory_girl (~> 4.2.0)
       railties (>= 3.0.0)
-    faraday (0.9.1)
+    faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     fastercsv (1.5.5)
     ffi (1.9.8)
@@ -371,7 +371,7 @@ GEM
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
-    jwt (1.5.1)
+    jwt (1.5.2)
     kgio (2.8.1)
     launchy (2.4.3)
       addressable (~> 2.3)
@@ -403,7 +403,7 @@ GEM
     minitest (4.7.5)
     mono_logger (1.1.0)
     morphine (0.1.1)
-    multi_json (1.11.0)
+    multi_json (1.11.2)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     mysql2 (0.3.13)
@@ -628,12 +628,12 @@ GEM
       nokogiri
       stomp
       xml-simple
-    sprockets (2.12.3)
+    sprockets (2.12.4)
       hike (~> 1.2)
       multi_json (~> 1.0)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
-    sprockets-rails (2.3.2)
+    sprockets-rails (2.3.3)
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
@@ -668,7 +668,7 @@ GEM
     tilt (1.4.1)
     timecop (0.6.3)
     trollop (1.16.2)
-    tzinfo (0.3.44)
+    tzinfo (0.3.45)
     uber (0.0.15)
     uglifier (2.2.1)
       execjs (>= 0.3.0)
@@ -708,6 +708,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootstrap-datepicker-rails
+  browse-everything (= 0.8.2)
   byebug
   capistrano (~> 2.15)
   capybara (~> 2.4)


### PR DESCRIPTION
There is/was a leaky event handler in browse everything that stomped on
ALL checkbox inputs. This broke the accept terms of deposit checkbox in
some circumstances.

Thanks to @jeremyf for locating the problem.

---
Addresses #249