### PR TITLE
Normalizing /show/:id and concern/:type/:id view rendering

### DIFF
--- a/app/views/common_objects/show.html.erb
+++ b/app/views/common_objects/show.html.erb
@@ -65,7 +65,7 @@
 <% end %>
 
 <%
-  has_doi = curation_concern.identifier.present?
+  has_doi = curation_concern.try(:identifier).present?
 
   if has_doi
     doi = curation_concern.identifier

--- a/app/views/common_objects/show.html.erb
+++ b/app/views/common_objects/show.html.erb
@@ -6,22 +6,80 @@
 
 <% content_for :page_actions do %>
   <% if display_citation_generation? %>
-    <%= link_to 'Generate Citation', citation_path(curation_concern) , class: 'btn btn-default citation-modal-js' %>
+    <%= link_to 'Generate Citation', citation_path(curation_concern) , class: 'btn citation-modal-js' %>
   <% end %>
   <% if can?(:edit, curation_concern) %>
-    <%= link_to 'Edit', edit_polymorphic_path([:curation_concern, curation_concern]), class: 'btn btn-default' %>
+    <%= link_to edit_polymorphic_path([:curation_concern, curation_concern]), class: 'btn btn-default' do %>
+      <i class="icon icon-pencil"></i> Edit
+    <% end %>
+    <%= link_to [:curation_concern, curation_concern], class: 'btn', data: { confirm: "Delete this #{curation_concern.human_readable_type}?" }, method: :delete do %>
+      <i class="icon icon-trash"></i> Delete
+    <% end %>
   <% end %>
 <% end %>
 
-<div class="work-attributes">
+<% details = capture do %>
+  <%# MOVE these partials into the common_objects controller %>
   <%= render "curation_concern/#{curation_concern.class.model_name.plural}/attributes", curation_concern: curation_concern, with_actions: false %>
-</div>
+  <%= render 'curation_concern/base/doi', curation_concern: curation_concern %>
 
-<% case curation_concern %>
-<% when GenericFile %>
-  <%= link_to 'Download this File', download_path(curation_concern), class: 'btn btn-default' %>
-<% when LibraryCollection %>
-  <%= render 'curation_concern/library_collections/library_collection_members', curation_concern: curation_concern %>
-<% else %>
+  <% case curation_concern %>
+  <% when GenericFile %>
+    <%= link_to 'Download this File', download_path(curation_concern), class: 'btn btn-default' %>
+  <% when LibraryCollection %>
+    <%= render 'curation_concern/library_collections/library_collection_members', curation_concern: curation_concern %>
+  <% end %>
+
   <%= render 'curation_concern/base/related_files', curation_concern: curation_concern, with_actions: true %>
+  <%= render 'curation_concern/base/related_resources', curation_concern: curation_concern, with_actions: true %>
+  <%= render 'curation_concern/base/related_works', curation_concern: curation_concern, with_actions: true %>
+  <%= render 'curation_concern/base/collections', curation_concern: curation_concern %>
+<% end %>
+
+<% if curation_concern.representative.present? %>
+  <% if curation_concern.is_a? Image %>
+    <div class="row">
+      <div class="work-representation span12">
+        <%= render partial: 'curation_concern/base/image_viewer', locals: { work: curation_concern } %>
+      </div>
+    </div>
+    <div class="row">
+      <div class="work-attributes span12">
+        <%= details %>
+      </div>
+    </div>
+  <% else %>
+    <div class="row">
+      <div class="work-representation span3">
+        <%= render partial: 'curation_concern/base/representative_media', locals: { work: curation_concern } %>
+      </div>
+      <div class="work-attributes span9">
+        <%= details %>
+      </div>
+    </div>
+  <% end %>
+<% else %>
+  <div class="work-attributes">
+    <%= details %>
+  </div>
+<% end %>
+
+<%
+  has_doi = curation_concern.identifier.present?
+
+  if has_doi
+    doi = curation_concern.identifier
+    pattern = %r{doi:}i
+    if pattern.match(doi)
+      unprefixed_doi = doi.gsub(pattern, '')
+    else
+      unprefixed_doi = doi
+    end
+  end
+%>
+<% if has_doi %>
+  <div class="show-analytics">
+    <hr />
+    <a href="https://plu.mx/notre/a/?doi=<%= unprefixed_doi %>" class="plumx-details" data-hide-when-empty="true" data-site="notre"></a>
+  </div>
 <% end %>

