### PR TITLE
Accounting for library_collections rendering

### DIFF
--- a/app/helpers/curate_helper.rb
+++ b/app/helpers/curate_helper.rb
@@ -134,6 +134,12 @@ module CurateHelper
   end
   private :__render_tabular_list_item_for_tag
 
+  def __render_tabular_list_item_for_library_collections(method_name, value, block_formatting, tag, options)
+    __render_tabular_list_item(method_name, value, block_formatting, tag, options) do
+      %(<a href="/show/#{value.noid}">#{h(value.title)}</a>)
+    end
+  end
+
   # options[:block_formatting, :class]
   def curation_concern_attribute_to_formatted_text(curation_concern, method_name, label = nil, options = {})
     markup = ""

--- a/spec/helpers/curate_helper_spec.rb
+++ b/spec/helpers/curate_helper_spec.rb
@@ -139,6 +139,15 @@ RSpec.describe CurateHelper do
         expect(output).to have_tag("tr td ul.tabular li.attribute.tag span.callout-text", text: callout_text, count: 1)
       end
     end
+    context 'for #library_collection' do
+      it 'will generate a link to the collection' do
+        library_collections = [LibraryCollection.new(pid: 'und:123', title: 'Hello'), LibraryCollection.new(pid: 'und:456', title: 'World')]
+        curation_concern = double('Curation Concern', library_collections: library_collections)
+        output = helper.curation_concern_attribute_to_html(curation_concern, :library_collections, "Member of")
+        expect(output).to have_tag("tr td ul.tabular li.attribute.library_collections a[href='/show/123']", text: 'Hello', count: 1)
+        expect(output).to have_tag("tr td ul.tabular li.attribute.library_collections a[href='/show/456']", text: 'World', count: 1)
+      end
+    end
   end
 
   describe '#curation_concern_attribute_to_formatted_text' do


### PR DESCRIPTION
Prior to this commit, when we attempted to render a library_collections
predicate, we encountered the following exception:

```console
Curate caught a registered error: TypeError
  wrong argument type LibraryCollection (expected String)
```

The reason being that we had not accounted for the breaking apart of
the LibraryCollection (and were treating it as a literal). With this
change, we now will have links to those collections.

DLTP-553