### PR TITLE
Implementing sorted departmental landing page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,12 +35,12 @@ GIT
 
 GIT
   remote: git://github.com/ndlib/locabulary.git
-  revision: 999fa84b5bb3f973d71ac8a6a02e34bb2499ed36
+  revision: aec912e2d617788d061df9511d5598ef58d020fb
   branch: master
   specs:
-    locabulary (0.4.0)
+    locabulary (0.6.0)
+      activesupport (~> 4.0)
       dry-configurable
-      hanami-utils
       json (~> 1.8)
 
 GIT
@@ -248,7 +248,7 @@ GEM
       devise (>= 2.1.0)
       railties (>= 3.0)
     diff-lcs (1.2.5)
-    dry-configurable (0.1.6)
+    dry-configurable (0.1.7)
       concurrent-ruby (~> 1.0)
     dry-equalizer (0.2.0)
     email_validator (1.5.0)
@@ -276,7 +276,6 @@ GEM
     fssm (0.2.10)
     git-version-bump (0.15.1)
     gli (2.14.0)
-    hanami-utils (0.7.1)
     hashie (3.3.2)
     highline (1.6.19)
     hike (1.2.3)
@@ -373,7 +372,7 @@ GEM
     minitest (4.7.5)
     mono_logger (1.1.0)
     morphine (0.1.1)
-    multi_json (1.11.2)
+    multi_json (1.12.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     mysql2 (0.3.13)
@@ -643,7 +642,7 @@ GEM
     thread_safe (0.3.5)
     tilt (1.4.1)
     trollop (1.16.2)
-    tzinfo (0.3.45)
+    tzinfo (0.3.51)
     uber (0.0.15)
     uglifier (2.2.1)
       execjs (>= 0.3.0)

--- a/app/assets/stylesheets/modules.scss
+++ b/app/assets/stylesheets/modules.scss
@@ -10,6 +10,7 @@
 @import 'modules/concerns';
 @import 'modules/choose_list_format';
 @import 'modules/deposit';
+@import 'modules/department_listing';
 @import 'modules/emphatic_action_area';
 @import 'modules/environment_notices';
 @import 'modules/facets';

--- a/app/assets/stylesheets/modules/department_listing.css.scss
+++ b/app/assets/stylesheets/modules/department_listing.css.scss
@@ -1,0 +1,11 @@
+// Show only ND departments on listing page
+// Show ALL departments in facet modal
+.department-listing .h-node {
+  display: none;
+}
+
+#ajax-modal .h-node,
+.department-listing .h-node:first-child,
+.department-listing .h-node .h-node {
+  display: block;
+}

--- a/app/assets/stylesheets/modules/department_listing.css.scss
+++ b/app/assets/stylesheets/modules/department_listing.css.scss
@@ -5,7 +5,7 @@
 }
 
 #ajax-modal .h-node,
-.department-listing .h-node:first-child,
+.department-listing .h-node.university-of-notre-dame,
 .department-listing .h-node .h-node {
   display: block;
 }

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -183,19 +183,28 @@ class CatalogController < ApplicationController
       # Instead of relying on the Blacklight hierarchy rendering, I want to
       # leverage the Locabulary hiararchy sorter.
       format.html do
-        @departments = FacetedHierarchyPresenter.new(
-          facet_field_name: params[:id],
-          items: @response.facet_by_field_name(params[:id]).items,
-          item_delimiter: ':',
-          predicate_name: 'administrative_units'
-        )
+        @departments = build_faceted_hierarchy_presenter(@response, 'administrative_units')
         render layout: 'curate_nd/1_column'
       end
       format.json { render json: render_facet_list_as_json }
 
       # Draw the partial for the "more" facet modal window:
-      format.js { render layout: false }
+      # Instead of relying on the Blacklight hierarchy rendering, I want to
+      # leverage the Locabulary hiararchy sorter.
+      format.js do
+        @departments = build_faceted_hierarchy_presenter(@response, 'administrative_units')
+        render layout: false
+      end
     end
