### PR TITLE
Show page consistency

### DIFF
--- a/app/views/common_objects/show.html.erb
+++ b/app/views/common_objects/show.html.erb
@@ -4,6 +4,12 @@
   <span class="human-readable-type"><%= curation_concern.human_readable_type %></span>
 <% end %>
 
+<% if can?(:edit, curation_concern) %>
+  <% content_for :page_actions do %>
+    <%= link_to 'Edit', edit_polymorphic_path([:curation_concern, curation_concern]), class: 'btn btn-default' %>
+  <% end %>
+<% end %>
+
 <div class="work-attributes">
   <%= render "curation_concern/#{curation_concern.class.model_name.plural}/attributes", curation_concern: curation_concern, with_actions: false %>
 </div>
@@ -15,10 +21,4 @@
   <%= link_to 'Download this File', download_path(curation_concern), class: 'btn btn-default' %>
 <% else %>
   <%= render 'curation_concern/base/related_files', curation_concern: curation_concern, with_actions: false %>
-<% end %>
-
-<% if can?(:edit, curation_concern) %>
-  <div class="form-actions">
-    <%= link_to 'Edit', edit_polymorphic_path([:curation_concern, curation_concern]), class: 'btn btn-primary' %>
-  </div>
 <% end %>

--- a/app/views/common_objects/show.html.erb
+++ b/app/views/common_objects/show.html.erb
@@ -20,5 +20,5 @@
 %>
   <%= link_to 'Download this File', download_path(curation_concern), class: 'btn btn-default' %>
 <% else %>
-  <%= render 'curation_concern/base/related_files', curation_concern: curation_concern, with_actions: false %>
+  <%= render 'curation_concern/base/related_files', curation_concern: curation_concern, with_actions: true %>
 <% end %>

--- a/app/views/common_objects/show.html.erb
+++ b/app/views/common_objects/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :page_title, construct_page_title(curation_concern.title, 'Show') if curation_concern.title %>
 <% content_for :page_header do %>
   <h1><%= richly_formatted_text(curation_concern.to_s) %></h1>
   <span class="human-readable-type"><%= curation_concern.human_readable_type %></span>

--- a/app/views/layouts/common_objects.html.erb
+++ b/app/views/layouts/common_objects.html.erb
@@ -6,9 +6,20 @@
   <div id="main" role="main" class="page-main container <%= yield(:page_class) if content_for?(:page_class)%>">
     <% if content_for?(:page_header) %>
       <div class="row">
-        <div class="span12 main-header">
+      <% if content_for?(:page_actions) %>
+        <div class="span12 main-header-with-actions">
+          <div class="main-header">
+            <%= yield(:page_header) %>
+          </div>
+          <div class="page-actions">
+            <%= yield(:page_actions) %>
+          </div>
+        </div>
+      <% else %>
+        <div class="span12 main-header ">
           <%= yield(:page_header) %>
         </div>
+      <% end %>
       </div>
     <% end %>
     <div class="row">


### PR DESCRIPTION
This PR accomplishes two things:

1. Provides a meaningful title for the common objects viewer (which is now the only way to see ETDs)
2. Moves the page action area of the common objects viewer from a form-style line of actions at the bottom of the page to just beneth the title. This means that patrons will not have to scroll to see if/what actions are available to them on that page.

### Action area before:
![move-show-page-actions-1-before](https://cloud.githubusercontent.com/assets/2133/12728096/3c793c1a-c8ee-11e5-8d71-09c75d60d011.png)

### Action area after:
![move-show-page-actions-2-after](https://cloud.githubusercontent.com/assets/2133/12728111/48c55c6a-c8ee-11e5-95b0-216aea076968.png)

It _should_ be more visable.