### PR TITLE
343 clean up after CurateND lifeboat

### DIFF
--- a/app/controllers/curation_concern/finding_aids_controller.rb
+++ b/app/controllers/curation_concern/finding_aids_controller.rb
@@ -1,4 +1,5 @@
 class CurationConcern::FindingAidsController < CurationConcern::GenericWorksController
+  helper AccordionBuilderHelper
   self.curation_concern_type = FindingAid
 
   def after_create_response

--- a/app/helpers/curation_concern_helper.rb
+++ b/app/helpers/curation_concern_helper.rb
@@ -5,6 +5,7 @@ module CurationConcernHelper
   end
 
   def decode_administrative_unit(curation_concern, method_name, label = nil, options = { class: 'descriptive-text' })
+    return unless curation_concern.respond_to?(:administrative_unit)
     markup = ""
     label ||= derived_label_for(curation_concern, method_name)
     administrative_unit = curation_concern.public_send(method_name)

--- a/app/models/citation.rb
+++ b/app/models/citation.rb
@@ -73,6 +73,7 @@ class Citation
   def date_created
     v = try_fields([:date_created, :created])
     return nil if v.nil?
+    return v if v.is_a? Date
     begin
       Date.parse(v)
     rescue ArgumentError

--- a/app/views/curation_concern/etds/_form_descriptive_fields.erb
+++ b/app/views/curation_concern/etds/_form_descriptive_fields.erb
@@ -1,95 +1,100 @@
 <fieldset class="required">
   <legend>Required Information</legend>
 
-  <div class="row">
-      <%= f.input :title,
-        input_html: { class: 'input-xlarge' }
-      %>
-      <%= f.input :alternate_title,
-        input_html: { class: 'input-xlarge' }
-      %>
-      <%= f.input :urn,
-        label: 'URN',
-        input_html: { class: 'input-xlarge' }
-      %>
-      <%= f.input :creator,
-        as: :multi_value,
-        label: 'Author',
-        input_html: { class: 'input-xlarge' }
-      %>
-      <%= f.input :advisor,
-        as: :multi_value,
-        input_html: { class: 'input-xlarge' }
-      %>
-      <%= f.input :abstract,
-        as: :text,
-        input_html: {
-          class: 'input-xxxlarge rich-textarea-js',
-          rows: '14'
-        }
-      %>
-      <%= f.input :subject,
-        as: :multi_value,
-        input_html: { class: 'input-xlarge' }
-      %>
-      <%= render partial: 'degree', locals: {f: f, curation_concern: curation_concern} %>
-      <%= f.input :date,
-        label: 'Date of Defense',
-        input_html: { class: 'input-xlarge datepicker' }
-      %>
-      <%= f.input :country,
-        as: :string,
-        input_html: { class: 'input-xlarge' }
-      %>
-      <%= f.input :date_uploaded,
-        label: 'Submission Date',
-        input_html: { class: 'input-xlarge datepicker' }
-      %>
-      <%= f.input :date_approved,
-        label: 'Approval Date',
-        input_html: { class: 'input-xlarge datepicker' }
-      %>
-      <%= f.input :language,
-        as: :multi_value,
-        input_html: { class: 'input-xlarge' }
-      %>
-  </div>
+  <%= f.input :title,
+    input_html: { class: 'input-xlarge' }
+  %>
+
+  <%= f.input :alternate_title,
+    input_html: { class: 'input-xlarge' }
+  %>
+
+  <%= f.input :urn,
+    label: 'URN',
+    input_html: { class: 'input-xlarge' }
+  %>
+
+  <%= f.input :creator,
+    as: :multi_value,
+    label: 'Author',
+    input_html: { class: 'input-xlarge' }
+  %>
+
+  <%= f.input :advisor,
+    as: :multi_value,
+    input_html: { class: 'input-xlarge' }
+  %>
+
+  <%= f.input :abstract,
+    as: :text,
+    input_html: {
+      class: 'input-xxxlarge rich-textarea-js',
+      rows: '14'
+    }
+  %>
+
+  <%= f.input :subject,
+    as: :multi_value,
+    input_html: { class: 'input-xlarge' }
+  %>
+
+  <%= render partial: 'degree', locals: {f: f, curation_concern: curation_concern} %>
+
+  <%= f.input :date,
+    label: 'Date of Defense',
+    input_html: { class: 'input-xlarge datepicker' }
+  %>
+
+  <%= f.input :country,
+    as: :string,
+    input_html: { class: 'input-xlarge' }
+  %>
+
+  <%= f.input :date_uploaded,
+    label: 'Submission Date',
+    input_html: { class: 'input-xlarge datepicker' }
+  %>
+
+  <%= f.input :date_approved,
+    label: 'Approval Date',
+    input_html: { class: 'input-xlarge datepicker' }
+  %>
+
+  <%= f.input :language,
+    as: :multi_value,
+    input_html: { class: 'input-xlarge' }
+  %>
 </fieldset>
 
 <fieldset class="optional prompt">
 
