### PR TITLE
Clarify access level when viewing repository objects

### DIFF
--- a/app/assets/stylesheets/modules/concerns.css.scss
+++ b/app/assets/stylesheets/modules/concerns.css.scss
@@ -41,6 +41,7 @@
     display: inline-block;
     position: relative;
 
+    &.width-100 .access-rights-qualifier,
     &.width-100 .label {
       left: 115px;
       right: auto;
@@ -50,6 +51,15 @@
       position: absolute;
       right: 0;
       top: 0;
+    }
+
+    .access-rights-qualifier {
+      color: $gray-dark;
+      display: inline-block;
+      position: absolute;
+      right: 0;
+      top: 1.7em;
+      white-space: nowrap;
     }
   }
 

--- a/app/models/access_renderer.rb
+++ b/app/models/access_renderer.rb
@@ -63,7 +63,7 @@ class AccessRenderer
       if has_embargo? && currently_under_embargo?
         dom_label_class = 'label-warning'
         link_title = 'Under Embargo'
-        qualifier = " until #{human_readable_embargo_release_date}"
+        qualifier = "until #{human_readable_embargo_release_date}"
       elsif publically_viewable?
         dom_label_class = 'label-success'
         link_title = 'Open Access'
@@ -81,7 +81,7 @@ class AccessRenderer
     markup = %(<span class="label #{dom_label_class}" title="#{link_title}">#{link_title}</span>).html_safe
 
     if show_date
-      markup << qualifier
+      markup << %( <span class="access-rights-qualifier">#{qualifier}</span>).html_safe
     else
       markup
     end

--- a/app/models/access_renderer.rb
+++ b/app/models/access_renderer.rb
@@ -76,8 +76,14 @@ class AccessRenderer
   end
   private :extract_dom_label_class_and_link_title
 
-  def badge
+  def badge(show_date: false)
     dom_label_class, link_title, qualifier = extract_dom_label_class_and_link_title
-    %(<span class="label #{dom_label_class}" title="#{link_title}">#{link_title}</span>#{qualifier}).html_safe
+    markup = %(<span class="label #{dom_label_class}" title="#{link_title}">#{link_title}</span>).html_safe
+
+    if show_date
+      markup << qualifier
+    else
+      markup
+    end
   end
 end

--- a/app/models/access_renderer.rb
+++ b/app/models/access_renderer.rb
@@ -1,0 +1,83 @@
+class AccessRenderer
+  def initialize(curation_concern, solr_document = nil)
+    @solr_document ||= curation_concern.to_solr
+  end
+
+  def access_rights_hash
+    @access_rights_hash ||= @solr_document.stringify_keys
+  end
+
+  def viewable_groups_key
+    Hydra.config[:permissions][:read][:group]
+  end
+  private :viewable_groups_key
+
+  def viewable_groups
+    @viewable_groups ||= access_rights_hash[viewable_groups_key]
+  end
+
+  def viewable?
+    viewable_groups.present?
+  end
+
+  def publically_viewable?
+    viewable_groups.include?('public')
+  end
+
+  def viewable_by_institution?
+    viewable_groups.include?('registered')
+  end
+
+  def embargo_release_date_key
+    Hydra.config[:permissions][:embargo_release_date]
+  end
+  private :embargo_release_date_key
+
+  def embargo_release_date_value
+    access_rights_hash[embargo_release_date_key]
+  end
+  private :embargo_release_date_value
+
+  def embargo_release_date
+    @embargo_release_date ||= DateTime.parse(embargo_release_date_value)
+  end
+
+  def human_readable_embargo_release_date
+    embargo_release_date.strftime("%Y-%m-%d")
+  end
+
+  def has_embargo?
+    embargo_release_date_value.present?
+  end
+
+  def currently_under_embargo?
+    embargo_release_date > DateTime.current
+  end
+
+  def extract_dom_label_class_and_link_title
+    dom_label_class = 'label-important'
+    link_title = 'Private'
+    qualifier = ''
+
+    if viewable?
+      if has_embargo? && currently_under_embargo?
+        dom_label_class = 'label-warning'
+        link_title = 'Under Embargo'
+        qualifier = " until #{human_readable_embargo_release_date}"
+      elsif publically_viewable?
+        dom_label_class = 'label-success'
+        link_title = 'Open Access'
+      elsif viewable_by_institution?
+        dom_label_class = 'label-info'
+        link_title = I18n.t('sufia.institution_name')
+      end
+    end
+    [dom_label_class, link_title, qualifier]
+  end
+  private :extract_dom_label_class_and_link_title
+
+  def badge
+    dom_label_class, link_title, qualifier = extract_dom_label_class_and_link_title
+    %(<span class="label #{dom_label_class}" title="#{link_title}">#{link_title}</span>#{qualifier}).html_safe
+  end
+end

--- a/app/models/access_renderer.rb
+++ b/app/models/access_renderer.rb
@@ -1,6 +1,10 @@
 class AccessRenderer
   def initialize(curation_concern, solr_document = nil)
-    @solr_document ||= curation_concern.to_solr
+    if solr_document
+      @solr_document = solr_document
+    else
+      @solr_document = curation_concern.to_solr
+    end
   end
 
   def access_rights_hash

--- a/app/views/application/_permission_badge.html.erb
+++ b/app/views/application/_permission_badge.html.erb
@@ -1,0 +1,5 @@
+<%
+  show_date ||= false
+  access_controls = AccessRenderer.new(curation_concern)
+%>
+<%= access_controls.badge(show_date: show_date) %>

--- a/app/views/curate/collections/unauthorized.html.erb
+++ b/app/views/curate/collections/unauthorized.html.erb
@@ -1,6 +1,7 @@
 <h1>Unauthorized</h1>
 <p>The collection you have tried to access is private.</p>
 <p>ID: <%= @collection.noid %></p>
+<p><%= render partial: 'permission_badge', locals: { curation_concern: @collection, show_date: true } %></p>
 <% unless current_user %>
   <p>If you think you should have access, please try logging in.</p>
   <%= link_to 'Log In', new_user_session_path, class: 'btn btn-primary login', role: 'menuitem' %>

--- a/app/views/curation_concern/articles/_attributes.html.erb
+++ b/app/views/curation_concern/articles/_attributes.html.erb
@@ -20,7 +20,7 @@
   <tr>
     <th>Access Rights</th>
     <td>
-      <%= permission_badge_for(curation_concern) %>
+      <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern } %>
     </td>
   </tr>
   <%= curation_concern_attribute_to_html(curation_concern, :embargo_release_date, "Embargo Release Date") %>

--- a/app/views/curation_concern/base/_form_manage_related_files.html.erb
+++ b/app/views/curation_concern/base/_form_manage_related_files.html.erb
@@ -42,7 +42,7 @@
             <%= generic_file.date_uploaded %>
           </td>
           <td class="attribute permission">
-            <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern } %>
+            <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern, show_date: true } %>
           </td>
           <td>
             <%= check_box_tag :delete %>&nbsp;<em>Not yet implemented</em>

--- a/app/views/curation_concern/base/_form_manage_related_files.html.erb
+++ b/app/views/curation_concern/base/_form_manage_related_files.html.erb
@@ -32,11 +32,21 @@
     <tbody>
       <% curation_concern.generic_files.each do |generic_file| %>
         <tr class="<%= dom_class(generic_file) %> attributes">
-          <td class="attribute title"><%= generic_file %></td>
-          <td class="attribute filename"><%= generic_file.filename %></td>
-          <td class="attribute date_uploaded"><%= generic_file.date_uploaded %></td>
-          <td class="attribute permission"><%= permission_badge_for(generic_file) %></td>
-          <td><%= check_box_tag :delete %>&nbsp;<em>Not yet implemented</em></td>
+          <td class="attribute title">
+            <%= generic_file %>
+          </td>
+          <td class="attribute filename">
+            <%= generic_file.filename %>
+          </td>
+          <td class="attribute date_uploaded">
+            <%= generic_file.date_uploaded %>
+          </td>
+          <td class="attribute permission">
+            <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern } %>
+          </td>
+          <td>
+            <%= check_box_tag :delete %>&nbsp;<em>Not yet implemented</em>
+          </td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/curation_concern/base/_manage_related_files.html.erb
+++ b/app/views/curation_concern/base/_manage_related_files.html.erb
@@ -19,11 +19,21 @@
     <tbody>
       <% curation_concern.generic_files.each do |generic_file| %>
         <tr class="<%= dom_class(generic_file) %> attributes">
-          <td class="attribute title"><%= generic_file %></td>
-          <td class="attribute filename"><%= generic_file.filename %></td>
-          <td class="attribute date_uploaded"><%= generic_file.date_uploaded %></td>
-          <td class="attribute permission"><%= permission_badge_for(generic_file) %></td>
-          <td><%= check_box_tag :delete %>&nbsp;<em>Not yet implemented</em></td>
+          <td class="attribute title">
+            <%= generic_file %>
+          </td>
+          <td class="attribute filename">
+            <%= generic_file.filename %>
+          </td>
+          <td class="attribute date_uploaded">
+            <%= generic_file.date_uploaded %>
+          </td>
+          <td class="attribute permission">
+            <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern } %>
+          </td>
+          <td>
+            <%= check_box_tag :delete %>&nbsp;<em>Not yet implemented</em>
+          </td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/curation_concern/base/_manage_related_files.html.erb
+++ b/app/views/curation_concern/base/_manage_related_files.html.erb
@@ -29,7 +29,7 @@
             <%= generic_file.date_uploaded %>
           </td>
           <td class="attribute permission">
