### PR TITLE
Remove index_type for field dc:source

### DIFF
--- a/app/repository_datastreams/finding_aid_rdf_datastream.rb
+++ b/app/repository_datastreams/finding_aid_rdf_datastream.rb
@@ -48,7 +48,6 @@ class FindingAidRdfDatastream < ActiveFedora::NtriplesRDFDatastream
     map.part(:to => "hasPart", in: RDF::DC)
 
     map.source(to: 'source', in: RDF::DC) do |index|
-      index.type :text
       index.as :stored_searchable, :displayable
     end
   end


### PR DESCRIPTION
As Don requested, I took out index.type :text because this is a URL.