-  <div class="row">
-      <%= f.input :date_created,
-        label: 'Cataloged Date',
-        hint: false,
-        input_html: { class: 'input-xlarge datepicker' }
-      %>
+  <%= f.input :date_created,
+    label: 'Cataloged Date',
+    hint: false,
+    input_html: { class: 'input-xlarge datepicker' }
+  %>
 
-      <%= f.input :publisher,
-        as: :multi_value,
-        input_html: { class: 'input-xlarge' }
-      %>
+  <%= f.input :publisher,
+    as: :multi_value,
+    input_html: { class: 'input-xlarge' }
+  %>
 
-      <%= f.input :coverage_temporal,
-        as: :multi_value,
-        input_html: { class: 'input-xlarge' }
-      %>
+  <%= f.input :coverage_temporal,
+    as: :multi_value,
+    input_html: { class: 'input-xlarge' }
+  %>
 
-      <%= f.input :coverage_spatial,
-        as: :multi_value,
-        input_html: { class: 'input-xlarge' }
-      %>
+  <%= f.input :coverage_spatial,
+    as: :multi_value,
+    input_html: { class: 'input-xlarge' }
+  %>
 
-  </div>
-
-  <div class="row">
-    <%= render partial: 'contributor', locals: {f: f, curation_concern: curation_concern} %>
-    <%= f.input :note,
-      as: :text,
-      input_html: {
-        class: 'input-xxxlarge rich-textarea-js',
-        rows: '5'
-      }
-    %>
-  </div>
+  <%= render partial: 'contributor', locals: {f: f, curation_concern: curation_concern} %>
+  <%= f.input :note,
+    as: :text,
+    input_html: {
+      class: 'input-xxxlarge rich-textarea-js',
+      rows: '5'
+    }
+  %>
 </fieldset>

--- a/app/views/curation_concern/etds/new.html.erb
+++ b/app/views/curation_concern/etds/new.html.erb
@@ -1,0 +1,14 @@
+<% content_for :page_title, curation_concern_page_title(curation_concern) %>
+<% content_for :page_header do %>
+
+<h2>Describe Your <%= curation_concern.class.human_readable_type %></h2>
+<p>
+  The more descriptive information you provide the better we can serve your needs.
+</p>
+<p>
+  Please consider releasing your <%= curation_concern.human_readable_type.downcase %> as an <span class="label label-success">Open Access</span> work.
+</p>
+
+<% end %>
+
+<%= render 'form' %>

--- a/app/views/curation_concern/etds/new.html.erb
+++ b/app/views/curation_concern/etds/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, curation_concern_page_title(curation_concern) %>
+<% content_for :page_title, "New #{curation_concern.class.human_readable_type} // CurateND" %>
 <% content_for :page_header do %>
 
 <h2>Describe Your <%= curation_concern.class.human_readable_type %></h2>


### PR DESCRIPTION
@0bc32a3 — Overriding new page title for new ETD form
@20e7e3a — Allow Senior Theses to render properly
@d8dbdfe — ETDs determine the `human_readable_type` based on the degree
@c06c3a3 — Removing wrapping div; indentation and spacing
@e3fce87 — Allow accordion control to be used on EAD forms

Fixes #343