### PR TITLE
Forcing ETDs to be rendered through the common objects viewer

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,10 @@ CurateNd::Application.routes.draw do
 
   root 'static_pages#home'
 
+  # Some ETDs are not loading correctly on the curation concern page
+  get '/concern/etds/:id', to: redirect { |params, request|
+    "/show/#{params[:id]}"
+  }
   curate_for
 
   namespace :admin do


### PR DESCRIPTION
Several ETDs do not render correctly via the show action under curation concerns. This change bypasses the problem rather instead of fixing it directly.

Here are some examples:
https://curate.nd.edu/concern/etds/4f16c24994w
https://curate.nd.edu/show/4f16c24994w
https://curate.nd.edu/concern/etds/w3763487g4k
https://curate.nd.edu/show/w3763487g4k