### PR TITLE
Make single-use URLs valid for a time window

### DIFF
--- a/app/controllers/admin/temporary_access_tokens_controller.rb
+++ b/app/controllers/admin/temporary_access_tokens_controller.rb
@@ -48,7 +48,7 @@ class Admin::TemporaryAccessTokensController < ApplicationController
 
   # Only allow a trusted parameter "white list" through.
   def temporary_access_token_params
-    params.require(:temporary_access_token).permit(:noid, :issued_by, :used)
+    params.require(:temporary_access_token).permit(:noid, :issued_by, :reset_expiry_date)
   end
 
   # Only accept a noid during token creation

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -31,7 +31,7 @@ class DownloadsController
 
   def can_download?
     if params[:token] && TemporaryAccessToken.permitted?(Sufia::Noid.noidify(params[:id]), params[:token])
-      TemporaryAccessToken.expire!(params[:token])
+      TemporaryAccessToken.use!(params[:token])
       true
     else
       super
@@ -41,4 +41,5 @@ class DownloadsController
   def thumbnail_datastream?
     params[:datastream_id] == 'thumbnail'
   end
+
 end

--- a/app/models/temporary_access_token.rb
+++ b/app/models/temporary_access_token.rb
@@ -35,6 +35,8 @@ class TemporaryAccessToken < ActiveRecord::Base
   validates_presence_of :noid, :issued_by
   validates_uniqueness_of :sha
   before_create :assign_new_sha, :strip_pid_namespace
+  before_update :reset_expiry_date_if_prompted
+  attr_accessor :reset_expiry_date
 
   def assign_new_sha
     assign_attributes(sha: generate_sha)
@@ -45,6 +47,13 @@ class TemporaryAccessToken < ActiveRecord::Base
     SecureRandom.urlsafe_base64(32, false)
   end
   private :generate_sha
+
+  def reset_expiry_date_if_prompted
+    if reset_expiry_date
+      self.expiry_date = nil
+    end
+  end
+  private :reset_expiry_date_if_prompted
 
   def strip_pid_namespace
     assign_attributes(noid: Sufia::Noid.noidify(noid))

--- a/app/models/temporary_access_token.rb
+++ b/app/models/temporary_access_token.rb
@@ -2,7 +2,9 @@ class TemporaryAccessToken < ActiveRecord::Base
   self.primary_key = 'sha'
   paginates_per 15
 
-  HOURS_UNTIL_EXPIRY = 24
+  def self.hours_until_expiry
+    24
+  end
 
   def self.permitted?(noid, sha)
     valid_tokens(noid, sha).any?
@@ -28,7 +30,7 @@ class TemporaryAccessToken < ActiveRecord::Base
   private_class_method :valid_tokens
 
   def self.new_expiry_date
-    Time.now + HOURS_UNTIL_EXPIRY.hours
+    Time.now + hours_until_expiry.hours
   end
   private_class_method :new_expiry_date
 

--- a/app/models/temporary_access_token.rb
+++ b/app/models/temporary_access_token.rb
@@ -2,20 +2,35 @@ class TemporaryAccessToken < ActiveRecord::Base
   self.primary_key = 'sha'
   paginates_per 15
 
+  HOURS_UNTIL_EXPIRY = 24
+
   def self.permitted?(noid, sha)
-    valid_tokens = self.where(noid: noid).where(sha: sha).where(used: false)
-    valid_tokens.any?
+    valid_tokens(noid, sha).any?
   end
 
-  def self.expire!(sha)
-    tokens = self.where(sha: sha).where(used: false)
+  def self.use!(sha)
+    tokens = self.where(sha: sha)
+    updated_tokens  = []
 
-    if tokens.count == 1
-      tokens.first.update_attribute(:used, true)
-    else
-      false
+    tokens.each do |token|
+      if token.expiry_date.blank?
+        token.update_attribute(:expiry_date, new_expiry_date)
+        updated_tokens << token
+      end
     end
+
+    updated_tokens.any?
   end
+
+  def self.valid_tokens(noid, sha)
+    self.where(noid: noid, sha: sha).where("#{self.quoted_table_name}.`expiry_date` IS NULL OR #{self.quoted_table_name}.`expiry_date` >= ?", Time.now)
+  end
+  private_class_method :valid_tokens
+
+  def self.new_expiry_date
+    Time.now + HOURS_UNTIL_EXPIRY.hours
+  end
+  private_class_method :new_expiry_date
 
   validates_presence_of :noid, :issued_by
   validates_uniqueness_of :sha