-            <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern } %>
+            <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern, show_date: true } %>
           </td>
           <td>
             <%= check_box_tag :delete %>&nbsp;<em>Not yet implemented</em>

--- a/app/views/curation_concern/base/_permission_badge.html.erb
+++ b/app/views/curation_concern/base/_permission_badge.html.erb
@@ -1,2 +1,0 @@
-<% access_controls = AccessRenderer.new(curation_concern) %>
-<%= access_controls.badge %>

--- a/app/views/curation_concern/base/_permission_badge.html.erb
+++ b/app/views/curation_concern/base/_permission_badge.html.erb
@@ -1,0 +1,2 @@
+PERMISSION BADGE
+<%= debug curation_concern %>

--- a/app/views/curation_concern/base/_permission_badge.html.erb
+++ b/app/views/curation_concern/base/_permission_badge.html.erb
@@ -1,2 +1,2 @@
-PERMISSION BADGE
-<%= debug curation_concern %>
+<% access_controls = AccessRenderer.new(curation_concern) %>
+<%= access_controls.badge %>

--- a/app/views/curation_concern/base/_related_files.html.erb
+++ b/app/views/curation_concern/base/_related_files.html.erb
@@ -9,7 +9,7 @@
 
   <% curation_concern.generic_files.each_with_index do |generic_file, index| %>
     <% badge_html = capture do %>
