### PR TITLE
Refining attribute spacing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -112,4 +112,5 @@ end
 group :development do
   gem 'meta_request'
   gem 'rubocop', require: false
+  gem 'scss-lint', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,6 +191,7 @@ GEM
       execjs
     coffee-script-source (1.6.3)
     colored (1.2)
+    colorize (0.7.7)
     columnize (0.3.6)
     compass (0.12.2)
       chunky_png (~> 1.2)
@@ -550,6 +551,9 @@ GEM
       sprockets (~> 2.8, < 3.0)
       sprockets-rails (~> 2.0)
     scrub_rb (1.0.1)
+    scss-lint (0.7.0)
+      colorize
+      sass
     select2-rails (4.0.1)
       thor (~> 0.14)
     sexp_processor (4.3.0)
@@ -722,6 +726,7 @@ DEPENDENCIES
   rubydora (~> 1.7.4)
   sanitize (~> 3.0.2)
   sass-rails (~> 4.0)
+  scss-lint
   select2-rails
   sextant
   simple_form (~> 3.0.1)

--- a/app/assets/stylesheets/modules/attributes.css.scss
+++ b/app/assets/stylesheets/modules/attributes.css.scss
@@ -23,20 +23,28 @@
 
   .attribute {
     list-style-type: none;
+
+    p {
+      margin-bottom: 0;
+    }
+
+    p + p {
+      margin-top: 10px;
+    }
+  }
+
+  .attribute + .attribute {
+    margin-top: 10px;
   }
 
   .breadcrumb {
     background-color: transparent;
+    margin: 0;
     padding: 0;
-    margin:0;
+
     .divider {
       color: #ccc;
       padding: 0 5px;
     }
   }
-
 }
-
-
-
-


### PR DESCRIPTION
## Adding scss-lint as a development dependency for style guide enforcement

@83346e8df20b9607145038f3f63fca3d6481f0f3


## Evening out the spacing of repeating attributes

@88867f23df9ff5f043b1e3e6d12d6ff0c769beea

Since attribute values are run through a markdown parser they are all
wrapped in paragraph tags. This results in a lot of singleton paragraphs
that don't require bottom padding to display correctly.

Linting to appease scss-lint.