--- a/app/views/admin/temporary_access_tokens/edit.html.erb
+++ b/app/views/admin/temporary_access_tokens/edit.html.erb
@@ -19,7 +19,7 @@
       <p>Issued By: <%= @temporary_access_token.issued_by %></p>
     </div>
     <%= f.input :noid, label: "File ID (#{ link_to('View File Record', common_object_path(@temporary_access_token.noid))})".html_safe %>
-    <%= f.input :reset_expiry_date, as: :boolean, hint: 'When the expiry date is reset the single-use URL will be valid for 24 hours after its first use.' %>
+    <%= f.input :reset_expiry_date, as: :boolean, hint: "When the expiry date is reset the single-use URL will be valid for #{TemporaryAccessToken.hours_until_expiry} hours after its first use." %>
   </fieldset>
 
   <div class="form-actions">

--- a/app/views/admin/temporary_access_tokens/edit.html.erb
+++ b/app/views/admin/temporary_access_tokens/edit.html.erb
@@ -19,7 +19,7 @@
       <p>Issued By: <%= @temporary_access_token.issued_by %></p>
     </div>
     <%= f.input :noid, label: "File ID (#{ link_to('View File Record', common_object_path(@temporary_access_token.noid))})".html_safe %>
-    <%= f.input :used %>
+    <%= f.input :reset_expiry_date, as: :boolean, hint: 'When the expiry date is reset the single-use URL will be valid for 24 hours after its first use.' %>
   </fieldset>
 
   <div class="form-actions">

--- a/app/views/admin/temporary_access_tokens/index.html.erb
+++ b/app/views/admin/temporary_access_tokens/index.html.erb
@@ -20,7 +20,7 @@
       <th>Single-Use URL</th>
       <th>File ID</th>
       <th>Issued by</th>
-      <th>Used</th>
+      <th>Expiry Date</th>
       <th></th>
     </tr>
   </thead>
@@ -35,7 +35,7 @@
         </td>
         <td><%= link_to temporary_access_token.noid, common_object_path(temporary_access_token.noid) %></td>
         <td><%= temporary_access_token.issued_by %></td>
-        <td><%= temporary_access_token.used ? 'Yes' : 'No' %></td>
+        <td><%= temporary_access_token.expiry_date.present? ? temporary_access_token.expiry_date.strftime('%Y-%m-%d') : 'Unused' %></td>
         <td>
           <%= link_to 'Show', admin_temporary_access_token_path(temporary_access_token), class: 'btn btn-default' %>
           <%= link_to 'Edit', edit_admin_temporary_access_token_path(temporary_access_token), class: 'btn btn-default' %>

--- a/app/views/admin/temporary_access_tokens/new.html.erb
+++ b/app/views/admin/temporary_access_tokens/new.html.erb
@@ -12,7 +12,8 @@
 <% end %>
 
 <p class="alert alert-waring">
-  A single-use URL will be generated from the provided file ID that will allow a patron to download the file <em>even if it is normally inaccessible.</em>
+  A single-use URL will be generated from the provided file ID that will allow a patron to download the file <em>even if it is normally inaccessible.</em><br/>
+  Single-use URLs are valid for <em>24 hours</em> after first use.
 </p>
 
 <%= simple_form_for([:admin, @temporary_access_token]) do |f| %>

--- a/app/views/admin/temporary_access_tokens/new.html.erb
+++ b/app/views/admin/temporary_access_tokens/new.html.erb
@@ -13,7 +13,7 @@
 
 <p class="alert alert-waring">
   A single-use URL will be generated from the provided file ID that will allow a patron to download the file <em>even if it is normally inaccessible.</em><br/>
-  Single-use URLs are valid for <em>24 hours</em> after first use.
+  Single-use URLs are valid for <em><%= TemporaryAccessToken.hours_until_expiry %> hours</em> after first use.
 </p>
 
 <%= simple_form_for([:admin, @temporary_access_token]) do |f| %>

--- a/app/views/admin/temporary_access_tokens/show.html.erb
+++ b/app/views/admin/temporary_access_tokens/show.html.erb
@@ -13,7 +13,7 @@
 
 <h2>Single-Use URL</h2>
 <form>
-  <p>Share this link with the patron who needs access</p>
+  <p>Share this link with the patron who needs access. It will be valid for 24 hours after its first use.</p>
   <input type="text" class="input-autoselect input-xxlarge" value="<%= download_url(@temporary_access_token.noid, token: @temporary_access_token.sha) %>">
 </form>
 
@@ -23,8 +23,8 @@
   <dd><%= link_to @temporary_access_token.noid, common_object_path(@temporary_access_token.noid) %></dd>
   <dt>Issued by:</dt>
   <dd><%= @temporary_access_token.issued_by %></dd>
