### PR TITLE
Extracting reindex logic from active fedora

### DIFF
--- a/app/workers/reindex_worker.rb
+++ b/app/workers/reindex_worker.rb
@@ -24,7 +24,7 @@ class ReindexWorker
     ActiveFedora::Base.send(:connections).each do |conn|
       conn.search(query) do |object|
         next if object.pid.start_with?(FEDORA_SYSTEM_PIDS)
-        reindex_for(object.pid)
+        Sufia.queue.push(ReindexWorker.new(object.pid))
       end
     end
   end

--- a/app/workers/reindex_worker.rb
+++ b/app/workers/reindex_worker.rb
@@ -1,4 +1,5 @@
 class ReindexWorker
+  FEDORA_SYSTEM_PIDS = 'fedora-system:'.freeze
   def queue_name
     :resolrize
   end
@@ -11,11 +12,30 @@ class ReindexWorker
 
   def run
     if @pids_to_reindex == :everything
-      ActiveFedora::Base.reindex_everything("pid~#{Sufia.config.id_namespace}:*")
+      reindex_everything
     else
-      @pids_to_reindex.each do |pid|
-        ActiveFedora::Base.find(pid, cast: true).update_index
+      reindex_each_pid
+    end
+  end
+
+  private
+
+  def reindex_everything(query = "pid~#{Sufia.config.id_namespace}:*")
+    ActiveFedora::Base.send(:connections).each do |conn|
+      conn.search(query) do |object|
+        next if object.pid.start_with?(FEDORA_SYSTEM_PIDS)
+        reindex_for(object.pid)
       end
     end
+  end
+
+  def reindex_each_pid
+    @pids_to_reindex.each do |pid|
+      reindex_for(pid)
+    end
+  end
+
+  def reindex_for(pid)
+    ActiveFedora::Base.find(pid, :cast=>true).update_index
   end
 end

--- a/spec/workers/reindex_worker_spec.rb
+++ b/spec/workers/reindex_worker_spec.rb
@@ -10,7 +10,7 @@ describe ReindexWorker do
 
   it 'reindexes everything' do
     worker = ReindexWorker.new
-    expect(ActiveFedora::Base).to receive("reindex_everything").with(/^pid~.*\*$/)
+    expect(worker).to receive("reindex_everything")
     worker.run
   end
 


### PR DESCRIPTION
## Extracting the reindex logic from ActiveFedora

@cb5f2fc1315fc1439d1cd0aad8f969ea711778d5

Why:

* Because I'm encountering a case in which we are unable to reindex an
  object. With the current logic (even the extracted logic), if we
  encounter a failure reindexing an object, the entire process stops.

This change addresses the need by:

* Copying the code from ActiveFedora and extracting methods to help
  organize the logic.

See https://github.com/projecthydra/active_fedora/blob/v6.7.8/lib/active_fedora/indexing.rb#L92-L99
for reference.

## Adding asynchronous reindexing per object

@a3fb73b2bce52accf91e92f8f00d09dbedddb753
