### PR TITLE
Show a default thumbnail if you cannot read the file

### DIFF
--- a/app/views/application/_thumbnail.html.erb
+++ b/app/views/application/_thumbnail.html.erb
@@ -2,10 +2,10 @@
   width = 100 if width.blank?
   captured = '' if captured.blank?
 
-  if thumbnail.image? || thumbnail.pdf? || thumbnail.video?
+  if can?(:read, thumbnail) && ( thumbnail.image? || thumbnail.pdf? || thumbnail.video? )
     path = download_path(thumbnail, {datastream_id: 'thumbnail'})
   else
-    path = "curate/default.png"
+    path = 'curate/default.png'
   end
 %>
 


### PR DESCRIPTION
This fix is for the common objects viewer.

The same problem had previously been fixed for the curation concern show
views.