### PR TITLE
Simple feature toggle for citation generation

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,6 +16,10 @@ module ApplicationHelper
     end
   end
 
+  def display_citation_generation?
+    Rails.env.ends_with? 'production'
+  end
+
   def include_rich_text_editor?
     (['create', 'edit', 'new'].include? params[:action]) && params[:controller].start_with?('curation_concern')
   end

--- a/app/views/common_objects/show.html.erb
+++ b/app/views/common_objects/show.html.erb
@@ -5,7 +5,9 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= link_to 'Generate Citation', citation_path(curation_concern) , class: 'btn btn-default citation-modal-js' %>
+  <% if display_citation_generation? %>
+    <%= link_to 'Generate Citation', citation_path(curation_concern) , class: 'btn btn-default citation-modal-js' %>
+  <% end %>
   <% if can?(:edit, curation_concern) %>
     <%= link_to 'Edit', edit_polymorphic_path([:curation_concern, curation_concern]), class: 'btn btn-default' %>
   <% end %>

--- a/app/views/curation_concern/base/show.html.erb
+++ b/app/views/curation_concern/base/show.html.erb
@@ -6,7 +6,9 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= link_to 'Generate Citation', citation_path(curation_concern) , class: 'btn citation-modal-js' %>
+  <% if display_citation_generation? %>
+    <%= link_to 'Generate Citation', citation_path(curation_concern) , class: 'btn citation-modal-js' %>
+  <% end %>
   <% if can?(:edit, curation_concern) %>
     <%= link_to edit_polymorphic_path([:curation_concern, curation_concern]), class: 'btn' do %>
       <i class="icon icon-pencil"></i> Edit


### PR DESCRIPTION
Hide the “Citation Generation” button for production and pre_production environments. Calling this a “toggle” is perhaps generous.