### PR TITLE
Replace complicated bash stuff with awk one liner

### DIFF
--- a/script/next-build-identifier.sh
+++ b/script/next-build-identifier.sh
@@ -4,21 +4,10 @@
 
 current_year=$(date "+%Y")
 
-# Oye! Find a build in the current year. Munge it so we can sort things. Grab the latest build. Then reconstitute to build format.
-current_build=$(git tag | grep ^v$current_year\.[0-9]*$ | sed -e 's/^v\([0-9]*\)\.\([0-9]*\)$/\2\1/' | sort -nr | head -1 | sed -e 's/^\([0-9]*\)\([0-9][0-9][0-9][0-9]\)$/v\2.\1/')
-if [ -z $current_build ]
-then
-  current_build="v$current_year.0"
-else
-  build_year=$(echo $current_build | sed -e 's/^v\([0-9]*\)\.\([0-9]*\)$/\1/')
-  if [ "$current_year" != "$build_year" ]
-  then
-    current_build="v$current_year.0"
-  fi
-fi
-current_minor_build=$(echo $current_build | sed -e 's/^[^\.]*\.//')
-next_minor_build=$(expr $current_minor_build + 1)
-next_major_build=$(echo $current_build | sed -e 's/^v\([0-9]*\)\.\([0-9]*\)$/v\1./')
-next_build="$next_major_build$next_minor_build"
-echo "$next_build"
+# For the beginning with the current year, figure out the maximum build number.
+# Then print a tag for the current year with the maximum build number
+# incremented by one. If there is no build number for the current year, use a
+# build number of "1". This is ugly because we need to shell expand current_year,
+# but not the awk argument $2.
+git tag | awk -F '.' "/^v$current_year/ {if (max < \$2) {max = \$2}} END {print \"v$current_year.\"max+1}"
 exit 0


### PR DESCRIPTION
Figuring out the next build identifier can be done using a one line awk
script. This replaces a much more complicated bash process.

As you can see, this is extremely critical.  :smiley: