### PR TITLE
enable vendoring in disadis 'go get'

### DIFF
--- a/puppet/modules/lib_curate/manifests/disadis.pp
+++ b/puppet/modules/lib_curate/manifests/disadis.pp
@@ -13,7 +13,7 @@ class lib_curate::disadis( $disadis_root = '/opt/disadis' ) {
 	}
 
 	exec { "Build-disadis-from-repo":
-		environment => "GOPATH=${disadis_root}",
+		environment => ["GOPATH=${disadis_root}","GO15VENDOREXPERIMENT=1"],
 		path => "/usr/bin",
 		command => "go get github.com/ndlib/disadis",
 		# The following test seems like it will never update the binary if it has already been deployed.


### PR DESCRIPTION
"GO15VENDOREXPERIMENT=1 environment variable allows go 1.5 to look for
vendored packages