-  <dt>Used:</dt>
-  <dd><%= @temporary_access_token.used ? 'Yes' : 'No' %></dd>
+  <dt>Expiry Date:</dt>
+  <dd><%= @temporary_access_token.expiry_date.present? ? temporary_access_token.expiry_date.strftime('%Y-%m-%d') : 'Unused' %></dd>
 </dl>
 
 <%= link_to 'Edit', edit_admin_temporary_access_token_path(@temporary_access_token), class: 'btn btn-default' %>

--- a/app/views/admin/temporary_access_tokens/show.html.erb
+++ b/app/views/admin/temporary_access_tokens/show.html.erb
@@ -13,7 +13,7 @@
 
 <h2>Single-Use URL</h2>
 <form>
-  <p>Share this link with the patron who needs access. It will be valid for 24 hours after its first use.</p>
+  <p>Share this link with the patron who needs access. It will be valid for <%= TemporaryAccessToken.hours_until_expiry %> hours after its first use.</p>
   <input type="text" class="input-autoselect input-xxlarge" value="<%= download_url(@temporary_access_token.noid, token: @temporary_access_token.sha) %>">
 </form>
 

--- a/db/migrate/20151118201016_add_expiry_date_to_temporary_access_token.rb
+++ b/db/migrate/20151118201016_add_expiry_date_to_temporary_access_token.rb
@@ -1,0 +1,21 @@
+class AddExpiryDateToTemporaryAccessToken < ActiveRecord::Migration
+  def self.up
+    remove_index :temporary_access_tokens, :used
+    remove_index :temporary_access_tokens, [:sha, :noid, :used]
+    remove_column :temporary_access_tokens, :used
+
+    add_column :temporary_access_tokens, :expiry_date, :datetime, null: true
+    add_index :temporary_access_tokens, :expiry_date
+    add_index :temporary_access_tokens, [:sha, :noid, :expiry_date], unique: true
+  end
+
+  def self.down
+    remove_index :temporary_access_tokens, :expiry_date
+    remove_index :temporary_access_tokens, [:sha, :noid, :expiry_date]
+    remove_column :temporary_access_tokens, :expiry_date
+
+    add_column :temporary_access_tokens, :used, :boolean, default: false
+    add_index :temporary_access_tokens, :used
+    add_index :temporary_access_tokens, [:sha, :noid, :used], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151113155448) do
+ActiveRecord::Schema.define(version: 20151118201016) do
 
   create_table "activity_engine_activities", force: true do |t|
     t.integer  "user_id"
@@ -312,18 +312,18 @@ ActiveRecord::Schema.define(version: 20151113155448) do
   add_index "subject_local_authority_entries", ["lowerLabel"], name: "entries_by_lower_label", using: :btree
 
   create_table "temporary_access_tokens", id: false, force: true do |t|
-    t.string   "sha",                        null: false
+    t.string   "sha",         null: false
     t.string   "noid"
     t.string   "issued_by"
-    t.boolean  "used",       default: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.datetime "expiry_date"
   end
 
+  add_index "temporary_access_tokens", ["expiry_date"], name: "index_temporary_access_tokens_on_expiry_date", using: :btree
   add_index "temporary_access_tokens", ["noid"], name: "index_temporary_access_tokens_on_noid", using: :btree
-  add_index "temporary_access_tokens", ["sha", "noid", "used"], name: "index_temporary_access_tokens_on_sha_and_noid_and_used", unique: true, using: :btree
+  add_index "temporary_access_tokens", ["sha", "noid", "expiry_date"], name: "index_temporary_access_tokens_on_sha_and_noid_and_expiry_date", unique: true, using: :btree
   add_index "temporary_access_tokens", ["sha"], name: "index_temporary_access_tokens_on_sha", unique: true, using: :btree
-  add_index "temporary_access_tokens", ["used"], name: "index_temporary_access_tokens_on_used", using: :btree
 
   create_table "trophies", force: true do |t|
     t.integer  "user_id"

--- a/spec/factories/temporary_access_tokens.rb
+++ b/spec/factories/temporary_access_tokens.rb
@@ -1,10 +1,8 @@
-# Read about factories at https://github.com/thoughtbot/factory_girl
-
 FactoryGirl.define do
   factory :temporary_access_token do
     sha 'scaxnVc5inR_DKZlpsce4KznPQ'
     noid 'a1b2c3d4'
     issued_by 'vlad_key'
-    used false
+    expiry_date nil
   end
 end