--- a/app/views/curation_concern/articles/_attributes.html.erb
+++ b/app/views/curation_concern/articles/_attributes.html.erb
@@ -6,10 +6,13 @@
     <tr><th>Attribute Name</th><th>Values</th></tr>
   </thead>
   <tbody>
+    <%= curation_concern_attribute_to_html(curation_concern, :alternate_title, 'Alternate Title') %>
     <%= curation_concern_attribute_to_html(curation_concern, :creator, 'Creator') %>
     <%= curation_concern_attribute_to_html(curation_concern, :contributor, 'Contributor') %>
     <%= curation_concern_attribute_to_html(curation_concern, :subject, "Subject") %>
     <%= curation_concern_attribute_to_html(curation_concern, :publisher, "Publisher") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :issn, "ISSN") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :date_created, "Date Created") %>
     <%= curation_concern_attribute_to_html(curation_concern, :recommended_citation, "Bibliographic Citation") %>
     <%= curation_concern_attribute_to_html(curation_concern, :language, "Language") %>
     <%= curation_concern_attribute_to_html(curation_concern, :source, "Source") %>
@@ -25,5 +28,8 @@
     <% if curation_concern.type_of_license == "Independently Licensed" %>
       <%= curation_concern_attribute_to_html(curation_concern, :license, "License Agreement") %>
     <% end %>
+    <%= curation_concern_attribute_to_html(curation_concern, :content_format, "Format Type") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :spatial_coverage, "Spatial Coverage") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :temporal_coverage, "Temporal Coverage") %>
   </tbody>
 </table>

--- a/app/views/curation_concern/articles/_attributes.html.erb
+++ b/app/views/curation_concern/articles/_attributes.html.erb
@@ -6,12 +6,8 @@
     <tr><th>Attribute Name</th><th>Values</th></tr>
   </thead>
   <tbody>
-  <% curation_concern.creator.each do |creator| %>
-    <tr><th> Creator </th><td><%= creator %></td></tr>
-  <% end %>
-  <% curation_concern.contributor.each do |contributor| %>
-    <tr><th> Contributor </th><td><%= contributor %></td></tr>
-  <% end %>
+  <%= curation_concern_attribute_to_html(curation_concern, :creator, 'Creator') %>
+  <%= curation_concern_attribute_to_html(curation_concern, :contributor, 'Contributor') %>
   <%= curation_concern_attribute_to_html(curation_concern, :subject, "Subject") %>
   <%= curation_concern_attribute_to_html(curation_concern, :publisher, "Publisher") %>
   <%= curation_concern_attribute_to_html(curation_concern, :recommended_citation, "Bibliographic Citation") %>

--- a/app/views/curation_concern/articles/_attributes.html.erb
+++ b/app/views/curation_concern/articles/_attributes.html.erb
@@ -6,24 +6,24 @@
     <tr><th>Attribute Name</th><th>Values</th></tr>
   </thead>
   <tbody>
