### PR TITLE
Adding view linter for CurateND ERB templates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -118,5 +118,6 @@ end
 group :development do
   gem 'meta_request'
   gem 'rubocop', require: false
+  gem 'rails-erb-lint', require: false
   gem 'scss-lint', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -272,6 +272,7 @@ GEM
       activerecord (>= 3.0.0)
     fssm (0.2.10)
     git-version-bump (0.15.1)
+    gli (2.14.0)
     hanami-utils (0.7.1)
     hashie (3.3.2)
     highline (1.6.19)
@@ -460,6 +461,10 @@ GEM
       sprockets-rails (~> 2.0)
     rails-assets-Leaflet--Leaflet.fullscreen (1.0.1)
     rails-assets-leaflet (0.7.7)
+    rails-erb-lint (1.1.6)
+      actionpack (>= 4.0)
+      gli (~> 2.1)
+      rainbow (~> 2.0)
     rails-observers (0.1.2)
       activemodel (~> 4.0)
     rails_autolink (1.1.6)
@@ -734,6 +739,7 @@ DEPENDENCIES
   rails (~> 4.0.2)
   rails-assets-Leaflet--Leaflet.fullscreen!
   rails-assets-leaflet!
+  rails-erb-lint
   rails_autolink
   rails_best_practices
   rake

--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ task :test_setup do
 
 end
 desc "run all of the specs"
-task :rspec => :test_setup do
+task :rspec => [:test_setup, 'curatend:lint_erb'] do
   RSpec::Core::RakeTask.new(:__rspec) do |t|
     t.pattern = "./spec/**/*_spec.rb"
   end

--- a/lib/tasks/curatend.rake
+++ b/lib/tasks/curatend.rake
@@ -79,10 +79,17 @@ namespace :curatend do
       Rake::Task['db:schema:load'].invoke
 
       Rake::Task['curatend:ci_spec'].invoke
+      Rake::Task['curatend:lint_erb'].invoke
     end
 
     RSpec::Core::RakeTask.new(:ci_spec) do |t|
       t.pattern = "./spec/**/*_spec.rb"
+    end
+
+    desc "Lint ERB templates"
+    task lint_erb: :environment do
+      returning_value = system("cd #{Rails.root.join('app/views')} && bundle exec rails-erb-lint check")
+      abort "There were linting errors in the ERB templates. See above message(s)." unless returning_value
     end
   end
 end


### PR DESCRIPTION
## Adding rails-erb-lint gem

@57277591dd6c0cdc3425cfdb206f399ab9b01ae3

```console
$ bundle
```

## Adding view linter for CurateND ERB templates

@e397eaaa5a02b7607993a6cbb99b6e77ac9cfd0f

We have minimal view tests, and as such, invalid ERB can make its way
into production. This is a step we are taking to guard against adding
invalid ERB (and thus causing a hard system crash as the template is
unparsable).

Closes DLT-488