--- a/spec/models/temporary_access_token_spec.rb
+++ b/spec/models/temporary_access_token_spec.rb
@@ -11,17 +11,17 @@ describe TemporaryAccessToken do
   end
 
   context 'when being created' do
-    it 'permits a null sha during object initialization' do
+    it 'permits a null SHA during object initialization' do
       token = FactoryGirl.build(:temporary_access_token, sha: nil)
       expect(token.sha).to eq(nil)
     end
 
-    it 'sets a sha during object persistance' do
+    it 'sets a SHA during object persistence' do
       token = FactoryGirl.create(:temporary_access_token, sha: nil)
       expect(token.sha).not_to eq(nil)
     end
 
-    it 'ignores sha values passed during object initialization' do
+    it 'ignores SHA values passed during object initialization' do
       provided_sha = 'please_ignore_this_sha'
       token = FactoryGirl.create(:temporary_access_token, sha: provided_sha)
       expect(token.sha).not_to eq(provided_sha)
@@ -35,38 +35,45 @@ describe TemporaryAccessToken do
     end
   end
 
-    context 'when validating existing tokens' do
+  context 'when validating existing tokens' do
     subject { FactoryGirl.create(:temporary_access_token, attributes) }
 
-    it 'should allow access exisiting, unused tokens' do
+    it 'should allow access to existing, unused tokens' do
       subject.save!
       expect(TemporaryAccessToken.count).not_to eq(0)
       expect(TemporaryAccessToken.permitted?(subject.noid, subject.sha)).to eq(true)
     end
 
-    it 'should not allow access exisiting, used tokens' do
-      subject.used = true
+    it 'should set a expiry date the first time it has been used' do
       subject.save!
-      expect(TemporaryAccessToken.count).not_to eq(0)
-      expect(TemporaryAccessToken.permitted?(subject.noid, subject.sha)).to eq(false)
+      expect(subject.expiry_date).to be_nil
+      expect(TemporaryAccessToken.use!(subject.sha)).to eq(true)
+      expect(subject.expiry_date).to_not be_nil
     end
 
-    it 'should not allow access to a token after it has been expired' do
+    it 'should not change the expiry date if the token is used repeatedly' do
+      expected_expiry_date = Time.now + 1.hour
+      subject.expiry_date = expected_expiry_date
       subject.save!
-      expect(TemporaryAccessToken.count).not_to eq(0)
+      expect(TemporaryAccessToken.use!(subject.sha)).to eq(false)
+      expect(subject.expiry_date).to eq(expected_expiry_date)
+    end
+
+    it 'should permit access with a token to be used repeatedly before the expiry period has elapsed' do
+      subject.expiry_date = Time.now + 1.hour
+      subject.save!
       expect(TemporaryAccessToken.permitted?(subject.noid, subject.sha)).to eq(true)
-      expect(TemporaryAccessToken.expire!(subject.sha)).to eq(true)
+      expect(TemporaryAccessToken.permitted?(subject.noid, subject.sha)).to eq(true)
+    end
+
+    it 'should not permit access with a token after the expiry period has elapsed' do
+      subject.expiry_date = Time.now - 1.hour
+      subject.save!
       expect(TemporaryAccessToken.permitted?(subject.noid, subject.sha)).to eq(false)
     end
 
-    it 'should not be able to expire a used token' do
-      subject.used = true
-      subject.save!
-      expect(TemporaryAccessToken.expire!(subject.sha)).to eq(false)
-    end
-
-    it 'should not be able to expire a token with an unknown sha' do
-      expect(TemporaryAccessToken.expire!('sha_that_does_not_exist')).to eq(false)
+    it 'should not be able to update the expiry date of a token with an unknown sha' do
+      expect(TemporaryAccessToken.use!('sha_that_does_not_exist')).to eq(false)
     end
   end
 end

--- a/spec/models/temporary_access_token_spec.rb
+++ b/spec/models/temporary_access_token_spec.rb
@@ -41,6 +41,7 @@ describe TemporaryAccessToken do
     it 'should allow access to existing, unused tokens' do
       subject.save!
       expect(TemporaryAccessToken.count).not_to eq(0)
+      expect(subject.expiry_date).to be_nil
       expect(TemporaryAccessToken.permitted?(subject.noid, subject.sha)).to eq(true)
     end
 

--- a/spec/models/temporary_access_token_spec.rb
+++ b/spec/models/temporary_access_token_spec.rb
@@ -48,7 +48,8 @@ describe TemporaryAccessToken do
       subject.save!
       expect(subject.expiry_date).to be_nil
       expect(TemporaryAccessToken.use!(subject.sha)).to eq(true)