-  <%= curation_concern_attribute_to_html(curation_concern, :creator, 'Creator') %>
-  <%= curation_concern_attribute_to_html(curation_concern, :contributor, 'Contributor') %>
-  <%= curation_concern_attribute_to_html(curation_concern, :subject, "Subject") %>
-  <%= curation_concern_attribute_to_html(curation_concern, :publisher, "Publisher") %>
-  <%= curation_concern_attribute_to_html(curation_concern, :recommended_citation, "Bibliographic Citation") %>
-  <%= curation_concern_attribute_to_html(curation_concern, :language, "Language") %>
-  <%= curation_concern_attribute_to_html(curation_concern, :source, "Source") %>
-  <%= decode_administrative_unit(curation_concern, :administrative_unit, "Departments and Units") %>
-  <tr>
-    <th>Access Rights</th>
-    <td>
-      <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern } %>
-    </td>
-  </tr>
-  <%= curation_concern_attribute_to_html(curation_concern, :embargo_release_date, "Embargo Release Date") %>
-  <%= curation_concern_attribute_to_html(curation_concern, :rights, "Content License") %>
-  <% if curation_concern.type_of_license == "Independently Licensed" %>
-    <%= curation_concern_attribute_to_html(curation_concern, :license, "License Agreement") %>
-  <% end %>
+    <%= curation_concern_attribute_to_html(curation_concern, :creator, 'Creator') %>
+    <%= curation_concern_attribute_to_html(curation_concern, :contributor, 'Contributor') %>
+    <%= curation_concern_attribute_to_html(curation_concern, :subject, "Subject") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :publisher, "Publisher") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :recommended_citation, "Bibliographic Citation") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :language, "Language") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :source, "Source") %>
+    <%= decode_administrative_unit(curation_concern, :administrative_unit, "Departments and Units") %>
+    <tr>
+      <th>Access Rights</th>
+      <td>
+        <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern } %>
+      </td>
+    </tr>
+    <%= curation_concern_attribute_to_html(curation_concern, :embargo_release_date, "Embargo Release Date") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :rights, "Content License") %>
+    <% if curation_concern.type_of_license == "Independently Licensed" %>
+      <%= curation_concern_attribute_to_html(curation_concern, :license, "License Agreement") %>
+    <% end %>
   </tbody>
 </table>

--- a/app/views/curation_concern/articles/_attributes.html.erb
+++ b/app/views/curation_concern/articles/_attributes.html.erb
@@ -17,6 +17,8 @@
     <%= curation_concern_attribute_to_html(curation_concern, :language, "Language") %>
     <%= curation_concern_attribute_to_html(curation_concern, :source, "Source") %>
     <%= decode_administrative_unit(curation_concern, :administrative_unit, "Departments and Units") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :spatial_coverage, "Spatial Coverage") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :temporal_coverage, "Temporal Coverage") %>
     <tr>
       <th>Access Rights</th>
       <td>
@@ -29,7 +31,5 @@
       <%= curation_concern_attribute_to_html(curation_concern, :license, "License Agreement") %>
     <% end %>
     <%= curation_concern_attribute_to_html(curation_concern, :content_format, "Format Type") %>
-    <%= curation_concern_attribute_to_html(curation_concern, :spatial_coverage, "Spatial Coverage") %>
-    <%= curation_concern_attribute_to_html(curation_concern, :temporal_coverage, "Temporal Coverage") %>
   </tbody>
 </table>

--- a/app/views/curation_concern/base/_doi.html.erb
+++ b/app/views/curation_concern/base/_doi.html.erb
@@ -1,4 +1,4 @@
-<% if curation_concern.identifier.present? %>
+<% if curation_concern.try(:identifier).present? %>
   <%- remote_service = Hydra::RemoteIdentifier.remote_service(:doi) -%>
   <h2>Digital Object Identifier</h2>
   <p>

--- a/app/views/curation_concern/base/_related_resources.html.erb
+++ b/app/views/curation_concern/base/_related_resources.html.erb
@@ -1,3 +1,4 @@
+<% if curation_concern.respond_to?(:linked_resources) %>
 <%
   editor = can?(:edit, curation_concern)
   with_linked_resources = curation_concern.linked_resources.present?
@@ -49,4 +50,5 @@
       <% end %>
     </div>
   <% end %>
+<% end %>
 <% end %>

--- a/app/views/curation_concern/base/_related_works.html.erb
+++ b/app/views/curation_concern/base/_related_works.html.erb
@@ -1,52 +1,52 @@
-<% if can? :edit, curation_concern %>
-  <h2>Related Works</h2>
-  <p>Add works that are related to this <%= curation_concern.human_readable_type %>.</p>
-  <%= form_for [:curation_concern, curation_concern], method: :patch, html: {class: "edit-related-works"} do |f| %>
-    <%# NOTE: You can't use a url builder to create the query URL because it will escape it; the JavaScript is already doing this %>
-    <%= f.text_field :related_work_tokens, class:"autocomplete tokens", data: { url: "#{catalog_index_path}?f[generic_type_sim][]=Work", load: curation_concern.related_works.to_json, exclude:"[#{curation_concern.pid.inspect}]" } %>
-    <%= f.submit "Update Related Works", class: 'btn' %>
-  <% end %>
-<% elsif curation_concern.related_works.present? %>
-<table class="table table-striped <%= dom_class(curation_concern) %> related-to-works with-headroom">
-  <caption class="table-heading">
+<% if curation_concern.respond_to?(:related_works) %>
+  <% if can? :edit, curation_concern %>
     <h2>Related Works</h2>
