### PR TITLE
Updating secrets for changes to permissions

### DIFF
--- a/script/update_secrets.sh
+++ b/script/update_secrets.sh
@@ -30,7 +30,7 @@ files_to_copy="
     service_dn.yml
     smtp_config.yml
     solr.yml
-    work_type_permissions.yml
+    work_type_policy_rules.yml
     licensing_permissions.yml
     newrelic.yml
     etd_manager_usernames.yml


### PR DESCRIPTION
This builds on the work for #361. There was a switch from
`work_type_permission.yml` to `work_type_policy_rules.yml` as part of
the previous work. The secrets, however, were not getting updated.