### PR TITLE
Updating EventMachine

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,7 +242,7 @@ GEM
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
     erubis (2.7.0)
-    eventmachine (1.0.3)
+    eventmachine (1.2.0.1)
     execjs (2.0.2)
     factory_girl (4.2.0)
       activesupport (>= 3.0.0)
@@ -749,4 +749,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.11.2
+   1.12.4


### PR DESCRIPTION
The old version was having trouble installing on El Capitan.
Thin still works.