### PR TITLE
Adding fault tolerance for representative image

### DIFF
--- a/app/views/curation_concern/base/_representative_media.html.erb
+++ b/app/views/curation_concern/base/_representative_media.html.erb
@@ -1,29 +1,34 @@
-<% if work.representative.present? && (generic_file = GenericFile.load_instance_from_solr(work.representative)) %>
-  <% if can?(:read, generic_file) %>
-    <% if generic_file.image? %>
-      <a href="<%= download_path(work.representative) %>" class="colorbox-image">
-        <%= image_tag download_path(generic_file, datastream_id: 'thumbnail'), class: 'representative_image' %>
-      </a>
-    <% elsif generic_file.pdf? || generic_file.video? %>
-      <a href="<%=download_path(work.representative) %>" target = "_blank">
-        <%= image_tag download_path(generic_file, datastream_id: 'thumbnail'), class: 'representative_image' %>
-      </a>
-    <% elsif generic_file.audio? %>
-      <audio controls="controls" class="video-js vjs-default-skin" data-setup="{}" preload="auto">
-        <source src="<%= download_path(generic_file, datastream_id: 'ogg') %>" type="audio/ogg" />
-        <source src="<%= download_path(generic_file, datastream_id: 'mp3') %>" type="audio/mpeg" />
-        Your browser does not support the audio tag.
-      </audio>
+<% if work.representative.present? %>
+  <% begin %>
+    <% generic_file = GenericFile.load_instance_from_solr(work.representative) %>
+    <% if can?(:read, generic_file) %>
+      <% if generic_file.image? %>
+        <a href="<%= download_path(work.representative) %>" class="colorbox-image">
+          <%= image_tag download_path(generic_file, datastream_id: 'thumbnail'), class: 'representative_image' %>
+        </a>
+      <% elsif generic_file.pdf? || generic_file.video? %>
+        <a href="<%=download_path(work.representative) %>" target = "_blank">
+          <%= image_tag download_path(generic_file, datastream_id: 'thumbnail'), class: 'representative_image' %>
+        </a>
+      <% elsif generic_file.audio? %>
+        <audio controls="controls" class="video-js vjs-default-skin" data-setup="{}" preload="auto">
+          <source src="<%= download_path(generic_file, datastream_id: 'ogg') %>" type="audio/ogg" />
+          <source src="<%= download_path(generic_file, datastream_id: 'mp3') %>" type="audio/mpeg" />
+          Your browser does not support the audio tag.
+        </audio>
+      <% else %>
+        <a href="<%= download_path(work.representative) %>" target = "_blank">
+          <%= image_tag 'curate/default.png', class: "canonical-image" %>
+        </a>
+      <% end %>
     <% else %>
       <a href="<%= download_path(work.representative) %>" target = "_blank">
-        <%= image_tag 'curate/default.png', class: "canonical-image" %>
+        <%= image_tag download_path(work.representative,'thumbnail'), class: 'representative_image' %>
       </a>
     <% end %>
+  <% rescue ActiveFedora::ObjectNotFoundError %>
+    <%= image_tag 'curate/default.png', class: 'canonical-image' %>
   <% end %>
-<% elsif work.representative.present? %>
-  <a href="<%= download_path(work.representative) %>" target = "_blank">
-    <%= image_tag download_path(work.representative,'thumbnail'), class: 'representative_image' %>
-  </a>
 <% else %>
   <%= image_tag 'curate/default.png', class: "canonical-image" %>
 <% end %>


### PR DESCRIPTION
The assumption that we attempt to load the image from SOLR but allow
for an exception to be thrown on the find is rather awkward.

This change wraps the rendering logic with a rescue clause to not
disrupt the users viewing experience.

Possible issues:

- If there is a missing SOLR we won't provide a link to the download