### PR TITLE
Documenting how to exclude clamav from development

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,18 @@
 # CurateND
+[![Build Status](https://travis-ci.org/ndlib/curate_nd.png)](https://travis-ci.org/ndlib/curate_nd)
 
 This application will be deployed to [curate.nd.edu](http://curate.nd.edu).
 
 It's primary function is to be a self-deposit interface for our institutional digital repository.
+
+## Installation Notes
+
+Installing the clamav gem on OS X is a trying process. It can be safely excluded
+from your development environment 
+
+```console
+$ bundle install --without headless
+```
 
 ## Testing
 
@@ -21,7 +31,3 @@ Once jetty is started, run either of the following
 ```console
 $ bundle exec thin start -p 3000 --ssl --ssl-key-file dev_server_keys/server.key --ssl-cert-file dev_server_keys/server.crt
 ```
-
-## Application Status
-
-[![Build Status](https://travis-ci.org/ndlib/curate_nd.png)](https://travis-ci.org/ndlib/curate_nd)


### PR DESCRIPTION
Ideally, we WOULD install clamav in development. However, unless you are modifying the background workers, it is not needed. If/when we have a documented solution to building clamav with homebrew on a mac this block of the README can be altered/removed.

[skip ci]