### PR TITLE
Enhancements to access denied pages

### DIFF
--- a/app/views/errors/401.html.erb
+++ b/app/views/errors/401.html.erb
@@ -1,14 +1,6 @@
-<% content_for :page_title, construct_page_title("#{response.status} #{action_name.humanize}") %>
+<% content_for :page_title, construct_page_title("#{response.status} Unauthorized") %>
 <% content_for :page_header do %>
+  <%= render '/errors/access_denied_alert' %>
   <h1>Unauthorized</h1>
 <% end %>
-<% if params[:token] %>
-  <p class="alert alert-warn">
-    Your single-use URL has expired or is no longer valid.
-  </p>
-<% end %>
-<p class="lead">You are not authorized to access the page.</p>
-<% if !params.has_key?(:token) && !current_user.present? %>
-  <p>If you think you should have access, please try logging in.</p>
-  <%= link_to 'Log In', new_user_session_path, class: 'btn btn-primary login', role: 'menuitem' %>
-<% end %>
+<%= render '/errors/access_denied_body' %>

--- a/app/views/errors/403.html.erb
+++ b/app/views/errors/403.html.erb
@@ -1,14 +1,6 @@
-<% content_for :page_title, construct_page_title("#{response.status} #{action_name.humanize}") %>
+<% content_for :page_title, construct_page_title("#{response.status} Forbidden") %>
 <% content_for :page_header do %>
-  <h1>Unauthorized</h1>
+  <%= render '/errors/access_denied_alert' %>
+  <h1>Forbidden</h1>
 <% end %>
-<% if params[:token] %>
-  <p class="alert alert-warn">
-    Your single-use URL has expired or is no longer valid.
-  </p>
-<% end %>
-<p class="lead">You are not authorized to access the page.</p>
-<% if !params.has_key?(:token) && !current_user.present? %>
-  <p>If you think you should have access, please try logging in.</p>
-  <%= link_to 'Log In', new_user_session_path, class: 'btn btn-primary login', role: 'menuitem' %>
-<% end %>
+<%= render '/errors/access_denied_body' %>

--- a/app/views/errors/_access_denied_alert.html.erb
+++ b/app/views/errors/_access_denied_alert.html.erb
@@ -1,0 +1,14 @@
+<% if params[:token] %>
+  <%
+    request_subject = "[ETD Access Request] Renewed Access to File (id: #{params[:id]})"
+    request_body = "Previously, I had been granted temporary access to a restricted file in CurateND (id: #{params[:noid] ? params[:noid] : params[:id]}). I no longer have access to the file and would like to view it again.\n\nHere is the access token I was given:\n #{params[:token]}"
+    request_html = <<-markup
+      <a href="mailto:dteditor@nd.edu?subject=#{URI.escape(request_subject)}&body=#{URI.escape(request_body)}" class="btn btn-default">Request an Access Extension</a>
+    markup
+    request_access = request_html.html_safe
+  %>
+  <div class="alert alert-warn">
+    <p>Your single-use URL has expired or is no longer valid.</p>
+    <%= request_access %>
+  </div>
+<% end %>

--- a/app/views/errors/_access_denied_body.html.erb
+++ b/app/views/errors/_access_denied_body.html.erb
@@ -1,0 +1,7 @@
+<% unless params.has_key?(:token) %>
+  <p class="lead">You are not authorized to access this page.</p>
+  <% unless current_user.present? %>
+    <p>If you think you should have access, please try logging in.</p>
+    <%= link_to 'Log In', new_user_session_path, class: 'btn btn-primary login' %>
+  <% end %>
+<% end %>


### PR DESCRIPTION
Based on feedback from Mandy Havert Shari Hill Sweet:
- Give patrons with an expired access token a way of requesting renewed
  access
- Simplify messaging on the page