### PR TITLE
Improving fault tolerance of ETD degree name

### DIFF
--- a/app/views/curation_concern/etds/_attributes.html.erb
+++ b/app/views/curation_concern/etds/_attributes.html.erb
@@ -26,7 +26,7 @@
         <tr><th> Degree Discipline </th><td><%= disc %></td></tr>
       <% end %>
     <% end %>
-    <tr><th> Degree Name </th><td><%= DEGREE.fetch('degrees')[degree.name.first] %></td></tr>
+    <tr><th> Degree Name </th><td><%= DEGREE.fetch('degrees').fetch(degree.name.first, degree.name.first) %></td></tr>
   <% end %>
   <%= curation_concern_attribute_to_html(curation_concern, :date, 'Defense Date') %>
   <tr><th> Submission Date </th><td><%= curation_concern.date_uploaded %></td></tr> 


### PR DESCRIPTION
Instead of requiring an exact match in order to render the degree, I'm
opting to fallback to the given value. In this way, as we move from
the abbreviations of ETD's degree names into the expanded ETD degree
name both methods will work.

ATTN: @dbrower