+  end
+
+  def build_faceted_hierarchy_presenter(solr_response, predicate_name)
+    FacetedHierarchyPresenter.new(
+      facet_field_name: params[:id],
+      items: solr_response.facet_by_field_name(params[:id]).items,
+      item_delimiter: ':',
+      predicate_name: predicate_name
+    )
   end
 
   def self.uploaded_field

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -174,6 +174,30 @@ class CatalogController < ApplicationController
     end
   end
 
+  def departments
+    # Oh Blacklight and your pervasive assumptions about rendering and response objects.
+    # params[:id] should == 'admin_unit_hierarchy_sim'
+    @pagination = get_facet_pagination(params[:id], params)
+    (@response, @document_list) = get_search_results
+    respond_to do |format|
+      # Instead of relying on the Blacklight hierarchy rendering, I want to
+      # leverage the Locabulary hiararchy sorter.
+      format.html do
+        @departments = FacetedHierarchyPresenter.new(
+          facet_field_name: params[:id],
+          items: @response.facet_by_field_name(params[:id]).items,
+          item_delimiter: ':',
+          predicate_name: 'administrative_units'
+        )
+        render layout: 'curate_nd/1_column'
+      end
+      format.json { render json: render_facet_list_as_json }
+
+      # Draw the partial for the "more" facet modal window:
+      format.js { render layout: false }
+    end
+  end
+
   def self.uploaded_field
     #  system_create_dtsi
     solr_name('desc_metadata__date_uploaded', :stored_sortable, type: :date)

--- a/app/presenters/faceted_hierarchy_presenter.rb
+++ b/app/presenters/faceted_hierarchy_presenter.rb
@@ -1,0 +1,54 @@
+require 'locabulary'
+
+# Responsible for rendering a FacetedHierarchy. The HTML fragments created are
+# identical to the fragments in blacklight-hierarchy.
+#
+# @note Instead of using template#content_for, I'm rendering direct HTML. This is a significant rendering time improvement.
+class FacetedHierarchyPresenter
+  def initialize(options = {})
+    @facet_field_name = options.fetch(:facet_field_name)
+    @roots = Locabulary.build_ordered_hierarchical_tree(
+      faceted_items: options.fetch(:items),
+      faceted_item_hierarchy_delimiter: options.fetch(:item_delimiter),
+      predicate_name: options.fetch(:predicate_name)
+    )
+  end
+
+  def render(options={})
+    # I'd prefer to set an instance variable as part of the instantiation of this object, but due to timing, this isn't as easy.
+    @template = options.fetch(:template)
+    html = "<ul class='facet-hierarchy'>\n"
+    html << items_to_html(roots)
+    html << "</ul>"
+    html.html_safe
+  end
+
+  private
+
+  def items_to_html(items)
+    html = ""
+    items.each do |item|
+      item_class = item.children.any? ? 'h-node' : 'h-leaf'
+      html << "<li class='#{item_class}'>\n"
+      html << template.link_to(label_for(item), href_for(item), class: 'facet_select')
+      html << "  <span class='count'>#{item.hits}</span>\n"
+      if item.children.present?
+        html << "  <ul>\n"
+        html << items_to_html(item.children)
+        html << "  </ul>\n"
+      end
+      html << "</li>\n"
+    end
+    html
+  end
+
+  def label_for(item)
+    item.hierarchy_facet_label
+  end
+
+  def href_for(item)
+    template.add_facet_params_and_redirect(facet_field_name, item.value)
+  end
+
+  attr_reader :roots, :template, :facet_field_name
+end

--- a/app/presenters/faceted_hierarchy_presenter.rb
+++ b/app/presenters/faceted_hierarchy_presenter.rb
@@ -18,17 +18,18 @@ class FacetedHierarchyPresenter
     # I'd prefer to set an instance variable as part of the instantiation of this object, but due to timing, this isn't as easy.
     @template = options.fetch(:template)
     html = "<ul class='facet-hierarchy'>\n"
-    html << items_to_html(roots)
+    html << items_to_html(roots, root: true)
     html << "</ul>"
     html.html_safe
   end
 
   private
 
-  def items_to_html(items)
+  def items_to_html(items, root: false)
     html = ""
     items.each do |item|
       item_class = item.children.any? ? 'h-node' : 'h-leaf'