-    <p>Works that are related to this <%= curation_concern.human_readable_type %>.</p>
-  </caption>
-  <% if curation_concern.related_works.present? %>
-    <thead>
-    <tr>
-      <th>Work Title</th>
-    </tr>
-    </thead>
-    <tbody>
-    <% curation_concern.related_works.each do |related_work| %>
-      <tr class="referenced_by_works attributes">
-        <td class="attribute title"><%= link_to related_work.title, polymorphic_path([:curation_concern, related_work]) %></td>
-      </tr>
+    <p>Add works that are related to this <%= curation_concern.human_readable_type %>.</p>
+    <%= form_for [:curation_concern, curation_concern], method: :patch, html: {class: "edit-related-works"} do |f| %>
+      <%# NOTE: You can't use a url builder to create the query URL because it will escape it; the JavaScript is already doing this %>
+      <%= f.text_field :related_work_tokens, class:"autocomplete tokens", data: { url: "#{catalog_index_path}?f[generic_type_sim][]=Work", load: curation_concern.related_works.to_json, exclude:"[#{curation_concern.pid.inspect}]" } %>
+      <%= f.submit "Update Related Works", class: 'btn' %>
     <% end %>
-    </tbody>
   <% end %>
-</table>
-
+  <table class="table table-striped <%= dom_class(curation_concern) %> related-to-works with-headroom">
+    <caption class="table-heading">
+      <h2>Related Works</h2>
+      <p>Works that are related to this <%= curation_concern.human_readable_type %>.</p>
+    </caption>
+    <% if curation_concern.related_works.present? %>
+      <thead>
+      <tr>
+        <th>Work Title</th>
+      </tr>
+      </thead>
+      <tbody>
+      <% curation_concern.related_works.each do |related_work| %>
+        <tr class="referenced_by_works attributes">
+          <td class="attribute title"><%= link_to related_work.title, polymorphic_path([:curation_concern, related_work]) %></td>
+        </tr>
+      <% end %>
+      </tbody>
+    <% end %>
+  </table>
 <% end %>
 
-<% if curation_concern.referenced_by_works.present? %>
-<table class="table table-striped <%= dom_class(curation_concern) %> referenced-by-works with-headroom">
-  <caption class="table-heading">
-    <h2>Referenced by</h2>
-    <p>Works that list this one in as being related to them.</p>
-  </caption>
-    <thead>
-    <tr>
-      <th>Work Title</th>
-    </tr>
-    </thead>
-    <tbody>
-    <% curation_concern.referenced_by_works.each do |related_work| %>
-      <tr class="referenced_by_works attributes">
-        <td class="attribute title"><%= link_to related_work.title, polymorphic_path([:curation_concern, related_work]) %></td>
+<% if curation_concern.respond_to?(:referenced_by_works) && curation_concern.referenced_by_works.present? %>
+  <table class="table table-striped <%= dom_class(curation_concern) %> referenced-by-works with-headroom">
+    <caption class="table-heading">
+      <h2>Referenced by</h2>
+      <p>Works that list this one in as being related to them.</p>
+    </caption>
+      <thead>
+      <tr>
+        <th>Work Title</th>
       </tr>
-    <% end %>
-    </tbody>
-</table>
+      </thead>
+      <tbody>
+      <% curation_concern.referenced_by_works.each do |related_work| %>
+        <tr class="referenced_by_works attributes">
+          <td class="attribute title"><%= link_to related_work.title, polymorphic_path([:curation_concern, related_work]) %></td>
+        </tr>
+      <% end %>
+      </tbody>
+  </table>
 <% end %>

--- a/app/views/curation_concern/datasets/_attributes.html.erb
+++ b/app/views/curation_concern/datasets/_attributes.html.erb
@@ -6,28 +6,24 @@
     <tr><th>Attribute Name</th><th>Values</th></tr>
   </thead>
   <tbody>