-      expect(subject.expiry_date).to_not be_nil
+      updated_token = TemporaryAccessToken.find(subject.sha)
+      expect(updated_token.expiry_date).to_not be_nil
     end
 
     it 'should not change the expiry date if the token is used repeatedly' do

--- a/spec/models/temporary_access_token_spec.rb
+++ b/spec/models/temporary_access_token_spec.rb
@@ -79,4 +79,19 @@ describe TemporaryAccessToken do
       expect(described_class.use!('sha_that_does_not_exist')).to eq(false)
     end
   end
+
+  context 'when updating existing tokens' do
+    it 'should accept a "reset" flag' do
+      subject.reset_expiry_date = true
+      subject.save!
+    end
+
+    it 'should reset the expiry date if the "reset" flag is passed' do
+      subject.expiry_date = Time.now
+      subject.save!
+      subject.reset_expiry_date = true
+      subject.save!
+      expect(subject.expiry_date).to be_nil
+    end
+  end
 end

--- a/spec/models/temporary_access_token_spec.rb
+++ b/spec/models/temporary_access_token_spec.rb
@@ -40,16 +40,16 @@ describe TemporaryAccessToken do
 
     it 'should allow access to existing, unused tokens' do
       subject.save!
-      expect(TemporaryAccessToken.count).not_to eq(0)
+      expect(described_class.count).not_to eq(0)
       expect(subject.expiry_date).to be_nil
-      expect(TemporaryAccessToken.permitted?(subject.noid, subject.sha)).to eq(true)
+      expect(described_class.permitted?(subject.noid, subject.sha)).to eq(true)
     end
 
     it 'should set a expiry date the first time it has been used' do
       subject.save!
       expect(subject.expiry_date).to be_nil
-      expect(TemporaryAccessToken.use!(subject.sha)).to eq(true)
-      updated_token = TemporaryAccessToken.find(subject.sha)
+      expect(described_class.use!(subject.sha)).to eq(true)
+      updated_token = described_class.find(subject.sha)
       expect(updated_token.expiry_date).to_not be_nil
     end
 
@@ -57,25 +57,25 @@ describe TemporaryAccessToken do
       expected_expiry_date = Time.now + 1.hour
       subject.expiry_date = expected_expiry_date
       subject.save!
-      expect(TemporaryAccessToken.use!(subject.sha)).to eq(false)
+      expect(described_class.use!(subject.sha)).to eq(false)
       expect(subject.expiry_date).to eq(expected_expiry_date)
     end
 
     it 'should permit access with a token to be used repeatedly before the expiry period has elapsed' do
       subject.expiry_date = Time.now + 1.hour
       subject.save!
-      expect(TemporaryAccessToken.permitted?(subject.noid, subject.sha)).to eq(true)
-      expect(TemporaryAccessToken.permitted?(subject.noid, subject.sha)).to eq(true)
+      expect(described_class.permitted?(subject.noid, subject.sha)).to eq(true)
+      expect(described_class.permitted?(subject.noid, subject.sha)).to eq(true)
     end
 
     it 'should not permit access with a token after the expiry period has elapsed' do
       subject.expiry_date = Time.now - 1.hour
       subject.save!
-      expect(TemporaryAccessToken.permitted?(subject.noid, subject.sha)).to eq(false)
+      expect(described_class.permitted?(subject.noid, subject.sha)).to eq(false)
     end
 
     it 'should not be able to update the expiry date of a token with an unknown sha' do
-      expect(TemporaryAccessToken.use!('sha_that_does_not_exist')).to eq(false)
+      expect(described_class.use!('sha_that_does_not_exist')).to eq(false)
     end
   end
 end

--- a/spec/models/temporary_access_token_spec.rb
+++ b/spec/models/temporary_access_token_spec.rb
@@ -3,6 +3,10 @@ require 'spec_helper'
 describe TemporaryAccessToken do
   subject { FactoryGirl.build(:temporary_access_token) }
 
+  it 'can report how long tokens are valid after first use' do
+    expect(described_class.hours_until_expiry).to be_kind_of(Fixnum)
+  end
+
   context 'test support' do
     it 'has a valid factory' do
       expect(subject).to be_valid


### PR DESCRIPTION
Expiring a one-time-use token after a single request is not a sufficiently sophisticated solution. For example, Chrome uses range requests to incrementally fetch PDFs. The prior implementation of this feature would deny all rage requests after the first request resulting in Chrome rendering a "empty" PDF.

Insead, “single-use” URLs will be valid for 24 hours after they have first been used to access a file.