### PR TITLE
Change start-issue and close-issue to support JIRA issues

### DIFF
--- a/script/close-issue
+++ b/script/close-issue
@@ -6,12 +6,10 @@
 #
 #*******************************************************************************
 
-CONFIG_KEYS = [:REMOTE, :REPOSITORY_PATH, :STARTED_ISSUES_FILE].freeze
+CONFIG_KEYS = [:REPOSITORY_PATH, :STARTED_ISSUES_FILE].freeze
 
 REPOSITORY_PATH = ENV.fetch('REPOSITORY_PATH') { File.expand_path(File.join(File.dirname(__FILE__), '../')) }
-REMOTE = ENV.fetch('REMOTE', 'origin')
 
-# TODO: Retrieve the dasherized issue from Github's API
 STARTED_ISSUES_FILE = ENV.fetch('STARTED_ISSUES_FILE', '.started-issues')
 
 #*******************************************************************************
@@ -41,7 +39,7 @@ if ARGV.grep(/-h/i).size == 1
   $stdout.puts "ENV variable."
   $stdout.puts ""
   $stdout.puts "Example:"
-  $stdout.puts "$ REMOTE=origin ./scripts/#{File.basename(__FILE__)}"
+  $stdout.puts "$ REPOSITORY_PATH=.. ./scripts/#{File.basename(__FILE__)}"
   exit(0)
 end
 
@@ -63,10 +61,15 @@ end
 end
 
 # Guard that I know what the issue number is
-current_branch = `cd #{REPOSITORY_PATH} && git branch | grep '^*'`.sub(/^\*\s*/, '').strip
+current_branch = `cd #{REPOSITORY_PATH} && git branch | grep '^[*]'`.sub(/^\*\s*/, '').strip
 
-if current_branch =~ /^(\d+)[^\d]/
-  ISSUE_NUMBER = $1.to_i
+issue_source = :unknown
+if current_branch =~ /^(\w+-\d+)\D/  # jira issue
+  ISSUE_NUMBER = $1
+  issue_source = :jira
+elsif current_branch =~ /^(\d+)\D/   # github issue
+  ISSUE_NUMBER = $1
+  issue_source = :github
 else
   $stderr.puts "Expected to be able to determine issue number from branch #{current_branch} name @ #{REPOSITORY_PATH}.\n\n"
   $stderr.puts "See help for more information.\n\n"
