### PR TITLE
Removing unused configuration information

### DIFF
--- a/config/initializers/sufia.rb
+++ b/config/initializers/sufia.rb
@@ -51,29 +51,6 @@ Sufia.config do |config|
 
   config.cc_licenses_reverse = Hash[*config.cc_licenses.to_a.flatten.reverse]
 
-  config.resource_types = {
-    "Article" => "Article",
-    "Audio" => "Audio",
-    "Book" => "Book",
-    "Capstone Project" => "Capstone Project",
-    "Conference Proceeding" => "Conference Proceeding",
-    "Dataset" => "Dataset",
-    "Dissertation" => "Dissertation",
-    "Image" => "Image",
-    "Journal" => "Journal",
-    "Map or Cartographic Material" => "Map or Cartographic Material",
-    "Masters Thesis" => "Masters Thesis",
-    "Part of Book" => "Part of Book",
-    "Poster" => "Poster",
-    "Presentation" => "Presentation",
-    "Project" => "Project",
-    "Report" => "Report",
-    "Research Paper" => "Research Paper",
-    "Software or Program Code" => "Software or Program Code",
-    "Video" => "Video",
-    "Other" => "Other",
-  }
-
   config.permission_levels = {
     "Choose Access"=>"none",
     "View/Download" => "read",


### PR DESCRIPTION
In reviewing sufia-models and CurateND, there were no uses of the
configured `resource_types`.