### PR TITLE
Removing erroneous department key duplication

### DIFF
--- a/config/departments.yml
+++ b/config/departments.yml
@@ -266,7 +266,7 @@ physics:
   key: "physics"
   identifier: "Science::Physics"
   selectable: true
-chemistry_and_biochemistry:
+history_and_philosophy_of_science:
   key: "history_and_philosophy_of_science"
   identifier: "Science::History and Philosophy of Science"
   selectable: true


### PR DESCRIPTION
Because `chemistry_and_biochemistry` was duplicated the original
department was not available in the listing. Because the key and the key
attribute did not match for `history_and_philosophy_of_science` it was
also not present in the organization listing.