### PR TITLE
Display ETD type as "Thesis" or "Dissertation"

### DIFF
--- a/app/repository_models/etd.rb
+++ b/app/repository_models/etd.rb
@@ -6,4 +6,8 @@ class Etd
   def self.human_readable_type
     'Thesis or Dissertation'
   end
+
+  def human_readable_type
+    degree.map(&:level).flatten.to_sentence
+  end
 end


### PR DESCRIPTION
> Currently it displays 'Thesis or Dissertation' when viewing an
> individual item, and it should say one of the two depending on the
> item metadata

Closes #314