-  <% curation_concern.creator.each do |creator| %>
-    <tr><th> Creator </th><td><%= creator %></td></tr>
-  <% end %>
-  <% curation_concern.contributor.each do |contributor| %>
-    <tr><th> Contributor </th><td><%= contributor %></td></tr>
-  <% end %>
-  <%= curation_concern_attribute_to_html(curation_concern, :subject, "Subject") %>
-  <%= curation_concern_attribute_to_html(curation_concern, :publisher, "Publisher") %>
-  <%= curation_concern_attribute_to_html(curation_concern, :recommended_citation, "Recommeded Citation") %>
-  <%= curation_concern_attribute_to_html(curation_concern, :source, "Source") %>
-  <%= curation_concern_attribute_to_html(curation_concern, :language, "Language") %>
-  <%= decode_administrative_unit(curation_concern, :administrative_unit, "Departments and Units") %>
-  <tr>
-    <th>Access Rights</th>
-    <td>
-      <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern } %>
-    </td>
-  </tr>
-  <%= curation_concern_attribute_to_html(curation_concern, :embargo_release_date, "Embargo Release Date") %>
-  <%= curation_concern_attribute_to_html(curation_concern, :rights, "Content License") %>
-  <% if curation_concern.type_of_license == "Independently Licensed" %>
-    <%= curation_concern_attribute_to_html(curation_concern, :license, "License Agreement") %>
-  <% end %>
+    <%= curation_concern_attribute_to_html(curation_concern, :creator, 'Creator') %>
+    <%= curation_concern_attribute_to_html(curation_concern, :contributor, 'Contributor') %>
+    <%= curation_concern_attribute_to_html(curation_concern, :subject, "Subject") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :publisher, "Publisher") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :recommended_citation, "Recommeded Citation") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :source, "Source") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :language, "Language") %>
+    <%= decode_administrative_unit(curation_concern, :administrative_unit, "Departments and Units") %>
+    <tr>
+      <th>Access Rights</th>
+      <td>
+        <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern } %>
+      </td>
+    </tr>
+    <%= curation_concern_attribute_to_html(curation_concern, :embargo_release_date, "Embargo Release Date") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :rights, "Content License") %>
+    <% if curation_concern.type_of_license == "Independently Licensed" %>
+      <%= curation_concern_attribute_to_html(curation_concern, :license, "License Agreement") %>
+    <% end %>
   </tbody>
 </table>

--- a/app/views/curation_concern/datasets/_attributes.html.erb
+++ b/app/views/curation_concern/datasets/_attributes.html.erb
@@ -10,10 +10,14 @@
     <%= curation_concern_attribute_to_html(curation_concern, :contributor, 'Contributor') %>
     <%= curation_concern_attribute_to_html(curation_concern, :subject, "Subject") %>
     <%= curation_concern_attribute_to_html(curation_concern, :publisher, "Publisher") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :size, "Size") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :requires, "Requires") %>
     <%= curation_concern_attribute_to_html(curation_concern, :recommended_citation, "Recommeded Citation") %>
     <%= curation_concern_attribute_to_html(curation_concern, :source, "Source") %>
     <%= curation_concern_attribute_to_html(curation_concern, :language, "Language") %>
     <%= decode_administrative_unit(curation_concern, :administrative_unit, "Departments and Units") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :spatial_coverage, "Spatial Coverage") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :temporal_coverage, "Temporal Coverage") %>
     <tr>
       <th>Access Rights</th>
       <td>

--- a/app/views/curation_concern/images/_attributes.html.erb
+++ b/app/views/curation_concern/images/_attributes.html.erb
@@ -6,22 +6,32 @@
     <tr><th>Attribute Name</th><th>Values</th></tr>
   </thead>
   <tbody>