-      <%= permission_badge_for(generic_file) %>
+      <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern } %>
     <% end %>
 
     <article id="file-<%= index %>" class="attached-file <%= dom_class(generic_file) %> <%= alert_class(generic_file) %>">

--- a/app/views/curation_concern/base/_related_files.html.erb
+++ b/app/views/curation_concern/base/_related_files.html.erb
@@ -9,7 +9,7 @@
 
   <% curation_concern.generic_files.each_with_index do |generic_file, index| %>
     <% badge_html = capture do %>
-      <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern } %>
+      <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern, show_date: true } %>
     <% end %>
 
     <article id="file-<%= index %>" class="attached-file <%= dom_class(generic_file) %> <%= alert_class(generic_file) %>">

--- a/app/views/curation_concern/base/unauthorized.html.erb
+++ b/app/views/curation_concern/base/unauthorized.html.erb
@@ -1,6 +1,7 @@
 <h1>Unauthorized</h1>
 <p>The <%= curation_concern.human_readable_type.downcase %> you have tried to access is private.</p>
 <p>ID: <%= curation_concern.noid %></p>
+<p><%= render partial: 'permission_badge', locals: { curation_concern: curation_concern, show_date: true } %></p>
 <% unless current_user -%>
   <p>If you think you should have access, please try logging in.</p>
   <%= link_to 'Log In', new_user_session_path, class: 'btn btn-primary login', role: 'menuitem' %>

