### PR TITLE
Prevent redirection of requests to create new ETDs

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ CurateNd::Application.routes.draw do
   root 'static_pages#home'
 
   # Some ETDs are not loading correctly on the curation concern page
+  get '/concern/etds/new', to: 'curation_concern/etds#new'
   get '/concern/etds/:id', to: redirect { |params, request|
     "/show/#{params[:id]}"
   }


### PR DESCRIPTION
Shari would like to manually create records for some ETDs that were neither deposited in Sipity nor included in the legacy data import.

She was encountering a 404 error.