-  <% curation_concern.creator.each do |creator| %>
-    <tr><th> Creator </th><td><%= creator %></td></tr>
-  <% end %>
-  <%= curation_concern_attribute_to_html(curation_concern, :subject, "Subject") %>
-  <%= curation_concern_attribute_to_html(curation_concern, :publisher, "Publisher") %>
-  <%= decode_administrative_unit(curation_concern, :administrative_unit, "Departments and Units") %>
-  <tr>
-    <th>Access Rights</th>
-    <td>
-      <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern } %>
-    </td>
-  </tr>
-  <%= curation_concern_attribute_to_html(curation_concern, :embargo_release_date, "Embargo Release Date") %>
-  <%= curation_concern_attribute_to_html(curation_concern, :rights, "Content License") %>
-  <% if curation_concern.type_of_license == "Independently Licensed" %>
-    <%= curation_concern_attribute_to_html(curation_concern, :license, "License Agreement") %>
-  <% end %>
+    <%= curation_concern_attribute_to_html(curation_concern, :alternate_title, 'Alternate Title') %>
+    <%= curation_concern_attribute_to_html(curation_concern, :creator, 'Creator') %>
+    <%= curation_concern_attribute_to_html(curation_concern, :creator, 'Contributor') %>
+    <%= curation_concern_attribute_to_html(curation_concern, :subject, "Subject") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :source, "Source") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :size, "Size") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :requires, "Requires") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :publisher, "Publisher") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :date_created, "Date Created") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :date_digitized, "Date Digitized") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :digitizing_equipment, "Digitizing Equipment") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :recommended_citation, "Recommended Citation") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :language, "Language") %>
+    <%= decode_administrative_unit(curation_concern, :administrative_unit, "Departments and Units") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :spatial_coverage, "Spatial Coverage") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :temporal_coverage, "Temporal Coverage") %>
+    <tr>
+      <th>Access Rights</th>
+      <td>
+        <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern } %>
+      </td>
+    </tr>
+    <%= curation_concern_attribute_to_html(curation_concern, :embargo_release_date, "Embargo Release Date") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :rights, "Content License") %>
+    <% if curation_concern.type_of_license == "Independently Licensed" %>
+      <%= curation_concern_attribute_to_html(curation_concern, :license, "License Agreement") %>
+    <% end %>
   </tbody>
 </table>

--- a/app/views/curation_concern/images/_attributes.html.erb
+++ b/app/views/curation_concern/images/_attributes.html.erb
@@ -8,7 +8,7 @@
   <tbody>
     <%= curation_concern_attribute_to_html(curation_concern, :alternate_title, 'Alternate Title') %>
     <%= curation_concern_attribute_to_html(curation_concern, :creator, 'Creator') %>
-    <%= curation_concern_attribute_to_html(curation_concern, :creator, 'Contributor') %>
+    <%= curation_concern_attribute_to_html(curation_concern, :contributor, 'Contributor') %>
     <%= curation_concern_attribute_to_html(curation_concern, :subject, "Subject") %>
     <%= curation_concern_attribute_to_html(curation_concern, :source, "Source") %>
     <%= curation_concern_attribute_to_html(curation_concern, :size, "Size") %>

--- a/app/views/curation_concern/library_collections/_library_collection_members.html.erb
+++ b/app/views/curation_concern/library_collections/_library_collection_members.html.erb
@@ -2,7 +2,7 @@
   <h2>Library Collection Members</h2>
   <ul>
     <% curation_concern.library_collection_members.each do |member| %>
-      <li><%= link_to(member, polymorphic_path([:curation_concern, member])) %></li>
+      <li><%= link_to(member, common_object_path(member)) %></li>
     <% end %>
   </ul>
 </div>

--- a/app/views/curation_concern/senior_theses/_attributes.html.erb
+++ b/app/views/curation_concern/senior_theses/_attributes.html.erb
@@ -9,6 +9,7 @@
   <%= curation_concern_attribute_to_html(curation_concern, :creator, "Created by") %>
   <%= curation_concern_attribute_to_html(curation_concern, :created, "Created on") %>
   <%= curation_concern_attribute_to_html(curation_concern, :advisor, "Advisor") %>
+  <%= curation_concern_attribute_to_html(curation_concern, :contributor, "Contributor") %>
   <%= curation_concern_attribute_to_html(curation_concern, :subject, "Subject") %>
   <%= curation_concern_attribute_to_html(curation_concern, :bibliographic_citation, "Bibliographic Citation") %>
   <%= curation_concern_attribute_to_html(curation_concern, :language, "Language") %>

