### PR TITLE
Removing automatic drop index when reindexing

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -199,7 +199,6 @@ namespace :maintenance do
   task :reindex_solr, :roles => :app do
     run "cd #{current_path} && bundle exec rails runner 'Sufia.queue.push(ReindexWorker.new)' -e #{rails_env}"
   end
-  before 'maintenance:reindex_solr', 'maintenance:delete_index_solr'
 
   task :migrate_person, :roles => :app do
     run "cd #{current_path} && bundle exec rails runner 'Migrator.enqueue' -e #{rails_env}"


### PR DESCRIPTION
If you want to obliterate the index, do it explicitly.