### PR TITLE
Keep HTML5 required attributes from clobbering form submissions

### DIFF
--- a/app/assets/javascripts/rich_text_editor.js
+++ b/app/assets/javascripts/rich_text_editor.js
@@ -1,10 +1,15 @@
-//= require simplemde.min.js
+//= require simplemde.min
 
 $(function(){
   'use strict';
+  var $richTextAreas = $('.rich-textarea-js');
 
-   var simplemde = new SimpleMDE({
-     element: $('.rich-textarea-js')[0],
-     hideIcons: ['image']
-   });
+  // HTML5 require directives need the original form element to be focusable
+  $richTextAreas.removeAttr('required');
+
+  // Only decorate the FIRST rich text area
+  new SimpleMDE({
+    element: $richTextAreas[0],
+    hideIcons: ['image', 'heading']
+  });
 });

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,6 +17,6 @@ module ApplicationHelper
   end
 
   def include_rich_text_editor?
-    (params[:action] == 'edit' || params[:action] == 'new' ) && params[:controller].start_with?('curation_concern')
+    (['create', 'edit', 'new'].include? params[:action]) && params[:controller].start_with?('curation_concern')
   end
 end

--- a/app/views/curation_concern/base/_form.html.erb
+++ b/app/views/curation_concern/base/_form.html.erb
@@ -1,5 +1,5 @@
 <%= simple_form_for [:curation_concern, curation_concern] do |f| %>
-  
+
   <% if f.error_notification -%>
     <div class="alert alert-error fade in">
       <strong>Wait don't go!</strong> There was a problem with your submission. Please review the errors below:


### PR DESCRIPTION
Also allow rich text editing on create actions e.g. invalid form submissions.