--- a/config/initializers/curate_config.rb
+++ b/config/initializers/curate_config.rb
@@ -7,7 +7,6 @@ Curate.configure do |config|
   config.register_curation_concern :article
   config.register_curation_concern :image
   config.register_curation_concern :document
-  config.register_curation_concern :etd
   config.register_curation_concern :patent
 
   config.application_root_url = Rails.configuration.application_root_url

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ CurateNd::Application.routes.draw do
   get '/classify_concerns/new', to: redirect('deposit')
 
   # Some ETDs are not loading correctly on the curation concern page
-  ['etds', 'articles', 'datasets'].each do |curation_concern|
+  ['etds', 'articles', 'datasets', 'images'].each do |curation_concern|
     get "/concern/#{curation_concern}/new", to: "curation_concern/#{curation_concern}#new"
     get "/concern/#{curation_concern}/:id", to: redirect { |params, request|
       "/show/#{params[:id]}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,8 +10,8 @@ CurateNd::Application.routes.draw do
   get '/classify_concerns/new', to: redirect('deposit')
 
   # Some ETDs are not loading correctly on the curation concern page
-  get '/concern/etds/new', to: 'curation_concern/etds#new'
   ['etds', 'articles'].each do |curation_concern|
+    get "/concern/#{curation_concern}/new", to: "curation_concern/#{curation_concern}#new"
     get "/concern/#{curation_concern}/:id", to: redirect { |params, request|
       "/show/#{params[:id]}"
     }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ CurateNd::Application.routes.draw do
   get '/classify_concerns/new', to: redirect('deposit')
 
   # Some ETDs are not loading correctly on the curation concern page
-  ['etds', 'articles', 'datasets', 'senior_theses', 'images'].each do |curation_concern|
+  ['etds', 'articles', 'datasets', 'senior_theses', 'images', 'patents', 'generic_files', 'finding_aids', 'documents'].each do |curation_concern|
     get "/concern/#{curation_concern}/new", to: "curation_concern/#{curation_concern}#new"
     get "/concern/#{curation_concern}/:id", to: redirect { |params, request|
       "/show/#{params[:id]}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,9 +11,11 @@ CurateNd::Application.routes.draw do
 
   # Some ETDs are not loading correctly on the curation concern page
   get '/concern/etds/new', to: 'curation_concern/etds#new'
-  get '/concern/etds/:id', to: redirect { |params, request|
-    "/show/#{params[:id]}"
-  }
+  ['etds', 'articles'].each do |curation_concern|
+    get "/concern/#{curation_concern}/:id", to: redirect { |params, request|
+      "/show/#{params[:id]}"
+    }
+  end
   scope module: 'curate' do
     resources 'collections', 'profiles', 'profile_sections', controller: 'collections' do
       collection do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ CurateNd::Application.routes.draw do
   get '/classify_concerns/new', to: redirect('deposit')
 
   # Some ETDs are not loading correctly on the curation concern page
-  ['etds', 'articles', 'datasets', 'images'].each do |curation_concern|
+  ['etds', 'articles', 'datasets', 'senior_theses', 'images'].each do |curation_concern|
     get "/concern/#{curation_concern}/new", to: "curation_concern/#{curation_concern}#new"
     get "/concern/#{curation_concern}/:id", to: redirect { |params, request|
       "/show/#{params[:id]}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ CurateNd::Application.routes.draw do
   get '/classify_concerns/new', to: redirect('deposit')
 
   # Some ETDs are not loading correctly on the curation concern page
-  ['etds', 'articles'].each do |curation_concern|
+  ['etds', 'articles', 'datasets'].each do |curation_concern|
     get "/concern/#{curation_concern}/new", to: "curation_concern/#{curation_concern}#new"
     get "/concern/#{curation_concern}/:id", to: redirect { |params, request|
       "/show/#{params[:id]}"


### PR DESCRIPTION
## Normalizing Articles#attributes partial rendering

@65eb187b6e593adb837f170d528496f64a390ab1

To bring the rendering of creator and contributor inline with how we
chose to do them for documents, I'm leveraging the
`curation_concern_attribute_to_html` method for standardized rendering.

DLTP-486 #comment Normalizing Articles#attribute rendering

## Routing /concern/articles/:id to /show/:id

@564a67b4f05314b8d0ef201cdcae79e1073eda33

As part of DLTP-486, I want to have a common rendering page. This is
not yet a completion of that requirement, but addresses the common
URL aspect of the requirement.

## Updating common objects to reflect concern#show

@eafd56f613c0d14f4a50507b100b5c0c32817f1c

Prior to this commit there was a disparity between the
CurationConcern#show page and the CommonObjects#show page. This
adjustment brings the common objects inline with the show pages.

It will require visiting each of the curation concern types.

Related to DLTP-486

## Refactoring view logic to include better tabbing

@9e121ce0b7275ef3bd515d7fa404287180c30060


## Adding additional fields for Article show page

@70399ca77f37c27169224be213ce2273588d433d

Related to DLTP-500

## Preventing redirection for new Article requests

@0c0b34e34a8b36140d51be4a208bf0d2b80b5aac

This is a bit of an odd duck. Without the
"/concern/<curation_concern>/new" route, that URL will redirect to
"/show/new" URL.

See @13689221 for specific solution.

## Rearranging order of fields for articles#show

@f58361e8ae77f9ff21b488ce7979338a958cbf50


## Normalizing Datasets#attributes partial rendering

@c68427009cb371767b24f35efc90f4d7a924f1ea

To bring the rendering of creator and contributor inline with how we
chose to do them for documents, I'm leveraging the
`curation_concern_attribute_to_html` method for standardized rendering.

DLTP-492 #comment Normalizing Datasets#attribute rendering

## Adding additional fields for Dataset show page

@25d3bce119dff63c294c0a3cfa8d436a482663e6

Related to DLTP-501

## Routing /concern/datasets/:id to /show/:id

@568533b88aea17fa74a85cda049cacbb91c14fc0

As part of DLTP-492, I want to have a common rendering page. This is
not yet a completion of that requirement, but addresses the common
URL aspect of the requirement.

## Normalizing Images#attributes partial rendering

@0ae7f1c277b62ed8b9b7b821568be441847ea151

To bring the rendering of creator and contributor inline with how we
chose to do them for images, I'm leveraging the
`curation_concern_attribute_to_html` method for standardized rendering.

DLTP-501 #comment Normalizing Images#attribute rendering

## Routing /concern/images/:id to /show/:id

@6db8347716f801f0f652a9ad506a5fa228726419

As part of DLTP-497, I want to have a common rendering page. This is
not yet a completion of that requirement, but addresses the common
URL aspect of the requirement.

## Resolving route pathing error for Lib Collections

@c5003614571cc8ce61e27e23f3b98a016057fe69

```console
NoMethodError: undefined method
`curation_concern_library_collection_path' for object
```

## Prevent rendering errors for linked resources

@b00373a0c310f6752be511060c57299e1436bc15

Not all objects appear to respond to #linked_resources. As such, add
some fault tolerance to the application.

## Prevent rendering errors for related works

@03e2dcb8a4dd95ceab02faaac7cbe8df3b1201e1

Not all objects appear to respond to #related_works nor
referenced_by_works. As such, add some fault tolerance to the
application.

## Fixing a mislabeled field

@c51b792bea7568ade04944f06272567d484bd736


## Normalizing SeniorThesis#attributes rendering

@a99ba6d7f3789db5411781b0713543f0e87e26d2

To bring the rendering of creator and contributor inline with how we
chose to do them for images, I'm leveraging the
`curation_concern_attribute_to_html` method for standardized rendering.

DLTP-503 #comment Normalizing SeniorThesis#attribute rendering

## Routing /concern/senior_theses/:id to /show/:id

@9bb165534e3c2c081385ddedd80274c095b7a3de

As part of DLTP-499, I want to have a common rendering page. This is
not yet a completion of that requirement, but addresses the common
URL aspect of the requirement.

## Use standard "show" pages

@9d1dff8a620d8f48e8b234b3931a177dd4f2fd4e

Move patents, generic files, finding aids, and documents to use the standard
show page. Required additional modification for patents not having doi's.