--- a/app/views/curation_concern/datasets/_attributes.html.erb
+++ b/app/views/curation_concern/datasets/_attributes.html.erb
@@ -20,7 +20,7 @@
   <tr>
     <th>Access Rights</th>
     <td>
-      <%= permission_badge_for(curation_concern) %>
+      <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern } %>
     </td>
   </tr>
   <%= curation_concern_attribute_to_html(curation_concern, :embargo_release_date, "Embargo Release Date") %>

--- a/app/views/curation_concern/documents/_attributes.html.erb
+++ b/app/views/curation_concern/documents/_attributes.html.erb
@@ -21,7 +21,7 @@
   <tr>
     <th>Access Rights</th>
     <td>
-      <%= permission_badge_for(curation_concern) %>
+      <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern } %>
     </td>
   </tr>
   <%= curation_concern_attribute_to_html(curation_concern, :embargo_release_date, "Embargo Release Date") %>

--- a/app/views/curation_concern/etds/_attributes.html.erb
+++ b/app/views/curation_concern/etds/_attributes.html.erb
@@ -39,7 +39,7 @@
   <tr>
     <th>Access Rights</th>
     <td>
-      <%= permission_badge_for(curation_concern) %>
+      <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern } %>
     </td>
   </tr>
   <%= curation_concern_attribute_to_html(curation_concern, :embargo_release_date, "Embargo Release Date") %>

--- a/app/views/curation_concern/generic_works/_attributes.html.erb
+++ b/app/views/curation_concern/generic_works/_attributes.html.erb
@@ -16,7 +16,7 @@
   <tr>
     <th>Access Rights</th>
     <td>
-      <%= permission_badge_for(curation_concern) %>
+      <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern } %>
     </td>
   </tr>
   <%= curation_concern_attribute_to_html(curation_concern, :embargo_release_date, "Embargo Release Date") %>

--- a/app/views/curation_concern/images/_attributes.html.erb
+++ b/app/views/curation_concern/images/_attributes.html.erb
@@ -14,7 +14,7 @@
   <tr>
     <th>Access Rights</th>
     <td>
-      <%= permission_badge_for(curation_concern) %>
+      <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern } %>
     </td>
   </tr>
   <%= curation_concern_attribute_to_html(curation_concern, :embargo_release_date, "Embargo Release Date") %>

--- a/app/views/curation_concern/senior_theses/_attributes.html.erb
+++ b/app/views/curation_concern/senior_theses/_attributes.html.erb
@@ -17,7 +17,7 @@
   <tr>
     <th>Access Rights</th>
     <td>
-      <%= permission_badge_for(curation_concern) %>
+      <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern } %>
     </td>
   </tr>
   <%= curation_concern_attribute_to_html(curation_concern, :embargo_release_date, "Embargo Release Date") %>


### PR DESCRIPTION
These changes are trying to accomplish two things:
- Display the access control status taking the current date into consideration
- Expose the embargo date if an embargo is being enforced

We cannot divulge _any_ attributes of a private repository object that may include personally identifiable information, including `:title`. However, we should always be able to disclose the access controls placed on an object as well as an embargo date, if present.

Fixes #266
Fixes #271