+      item_class += " #{dom_class_for(item)}" if root
       html << "<li class='#{item_class}'>\n"
       html << template.link_to(label_for(item), href_for(item), class: 'facet_select')
       html << "  <span class='count'>#{item.hits}</span>\n"
@@ -44,6 +45,10 @@ class FacetedHierarchyPresenter
 
   def label_for(item)
     item.hierarchy_facet_label
+  end
+
+  def dom_class_for(item)
+    item.value.downcase.gsub(/[\W]+/, '-')
   end
 
   def href_for(item)

--- a/app/views/catalog/departments.html.erb
+++ b/app/views/catalog/departments.html.erb
@@ -11,7 +11,7 @@
   <h3><%= t("curate.catalog.facet_title.#{params[:id]}").html_safe %></h3>
 </div>
 
-<div class="modal-body">
+<div class="modal-body department-listing">
   <%
     help_text = t("curate.catalog.help_text.#{params[:id]}").html_safe
     if help_text.present?

--- a/app/views/catalog/departments.html.erb
+++ b/app/views/catalog/departments.html.erb
@@ -1,0 +1,25 @@
+<%
+  page_title = t("curate.catalog.facet_page_title.#{params[:id]}").html_safe
+  content_for :page_title, "#{page_title} // CurateND"
+%>
+<% content_for :page_header do %>
+  <h1><%= page_title %></h1>
+<% end %>
+<% content_for :main_column_class, 'hierarchical-facet-page span12'  %>
+<div class="hierarchical-value modal-header">
+  <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+  <h3><%= t("curate.catalog.facet_title.#{params[:id]}").html_safe %></h3>
+</div>
+
+<div class="modal-body">
+  <%
+    help_text = t("curate.catalog.help_text.#{params[:id]}").html_safe
+    if help_text.present?
+  %>
+    <p>
+      <%= help_text %>
+    </p>
+  <% end %>
+
+  <%= @departments.render(template: self) %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,6 +68,7 @@ CurateNd::Application.routes.draw do
   match "show/stub/:id" => "common_objects#show_stub_information", via: :get, as: "common_object_stub_information"
   match 'users/:id/edit' => 'users#edit', via: :get, as: 'edit_user'
   match 'downloads/:id(/:datastream_id)(.:format)' => 'downloads#show', via: :get, as: 'download'
+  match 'catalog/hierarchy/admin_unit_hierarchy_sim/facet' => 'catalog#departments', via: :get, id: 'admin_unit_hierarchy_sim'
   match 'catalog/hierarchy/:id/facet' => 'catalog#hierarchy_facet', via: :get, as: 'catalog_hierarchy_facet'
   match 'departments' => 'catalog#departments', via: :get, as: 'departments', id: 'admin_unit_hierarchy_sim'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,7 +69,7 @@ CurateNd::Application.routes.draw do
   match 'users/:id/edit' => 'users#edit', via: :get, as: 'edit_user'
   match 'downloads/:id(/:datastream_id)(.:format)' => 'downloads#show', via: :get, as: 'download'
   match 'catalog/hierarchy/:id/facet' => 'catalog#hierarchy_facet', via: :get, as: 'catalog_hierarchy_facet'
-  match 'departments' => 'catalog#hierarchy_facet', via: :get, as: 'departments', id: 'admin_unit_hierarchy_sim'
+  match 'departments' => 'catalog#departments', via: :get, as: 'departments', id: 'admin_unit_hierarchy_sim'
 
   scope module: 'bendo' do
     match 'cache_status' => 'file_cache_status#check', via: :get, as: 'bendo_cache_status'

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -45,4 +45,20 @@ describe CatalogController do
       end
     end
   end
+
+  describe "GET #departments" do
+    let(:user) { FactoryGirl.create(:user) }
+    # Need to have a well defined hierarchy otherwise things fall apart
+    let!(:work1) { FactoryGirl.create(:generic_work, user: user, title:"Work1", subject:"my subject", administrative_unit: "Notre Dame:College of Arts and Letters" ) }
+    let!(:work2) { FactoryGirl.create(:generic_work, user: user, title:"Work2", subject:"my subject", administrative_unit: "Notre Dame" ) }
+
+
+    describe "get hierarchy facet for administrative unit" do
+      it "should be render hierarchy facet" do
+        sign_in user
+        get :departments, id: 'admin_unit_hierarchy_sim'
+        expect(response).to be_success
+      end
+    end
+  end
 end