@@ -96,7 +99,7 @@ started_issues_file_lines = File.read(File.join(REPOSITORY_PATH, STARTED_ISSUES_
 
 File.open(STARTED_ISSUES_FILE, 'w+') do |file|
   started_issues_file_lines.each do |line|
-    file.puts line unless line.to_i == ISSUE_NUMBER.to_i
+    file.puts line unless line.strip.downcase == ISSUE_NUMBER.downcase
   end
 end
 
@@ -107,8 +110,10 @@ begin
   File.open(path_to_commit_message, 'w+') do |file|
     file.puts "Closing issue #{ISSUE_NUMBER}"
     file.puts ""
-    file.puts "Closes ##{ISSUE_NUMBER}"
-    file.puts ""
+    if issue_source == :github
+      file.puts "Closes ##{ISSUE_NUMBER}"
+      file.puts ""
+    end
 
     message = "$ ./script/#{File.basename(__FILE__)} #{ISSUE_NUMBER}"
     CONFIG_KEYS.each_with_object(message) do |key, mem|
@@ -122,4 +127,9 @@ begin
   $stdout.puts `cd #{REPOSITORY_PATH} && git commit -F #{path_to_commit_message}`
 ensure
   File.unlink(path_to_commit_message) rescue true
+end
+
+# update jira and mark this issue as finished
+if issue_source == :jira
+  `jira transition deployed #{ISSUE_NUMBER} --noedit`
 end

--- a/script/close-issue
+++ b/script/close-issue
@@ -131,5 +131,6 @@ end
 
 # update jira and mark this issue as finished
 if issue_source == :jira
-  `jira transition deployed #{ISSUE_NUMBER} --noedit`
+  system("jira transition qa #{ISSUE_NUMBER} --noedit")
+  exit!(5) unless $?.success?
 end

--- a/script/start-issue
+++ b/script/start-issue
@@ -122,6 +122,8 @@ if ISSUE_TITLE.nil?
                     # TODO(dbrower): sometimes this will block waiting for the user to
                     # enter a password. Is better way to handle the situation?
                     document = `jira view #{ISSUE_NUMBER}`
+                    # sometimes there is garbage before the "issue:" line.
+                    document.sub!(/\A[^i]*/, '')
                     issue = YAML.load(document)
                     title = issue["summary"]
                     if title == "<no value>"
@@ -200,6 +202,8 @@ end
 
 # If the commit was successful, assign the issue to us and move into "In Progress"
 if issue_source == :jira
-  `jira take #{ISSUE_NUMBER}`
-  `jira --noedit transition "In Progress" #{ISSUE_NUMBER}`
+  system("jira take #{ISSUE_NUMBER}")
+  exit!(5) unless $?.success?
+  system("jira --noedit transition "In Progress" #{ISSUE_NUMBER}")
+  exit!(5) unless $?.success?
 end

--- a/script/start-issue
+++ b/script/start-issue
@@ -39,27 +39,6 @@ REPOSITORY_PATH = ENV.fetch('REPOSITORY_PATH') { File.expand_path(File.join(File
 REMOTE = ENV.fetch('REMOTE', 'origin')
 FROM_BRANCH = ENV.fetch('FROM_BRANCH', 'master')
 
-issue_title_fetcher = lambda do
-  begin
-    remote_url = `cd #{REPOSITORY_PATH} && git config --get remote.#{REMOTE}.url`.strip
-    match = remote_url.match(/(\w+)\/(\w+)(?:\.git)?\Z/)
-    if match
-      require 'open-uri'
-      require 'json'
-      owner, repository = match.captures
-      document = open("https://api.github.com/repos/#{owner}/#{repository}/issues/#{ISSUE_NUMBER}.json").read
-      json = JSON.parse(document)
-      json.fetch('title').gsub(/\W+/, '-')
-    else
-      'issue-on-github'
-    end
-  rescue
-    'issue-on-github'
-  end
-end
-
-# TODO: Retrieve the dasherized issue from Github's API
-ISSUE_TITLE = ENV.fetch('ISSUE_TITLE', issue_title_fetcher)
 STARTED_ISSUES_FILE = ENV.fetch('STARTED_ISSUES_FILE', '.started-issues')
 
 #*******************************************************************************
@@ -77,7 +56,6 @@ if ARGV.grep(/-h/i).size == 1
   $stdout.puts "* Create a new branch for the given issue number"
   $stdout.puts "* Touch and append the issue number to a tracking file"
   $stdout.puts "* Write a rudimentary commit message"
-  $stdout.puts "* Push that commit up to #{REMOTE}"
   $stdout.puts ""
   $stdout.puts "Note: There are steps to insure you have a clean working directory."
   $stdout.puts "Note: If you have spaces in your configuration all bets are off!"
@@ -103,17 +81,62 @@ end
 
 # Guard that I have an issue number
 
+issue_source = nil
 ISSUE_NUMBER = ARGV.shift
 
-unless ISSUE_NUMBER =~ /^\d+$/
-  $stderr.puts "Expected first parameter to be an issue number for REPOSITORY.\n\n"
+if ISSUE_NUMBER =~ /^\w+-\d+$/
+  issue_source = :jira
+elsif ISSUE_NUMBER =~ /^\d+$/
+  issue_source = :github
+else
+  $stderr.puts "Expected first parameter to be a JIRA or GitHub issue number.\n\n"
   $stderr.puts "See help for details on specifying an issue number.\n\n"
   $stderr.puts "$ ./#{File.basename(__FILE__)} -h"
   exit!(1)
 end
 
 # Capture the issue_title
-issue_title = ISSUE_TITLE.respond_to?(:call) ? ISSUE_TITLE.call : ISSUE_TITLE
+ISSUE_TITLE = ENV.fetch('ISSUE_TITLE', nil)
+if ISSUE_TITLE.nil?
+  case issue_source
+  when :github
+    issue_title = begin
+                    remote_url = `cd #{REPOSITORY_PATH} && git config --get remote.#{REMOTE}.url`.strip
+                    match = remote_url.match(/(\w+)\/(\w+)(?:\.git)?\Z/)
+                    if match
+                      require 'open-uri'
+                      require 'json'
+                      owner, repository = match.captures
+                      document = open("https://api.github.com/repos/#{owner}/#{repository}/issues/#{ISSUE_NUMBER}.json").read
+                      json = JSON.parse(document)
+                      json.fetch('title').gsub(/\W+/, '-')
+                    else
+                      'issue-on-github'
+                    end
+                  rescue
+                    'issue-on-github'
+                  end
+  when :jira
+    issue_title = begin
+                    require 'yaml'
+                    # TODO(dbrower): sometimes this will block waiting for the user to
+                    # enter a password. Is better way to handle the situation?
+                    document = `jira view #{ISSUE_NUMBER}`
+                    issue = YAML.load(document)
+                    title = issue["summary"]
+                    if title == "<no value>"
+                      $stdout.puts "Problem finding issue #{ISSUE_NUMBER}"
+                      exit!(5)
+                    end
+                    title
+                  rescue
+                    $stdout.puts "Problem finding issue #{ISSUE_NUMBER}"
+                    exit!(6)
+                  end
+  end
+else
+  issue_title = ISSUE_TITLE
+end
 
 # Guard that directories exist
 [:REPOSITORY_PATH].each do |key|
@@ -154,8 +177,10 @@ begin
   File.open(path_to_commit_message, 'w+') do |file|
     file.puts "Claiming issue #{ISSUE_NUMBER}"
     file.puts ""
-    file.puts "relates to ##{ISSUE_NUMBER}"
-    file.puts ""
+    if issue_source == :github
+      file.puts "relates to ##{ISSUE_NUMBER}"
+      file.puts ""
+    end
 
     message = "$ ./script/#{File.basename(__FILE__)} #{ISSUE_NUMBER}"
     CONFIG_KEYS.each_with_object(message) do |key, mem|
@@ -171,4 +196,10 @@ begin
   $stdout.puts `cd #{REPOSITORY_PATH} && git commit -F #{path_to_commit_message}`
 ensure
   File.unlink(path_to_commit_message) rescue true
+end
+
+# If the commit was successful, assign the issue to us and move into "In Progress"
+if issue_source == :jira
+  `jira take #{ISSUE_NUMBER}`
+  `jira --noedit transition "In Progress" #{ISSUE_NUMBER}`
 end


### PR DESCRIPTION
Support for github issues is still there, but if a jira issue
is detected, it will try to update the jira ticket and will even resolve
it. The details of the workflow are easy to change.

All the interaction with jira are done using a command line tool `go-jira`.
It can be installed on macs using `brew install ndlib/dlt/go-jira`.
The tool was designed to be used by hand, there is some weirdness in
calling it from a script, mainly because one needs to make sure a current
password cookie is saved.

DLTP-563