### PR TITLE
Accommodating widest permission badge

### DIFF
--- a/app/assets/stylesheets/modules/concerns.css.scss
+++ b/app/assets/stylesheets/modules/concerns.css.scss
@@ -39,7 +39,7 @@
   .file-thumbnail {
     float: left;
     margin: 0 0 1em;
-    padding-right: 10em;
+    padding-right: 13em;
   }
 
   .canonical-image {
@@ -77,6 +77,7 @@
 
   .actions {
     line-height: 3;
+    margin-top: -.5em;
   }
 
   + .attached-file {


### PR DESCRIPTION
![file-list-with-access-badges](https://cloud.githubusercontent.com/assets/2133/12398557/8c1ebbb2-bde2-11e5-8437-9e98479a6c34.png)

The negative margin on the file actions area aligns the tops of the file buttons with the top of the badge and the thumbnail.

---
[Trello card](https://trello.com/c/FdPBg2RC)