--- a/spec/presenters/faceted_hierarchy_presenter_spec.rb
+++ b/spec/presenters/faceted_hierarchy_presenter_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+RSpec.describe FacetedHierarchyPresenter do
+
+  let(:items) {
+    [
+      double('Item', value: 'Parent', hits: 3 ),
+      double('Item', value: 'Parent:Child', hits: 2 ),
+      double('Item', value: 'Parent:Child:Grandchild', hits: 1 )
+    ]
+  }
+  let(:template) { double('Template') }
+  context '#render' do
+    subject { described_class.new(items: items, item_delimiter: ':', predicate_name: 'mock', facet_field_name: 'mock_sim') }
+    it 'returns html_safe nested lists based on given items' do
+      [
+        ["Parent", "Parent", "/parent"],
+        ["Parent:Child", "Child", "/parent/child"],
+        ["Parent:Child:Grandchild", "Grandchild", "/parent/child/grandchild"]
+      ].each do |value, slug, path|
+        expect(template).to receive(:add_facet_params_and_redirect).with('mock_sim', value).and_return(path)
+        expect(template).to receive(:link_to).with(slug, path, class: 'facet_select').
+          and_return("<a href='#{path}' class='facet_select'>#{slug}</a>")
+      end
+
+      expect(subject.render(template: template)).to have_tag('ul.facet-hierarchy') do
+        with_tag('.h-node a.facet_select', text: 'Parent')
+        with_tag('.h-node .count', text: 3)
+        with_tag('.h-node .h-node a.facet_select', text: 'Child')
+        with_tag('.h-node .h-node .count', text: 2)
+        with_tag('.h-node .h-node .h-leaf a.facet_select', text: 'Grandchild')
+        with_tag('.h-node .h-node .h-leaf .count', text: 1)
+      end
+    end
+  end
+
+end

--- a/spec/presenters/faceted_hierarchy_presenter_spec.rb
+++ b/spec/presenters/faceted_hierarchy_presenter_spec.rb
@@ -24,12 +24,12 @@ RSpec.describe FacetedHierarchyPresenter do
       end
 
       expect(subject.render(template: template)).to have_tag('ul.facet-hierarchy') do
-        with_tag('.h-node a.facet_select', text: 'Parent')
-        with_tag('.h-node .count', text: 3)
-        with_tag('.h-node .h-node a.facet_select', text: 'Child')
-        with_tag('.h-node .h-node .count', text: 2)
-        with_tag('.h-node .h-node .h-leaf a.facet_select', text: 'Grandchild')
-        with_tag('.h-node .h-node .h-leaf .count', text: 1)
+        with_tag('.h-node.parent a.facet_select', text: 'Parent')
+        with_tag('.h-node.parent .count', text: 3)
+        with_tag('.h-node.parent .h-node a.facet_select', text: 'Child')
+        with_tag('.h-node.parent .h-node .count', text: 2)
+        with_tag('.h-node.parent .h-node .h-leaf a.facet_select', text: 'Grandchild')
+        with_tag('.h-node.parent .h-node .h-leaf .count', text: 1)
       end
     end
   end


### PR DESCRIPTION
This can be verified on Libvirt9 (https://libvirt9.library.nd.edu/departments) as of August 8, 2016.

## Updating Locabulary to include Hierarchy processing

@99e7680fcab1c8c6abe06b08520d0ebe3ffd1715


## Implementing sorted departmental landing page

@9df90af21c4a9e45958d4a916f9c1cf123d3f36e

By moving the logic into the presenter, we can skip the custom
rendering of Blacklight Hierarchy and instead encode that information
in a class. This allows for more isolated testing as well as, what I
hope to be, a more clear description of what is going on.

DLTP-512

## Customizing interception of department facet URL

@132864484488a3cb38e7b13718c63a638e84f977

There are two places that should change:

1) The Facets on the left
2) The /departments landing page

With this change, we address item 1. The previous commit addressed
item 2.
