### PR TITLE
Parameterizing CAS configuration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -262,7 +262,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     fastercsv (1.5.5)
     ffi (1.9.8)
-    figaro (1.0.0)
+    figaro (1.1.1)
       thor (~> 0.14)
     flipper (0.6.2)
     foreigner (1.7.4)

--- a/config/application.yml
+++ b/config/application.yml
@@ -9,3 +9,10 @@
 # These are keys for the sandbox
 ORCID_APP_ID: 0000-0002-6683-6607
 ORCID_APP_SECRET: e1ff26a2-d889-40be-bd41-acac09214cae
+cas_base_url: "https://login.nd.edu/cas"
+cas_validate_url: "https://login.nd.edu/cas/serviceValidate"
+
+development:
+  cas_base_url: "https://cas.library.nd.edu/cas"
+  cas_destination_url: "http://localhost:3000"
+  cas_follow_url: "http://localhost:3000"

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -11,10 +11,12 @@ Devise.setup do |config|
                         )
 
   if Rails.env.development?
-    config.cas_base_url = "https://cas.library.nd.edu/cas"
+    config.cas_base_url = Figaro.env.cas_base_url
+    config.cas_destination_url = Figaro.env.cas_destination_url
+    config.cas_follow_url = Figaro.env.cas_follow_url
   else
-    config.cas_base_url = "https://login.nd.edu/cas"
-    config.cas_validate_url = "https://login.nd.edu/cas/serviceValidate"
+    config.cas_base_url = Figaro.env.cas_base_url
+    config.cas_validate_url = Figaro.env.cas_validate_url
   end
   config.cas_destination_url = Rails.configuration.application_root_url
   config.cas_follow_url = Rails.configuration.application_root_url


### PR DESCRIPTION
Moving the CAS configuration parameters into `application.yml` allows us to deploy different configurations to each environment. It also sets us up to scrub ND-specific CAS information from the repo.