### PR TITLE
Adding `edit_curation_concern_collection_path'

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ CurateNd::Application.routes.draw do
   match 'collections' => 'collections#index', via: :get, as: 'curation_concern_collections'
   get 'collection/:id', to: redirect('collections/%{id}')
   match 'collections/:id' => 'collections#show', via: :get, as: 'curation_concern_collection'
+  match 'collections/:id/edit' => 'collections#edit', via: :get, as: 'edit_curation_concern_collection'
   match 'people/:id' => 'people#show', via: :get, as: 'curation_concern_person'
   match 'people' => 'people#index', via: :get, as: 'curation_concern_people'
 


### PR DESCRIPTION
Addressing an issue in which we don't have a named route for
curation_concern collections, I'm adding a route.

https://errbit.library.nd.edu/apps/5788e498d6c0ee0af0001123/problems/57b33e6dd6c0ee28ed0000fa