### PR TITLE
Updating libv8 gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ group :default do
   gem "devise-guests", "~> 0.3"
   # Need rubyracer to run integration tests.....really?!?
   # See https://github.com/sstephenson/execjs#readme for more supported runtimes
-  gem 'libv8', '3.16.14.3'
+  gem 'libv8', '~> 3.16.14.3'
   gem 'therubyracer', '0.12.1', platforms: :ruby, require: 'v8'
   gem 'bootstrap-datepicker-rails'
   gem 'namae'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -313,7 +313,7 @@ GEM
     json (1.8.3)
     jwt (1.5.2)
     kgio (2.8.1)
-    libv8 (3.16.14.3)
+    libv8 (3.16.14.13)
     logger (1.2.8)
     lograge (0.3.5)
       actionpack (>= 3)
@@ -673,7 +673,7 @@ DEPENDENCIES
   jquery-rails
   jshintrb
   kaminari!
-  libv8 (= 3.16.14.3)
+  libv8 (~> 3.16.14.3)
   locabulary!
   lograge
   logstash-event
@@ -720,3 +720,6 @@ DEPENDENCIES
   vcr
   virtus
   webmock
+
+BUNDLED WITH
+   1.11.2


### PR DESCRIPTION
The previous locked version will not compile on El Capitan.