### PR TITLE
Dltp 395 save external links in desc metadata

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -266,7 +266,7 @@ class CatalogController < ApplicationController
     )
     config.add_facet_field solr_name("human_readable_type", :facetable), label: "Type of Work", limit: 5, multiple: true
     config.add_facet_field solr_name(:desc_metadata__creator, :facetable), label: "Creator", helper_method: :creator_name_from_pid, limit: 5
-    config.add_facet_field solr_name("desc_metadata__tag", :facetable), label: "Keyword", limit: 5
+    config.add_facet_field solr_name("desc_metadata__tag", :facetable), label: "Related Resource(s)", limit: 5
     config.add_facet_field solr_name("desc_metadata__subject", :facetable), label: "Subject", limit: 5
     config.add_facet_field solr_name("desc_metadata__language", :facetable), label: "Language", limit: 5
     config.add_facet_field solr_name("desc_metadata__based_near", :facetable), label: "Location", limit: 5
@@ -295,7 +295,7 @@ class CatalogController < ApplicationController
     #   The ordering of the field names is the order of the display
     config.add_index_field solr_name("desc_metadata__title", :stored_searchable, type: :string), label: "Title"
     config.add_index_field solr_name("desc_metadata__description", :stored_searchable, type: :string), label: "Description"
-    config.add_index_field solr_name("desc_metadata__tag", :stored_searchable, type: :string), label: "Keyword"
+    config.add_index_field solr_name("desc_metadata__relation", :facetable, type: :string), label: "Related Source(s)"
     config.add_index_field solr_name("desc_metadata__subject", :stored_searchable, type: :string), label: "Subject"
     config.add_index_field solr_name("desc_metadata__creator", :stored_searchable, type: :string), label: "Creator"
     config.add_index_field solr_name("desc_metadata__contributor", :stored_searchable, type: :string), label: "Contributor"
@@ -314,7 +314,7 @@ class CatalogController < ApplicationController
     #   The ordering of the field names is the order of the display
     config.add_show_field solr_name("desc_metadata__title", :stored_searchable, type: :string), label: "Title"
     config.add_show_field solr_name("desc_metadata__description", :stored_searchable, type: :string), label: "Description"
-    config.add_show_field solr_name("desc_metadata__tag", :stored_searchable, type: :string), label: "Keyword"
+    config.add_show_field solr_name("desc_metadata__relation", :stored_searchable, type: :string), label: "Keyword"
     config.add_show_field solr_name("desc_metadata__subject", :stored_searchable, type: :string), label: "Subject"
     config.add_show_field solr_name("desc_metadata__creator", :stored_searchable, type: :string), label: "Creator"
     config.add_show_field solr_name("desc_metadata__contributor", :stored_searchable, type: :string), label: "Contributor"

--- a/app/helpers/curate_helper.rb
+++ b/app/helpers/curate_helper.rb
@@ -140,6 +140,14 @@ module CurateHelper
     end
   end
 
+  def __render_tabular_list_item_for_relation(method_name, value, block_formatting, tag, options)
+    __render_tabular_list_item(method_name, value, block_formatting, tag, options) do
+      %(<a href=#{h(value)} target="_blank"> #{h(value)}</a>)
+    end
+  end
+
+  private :__render_tabular_list_item_for_relation
+
   # options[:block_formatting, :class]
   def curation_concern_attribute_to_formatted_text(curation_concern, method_name, label = nil, options = {})
     markup = ""

--- a/app/helpers/curate_helper.rb
+++ b/app/helpers/curate_helper.rb
@@ -134,6 +134,9 @@ module CurateHelper
   end
   private :__render_tabular_list_item_for_relation
 
+  alias __render_tabular_list_item_for_tag __render_tabular_list_item_for_relation
+  private :__render_tabular_list_item_for_tag
+
   def __render_tabular_list_item_for_library_collections(method_name, value, block_formatting, tag, options)
     __render_tabular_list_item(method_name, value, block_formatting, tag, options) do
       %(<a href="/show/#{value.noid}">#{h(value.title)}</a>)

--- a/app/helpers/curate_helper.rb
+++ b/app/helpers/curate_helper.rb
@@ -118,7 +118,6 @@ module CurateHelper
   private :__render_tabular_list_item_for_rights
 
   def __render_tabular_list_item_for_relation(method_name, value, block_formatting, tag, options = {})
-    puts "################ Method: #{method_name.inspect}, value: #{value} block_formatting: #{block_formatting}, tag:#{tag} ####################"
     callout_pattern = options.fetch(:callout_pattern, nil)
     if callout_pattern
       callout_text = options.fetch(:callout_text)

--- a/app/helpers/curate_helper.rb
+++ b/app/helpers/curate_helper.rb
@@ -117,7 +117,8 @@ module CurateHelper
   end
   private :__render_tabular_list_item_for_rights
 
-  def __render_tabular_list_item_for_tag(method_name, value, block_formatting, tag, options = {})
+  def __render_tabular_list_item_for_relation(method_name, value, block_formatting, tag, options = {})
+    puts "################ Method: #{method_name.inspect}, value: #{value} block_formatting: #{block_formatting}, tag:#{tag} ####################"
     callout_pattern = options.fetch(:callout_pattern, nil)
     if callout_pattern
       callout_text = options.fetch(:callout_text)
@@ -132,21 +133,13 @@ module CurateHelper
       __render_tabular_list_item(method_name, value, block_formatting, tag, options)
     end
   end
-  private :__render_tabular_list_item_for_tag
+  private :__render_tabular_list_item_for_relation
 
   def __render_tabular_list_item_for_library_collections(method_name, value, block_formatting, tag, options)
     __render_tabular_list_item(method_name, value, block_formatting, tag, options) do
       %(<a href="/show/#{value.noid}">#{h(value.title)}</a>)
     end
   end
-
-  def __render_tabular_list_item_for_relation(method_name, value, block_formatting, tag, options)
-    __render_tabular_list_item(method_name, value, block_formatting, tag, options) do
-      %(<a href=#{h(value)} target="_blank"> #{h(value)}</a>)
-    end
-  end
-
-  private :__render_tabular_list_item_for_relation
 
   # options[:block_formatting, :class]
   def curation_concern_attribute_to_formatted_text(curation_concern, method_name, label = nil, options = {})

--- a/app/repository_datastreams/article_metadata_datastream.rb
+++ b/app/repository_datastreams/article_metadata_datastream.rb
@@ -54,6 +54,10 @@ class ArticleMetadataDatastream < ActiveFedora::NtriplesRDFDatastream
       index.as :stored_searchable, :facetable
     end
 
+    map.relation(:in => RDF::DC) do |index|
+      index.as :stored_searchable
+    end
+
     map.content_format({in: RDF::QualifiedDC, to: 'format#mimetype'})
 
     map.date_created(:to => 'created', :in => RDF::DC) do |index|

--- a/app/repository_datastreams/article_metadata_datastream.rb
+++ b/app/repository_datastreams/article_metadata_datastream.rb
@@ -55,7 +55,7 @@ class ArticleMetadataDatastream < ActiveFedora::NtriplesRDFDatastream
     end
 
     map.relation(:in => RDF::DC) do |index|
-      index.as :stored_searchable
+      index.as :stored_searchable, :facetable
     end
 
     map.content_format({in: RDF::QualifiedDC, to: 'format#mimetype'})

--- a/app/repository_datastreams/dataset_metadata_datastream.rb
+++ b/app/repository_datastreams/dataset_metadata_datastream.rb
@@ -50,6 +50,10 @@ class DatasetMetadataDatastream < GenericWorkRdfDatastream
       index.as :stored_searchable
     end
 
+    map.relation(:in => RDF::DC) do |index|
+      index.as :stored_searchable, :facetable
+    end
+
     map.size({to: "format#extent", in: RDF::QualifiedDC})
   end
 end

--- a/app/repository_datastreams/document_datastream.rb
+++ b/app/repository_datastreams/document_datastream.rb
@@ -150,5 +150,9 @@ class DocumentDatastream < GenericWorkRdfDatastream
       index.type :date
       index.as :stored_sortable
     end
+
+    map.relation(:in => RDF::DC) do |index|
+      index.as :stored_searchable, :facetable
+    end
   end
 end

--- a/app/repository_datastreams/etd_metadata.rb
+++ b/app/repository_datastreams/etd_metadata.rb
@@ -103,6 +103,10 @@ class EtdMetadata < ActiveFedora::NtriplesRDFDatastream
     map.degree(in: RDF::EtdMs, class_name: 'Degree')
 
     map.contributor(in: RDF::DC, class_name: 'Contributor')
+
+    map.relation(:in => RDF::DC) do |index|
+      index.as :stored_searchable, :facetable
+    end
   end
 
   accepts_nested_attributes_for :degree, :contributor

--- a/app/repository_datastreams/finding_aid_rdf_datastream.rb
+++ b/app/repository_datastreams/finding_aid_rdf_datastream.rb
@@ -50,5 +50,9 @@ class FindingAidRdfDatastream < ActiveFedora::NtriplesRDFDatastream
     map.source(to: 'source', in: RDF::DC) do |index|
       index.as :stored_searchable, :displayable
     end
+
+    map.relation(:in => RDF::DC) do |index|
+      index.as :stored_searchable, :facetable
+    end
   end
 end

--- a/app/repository_datastreams/generic_work_rdf_datastream.rb
+++ b/app/repository_datastreams/generic_work_rdf_datastream.rb
@@ -65,6 +65,10 @@ class GenericWorkRdfDatastream < ActiveFedora::NtriplesRDFDatastream
 
     map.source({in: RDF::DC})
 
+    map.relation(:in => RDF::DC) do |index|
+      index.as :stored_searchable
+    end
+
     map.rights(:in => RDF::DC) do |index|
       index.as :stored_searchable, :facetable
     end

--- a/app/repository_datastreams/generic_work_rdf_datastream.rb
+++ b/app/repository_datastreams/generic_work_rdf_datastream.rb
@@ -66,7 +66,7 @@ class GenericWorkRdfDatastream < ActiveFedora::NtriplesRDFDatastream
     map.source({in: RDF::DC})
 
     map.relation(:in => RDF::DC) do |index|
-      index.as :stored_searchable
+      index.as :stored_searchable, :facetable
     end
 
     map.rights(:in => RDF::DC) do |index|

--- a/app/repository_datastreams/hydra/collection_rdf_datastream.rb
+++ b/app/repository_datastreams/hydra/collection_rdf_datastream.rb
@@ -60,7 +60,7 @@ module Hydra
       map.based_near(:in => RDF::FOAF) do |index|
         index.as :stored_searchable, :facetable
       end
-      map.tag(:to => "relation", :in => RDF::DC) do |index|
+      map.relation(:in => RDF::DC) do |index|
         index.as :stored_searchable, :facetable
       end
       map.related_url(:to => "seeAlso", :in => RDF::RDFS)

--- a/app/repository_datastreams/image_metadata.rb
+++ b/app/repository_datastreams/image_metadata.rb
@@ -105,5 +105,9 @@ class ImageMetadata < ActiveFedora::NtriplesRDFDatastream
 
     map.requires({in: RDF::DC})
 
+    map.relation(:in => RDF::DC) do |index|
+      index.as :stored_searchable, :facetable
+    end
+
   end
 end

--- a/app/repository_datastreams/library_collection_rdf_datastream.rb
+++ b/app/repository_datastreams/library_collection_rdf_datastream.rb
@@ -61,7 +61,7 @@ class LibraryCollectionRdfDatastream < ActiveFedora::NtriplesRDFDatastream
     map.based_near(:in => RDF::FOAF) do |index|
       index.as :stored_searchable, :facetable
     end
-    map.tag(:to => "relation", :in => RDF::DC) do |index|
+    map.relation(:in => RDF::DC) do |index|
       index.as :stored_searchable, :facetable
     end
     map.related_url(:to => "seeAlso", :in => RDF::RDFS)

--- a/app/repository_datastreams/patent_metadata_datastream.rb
+++ b/app/repository_datastreams/patent_metadata_datastream.rb
@@ -97,5 +97,9 @@ class PatentMetadataDatastream < ActiveFedora::NtriplesRDFDatastream
       index.as :stored_searchable
     end
 
+    map.relation(:in => RDF::DC) do |index|
+      index.as :stored_searchable, :facetable
+    end
+
   end
 end

--- a/app/repository_datastreams/senior_thesis_rdf_datastream.rb
+++ b/app/repository_datastreams/senior_thesis_rdf_datastream.rb
@@ -63,6 +63,10 @@ class SeniorThesisRdfDatastream < ActiveFedora::NtriplesRDFDatastream
 
     map.source({in: RDF::DC})
 
+    map.relation(:in => RDF::DC) do |index|
+      index.as :stored_searchable, :facetable
+    end
+
     map.rights(:in => RDF::DC) do |index|
       index.as :stored_searchable, :displayable, :facetable
     end

--- a/app/repository_models/article.rb
+++ b/app/repository_models/article.rb
@@ -100,6 +100,10 @@ class Article < ActiveFedora::Base
     default: "All rights reserved",
     validates: { presence: { message: 'You must select a license for your work.' } }
 
+  attribute :relation,
+    hint: "Link to External Content",
+    datastream: :descMetadata, multiple: true
+
   attribute :requires,
     datastream: :descMetadata, multiple: true
 

--- a/app/repository_models/article.rb
+++ b/app/repository_models/article.rb
@@ -102,7 +102,14 @@ class Article < ActiveFedora::Base
 
   attribute :relation,
     hint: "Link to External Content",
-    datastream: :descMetadata, multiple: true
+    datastream: :descMetadata, multiple: true,
+    validates: {
+        allow_blank: true,
+        format: {
+            with: URI::regexp(%w(http https ftp)),
+            message: 'must be a valid URL.'
+        }
+    }
 
   attribute :requires,
     datastream: :descMetadata, multiple: true

--- a/app/repository_models/dataset.rb
+++ b/app/repository_models/dataset.rb
@@ -60,6 +60,14 @@ class Dataset < ActiveFedora::Base
   attribute :collection_name,         datastream: :descMetadata, multiple: true
   attribute :size,                    datastream: :descMetadata, multiple: true
   attribute :requires,                datastream: :descMetadata, multiple: true
+  attribute :relation,                datastream: :descMetadata, multiple: true,
+    validates: {
+        allow_blank: true,
+        format: {
+            with: URI::regexp(%w(http https ftp)),
+            message: 'must be a valid URL.'
+        }
+    }
 
   attribute :files, multiple: true, form: {as: :file},
             hint: "CTRL-Click (Windows) or CMD-Click (Mac) to select multiple files."

--- a/app/repository_models/document.rb
+++ b/app/repository_models/document.rb
@@ -114,4 +114,12 @@ class Document < GenericWork
   attribute :recommended_citation,       datastream: :descMetadata, multiple: true
   attribute :identifier,                 datastream: :descMetadata, multiple: false
   attribute :doi,                        datastream: :descMetadata, multiple: false
+  attribute :relation,                   datastream: :descMetadata, multiple: true,
+            validates: {
+                allow_blank: true,
+                format: {
+                    with: URI::regexp(%w(http https ftp)),
+                    message: 'must be a valid URL.'
+                }
+            }
 end

--- a/app/repository_models/etd.rb
+++ b/app/repository_models/etd.rb
@@ -140,6 +140,16 @@ class Etd < ActiveFedora::Base
     ds.attribute :date_approved,
       multiple: false,
       label: "Approval Date"
+    ds.attribute :relation,
+      multiple: true,
+      label: "Related Resources",
+      validates: {
+          allow_blank: true,
+          format: {
+              with: URI::regexp(%w(http https ftp)),
+              message: 'must be a valid URL.'
+          }
+      }
   end
 
   def doi=(doi)

--- a/app/repository_models/finding_aid.rb
+++ b/app/repository_models/finding_aid.rb
@@ -46,6 +46,8 @@ class FindingAid < ActiveFedora::Base
     validates: { presence: { message: 'You must select a license for your work.' } }
   attribute :source,
     datastream: :descMetadata, multiple: true
+  attribute :relation,
+    datastream: :descMetadata, multiple: true
 
   private
   def set_visibility_to_open_access

--- a/app/repository_models/generic_work.rb
+++ b/app/repository_models/generic_work.rb
@@ -48,6 +48,14 @@ class GenericWork < ActiveFedora::Base
   attribute :extent,                 datastream: :descMetadata, multiple: true
   attribute :requires,               datastream: :descMetadata, multiple: true
   attribute :subject,                datastream: :descMetadata, multiple: true
+  attribute :relation,               datastream: :descMetadata, multiple: true,
+            validates: {
+                allow_blank: true,
+                format: {
+                    with: URI::regexp(%w(http https ftp)),
+                    message: 'must be a valid URL.'
+                }
+            }
 
   attribute :files, multiple: true, form: {as: :file},
     hint: "CTRL-Click (Windows) or CMD-Click (Mac) to select multiple files."

--- a/app/repository_models/hydra/collection.rb
+++ b/app/repository_models/hydra/collection.rb
@@ -18,7 +18,7 @@ module Hydra
                      datastream: :descMetadata, multiple: false
       has_attributes :creator, :contributor, :based_near, :part_of, :publisher,
                      :date_created, :subject,:resource_type, :rights,
-                     :identifier, :language, :tag, :related_url,
+                     :identifier, :language, :relation, :related_url,
                      :administrative_unit,:source,:curator, :date,
                      datastream: :descMetadata, multiple: true
 

--- a/app/repository_models/image.rb
+++ b/app/repository_models/image.rb
@@ -135,6 +135,17 @@ class Image < ActiveFedora::Base
     ds.attribute :doi,
       multiple: false,
       editable: false
+
+    ds.attribute :relation,
+       multiple: true,
+       label: "Related Resource(s)",
+       validates: {
+           allow_blank: true,
+           format: {
+               with: URI::regexp(%w(http https ftp)),
+               message: 'must be a valid URL.'
+           }
+       }
   end
 
   attribute :files,

--- a/app/repository_models/library_collection.rb
+++ b/app/repository_models/library_collection.rb
@@ -28,7 +28,7 @@ class LibraryCollection < ActiveFedora::Base
                  datastream: :descMetadata, multiple: false
   has_attributes :creator, :contributor, :based_near, :part_of, :publisher,
                  :date_created, :subject, :resource_type, :rights,
-                 :identifier, :language, :tag, :related_url,
+                 :identifier, :language, :relation, :related_url,
                  :administrative_unit, :source, :curator, :date,
                  datastream: :descMetadata, multiple: true
 

--- a/app/repository_models/patent.rb
+++ b/app/repository_models/patent.rb
@@ -73,5 +73,13 @@ class Patent < ActiveFedora::Base
   attribute :files,
             multiple: true, form: {as: :file}, label: "Upload Files",
             hint: "CTRL-Click (Windows) or CMD-Click (Mac) to select multiple files."
+  attribute :relation, datastream: :descMetadata, multiple: true,
+            validates: {
+                allow_blank: true,
+                format: {
+                    with: URI::regexp(%w(http https ftp)),
+                    message: 'must be a valid URL.'
+                }
+            }
 
 end

--- a/app/repository_models/senior_thesis.rb
+++ b/app/repository_models/senior_thesis.rb
@@ -111,6 +111,15 @@ class SeniorThesis < ActiveFedora::Base
   attribute :resource_type,
     label: "Archived Content Type",
     datastream: :descMetadata, multiple: false
+  attribute :relation,
+    datastream: :descMetadata, multiple: true,
+    validates: {
+        allow_blank: true,
+        format: {
+            with: URI::regexp(%w(http https ftp)),
+            message: 'must be a valid URL.'
+        }
+    }
 
   attribute :files,
     multiple: true, form: {as: :file}, label: "Upload Files",

--- a/app/views/common_objects/show.html.erb
+++ b/app/views/common_objects/show.html.erb
@@ -39,7 +39,6 @@
   <% end %>
 
   <%= render 'curation_concern/base/related_files', curation_concern: curation_concern, with_actions: true %>
-  <%= render 'curation_concern/base/related_resources', curation_concern: curation_concern, with_actions: true %>
   <%= render 'curation_concern/base/related_works', curation_concern: curation_concern, with_actions: true %>
   <%= render 'curation_concern/base/collections', curation_concern: curation_concern %>
 <% end %>

--- a/app/views/common_objects/show.html.erb
+++ b/app/views/common_objects/show.html.erb
@@ -5,14 +5,6 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <% if curation_concern.is_a? LibraryCollection %>
-    <% path = search_collection_pathbuilder(curation_concern) %>
-    <% if path %>
-      <%= link_to path, class: 'btn btn-default' do %>
-        <i class="icon icon-search"></i> Search Inside
-      <% end %>
-    <% end %>
-  <% end %>
   <% if display_citation_generation? %>
     <%= link_to 'Generate Citation', citation_path(curation_concern) , class: 'btn citation-modal-js' %>
   <% end %>
@@ -34,13 +26,19 @@
   <% case curation_concern %>
   <% when GenericFile %>
     <%= link_to 'Download this File', download_path(curation_concern), class: 'btn btn-default' %>
-  <% when LibraryCollection %>
-    <%= render 'curation_concern/library_collections/library_collection_members', curation_concern: curation_concern %>
   <% end %>
-
   <%= render 'curation_concern/base/related_files', curation_concern: curation_concern, with_actions: true %>
   <%= render 'curation_concern/base/related_works', curation_concern: curation_concern, with_actions: true %>
-  <%= render 'curation_concern/base/collections', curation_concern: curation_concern %>
+  <% if curation_concern.is_a? LibraryCollection %>
+    <% path = search_collection_pathbuilder(curation_concern) %>
+    <% if path %>
+      <%= link_to path, class: 'btn btn-large' do %>
+        <i class="icon icon-search"></i> Browse Objects in the Collection
+      <% end %>
+    <% end %>
+    <% else %>
+      <%= render 'curation_concern/base/collections', curation_concern: curation_concern %>
+  <% end %>
 <% end %>
 
 <% if curation_concern.representative.present? %>

--- a/app/views/curate/collections/show.html.erb
+++ b/app/views/curate/collections/show.html.erb
@@ -17,7 +17,7 @@
   <tbody>
     <%= curation_concern_attribute_to_html(@collection, :subject, "Subject") %>
     <%= curation_concern_attribute_to_html(@collection, :creator, "Creator") %>
-    <%= curation_concern_attribute_to_html(@collection, :tag, "Related Resources") %>
+    <%= curation_concern_attribute_to_html(@collection, :relation, "Related Resource(s)") %>
     <%= curation_concern_attribute_to_html(@collection, :source, "Source") %>
     <%= curation_concern_attribute_to_html(@collection, :contributor, "Collector") %>
     <%= curation_concern_attribute_to_html(@collection, :curator, "Curator") %>

--- a/app/views/curation_concern/articles/_attributes.html.erb
+++ b/app/views/curation_concern/articles/_attributes.html.erb
@@ -16,6 +16,7 @@
     <%= curation_concern_attribute_to_html(curation_concern, :recommended_citation, "Bibliographic Citation") %>
     <%= curation_concern_attribute_to_html(curation_concern, :language, "Language") %>
     <%= curation_concern_attribute_to_html(curation_concern, :source, "Source") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :relation, "External Links") %>
     <%= decode_administrative_unit(curation_concern, :administrative_unit, "Departments and Units") %>
     <%= curation_concern_attribute_to_html(curation_concern, :library_collections, "Member of") %>
     <%= curation_concern_attribute_to_html(curation_concern, :spatial_coverage, "Spatial Coverage") %>

--- a/app/views/curation_concern/articles/_attributes.html.erb
+++ b/app/views/curation_concern/articles/_attributes.html.erb
@@ -16,7 +16,7 @@
     <%= curation_concern_attribute_to_html(curation_concern, :recommended_citation, "Bibliographic Citation") %>
     <%= curation_concern_attribute_to_html(curation_concern, :language, "Language") %>
     <%= curation_concern_attribute_to_html(curation_concern, :source, "Source") %>
-    <%= curation_concern_attribute_to_html(curation_concern, :relation, "External Links") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :relation, "Related Resource(s)") %>
     <%= decode_administrative_unit(curation_concern, :administrative_unit, "Departments and Units") %>
     <%= curation_concern_attribute_to_html(curation_concern, :library_collections, "Member of") %>
     <%= curation_concern_attribute_to_html(curation_concern, :spatial_coverage, "Spatial Coverage") %>

--- a/app/views/curation_concern/articles/_form_additional_information.html.erb
+++ b/app/views/curation_concern/articles/_form_additional_information.html.erb
@@ -14,7 +14,7 @@
   <%= f.input :recommended_citation,    as: :multi_value, input_html: { class: 'input-xlarge' } %>
   <%= f.input :language,                as: :multi_value, input_html: { class: 'input-xlarge' } %>
   <%= f.input :source,                  as: :multi_value, input_html: { class: 'input-xlarge' } %>
-  <%= f.input :relation,                as: :multi_value, label: "External links", input_html: {class: 'input-xlarge'} %>
+  <%= f.input :relation,                as: :multi_value, label: "Related Resource(s)", input_html: {class: 'input-xlarge', type:'url'} %>
   <%= f.input :temporal_coverage,       as: :multi_value, input_html: { class: 'input-xlarge' } %>
   <%= f.input :spatial_coverage,        as: :multi_value, input_html: { class: 'input-xlarge' } %>
   <%= f.input :repository_name,         as: :multi_value, input_html: { class: 'input-xlarge' } %>

--- a/app/views/curation_concern/articles/_form_additional_information.html.erb
+++ b/app/views/curation_concern/articles/_form_additional_information.html.erb
@@ -14,6 +14,7 @@
   <%= f.input :recommended_citation,    as: :multi_value, input_html: { class: 'input-xlarge' } %>
   <%= f.input :language,                as: :multi_value, input_html: { class: 'input-xlarge' } %>
   <%= f.input :source,                  as: :multi_value, input_html: { class: 'input-xlarge' } %>
+  <%= f.input :relation,                as: :multi_value, label: "External links", input_html: {class: 'input-xlarge'} %>
   <%= f.input :temporal_coverage,       as: :multi_value, input_html: { class: 'input-xlarge' } %>
   <%= f.input :spatial_coverage,        as: :multi_value, input_html: { class: 'input-xlarge' } %>
   <%= f.input :repository_name,         as: :multi_value, input_html: { class: 'input-xlarge' } %>

--- a/app/views/curation_concern/base/_form_additional_information.html.erb
+++ b/app/views/curation_concern/base/_form_additional_information.html.erb
@@ -11,4 +11,5 @@
   <%= f.input :bibliographic_citation, as: :multi_value, input_html: { class: 'input-xlarge' } %>
   <%= f.input :source,                 as: :multi_value, input_html: { class: 'input-xlarge' } %>
   <%= f.input :language,               as: :multi_value, input_html: { class: 'input-xlarge' } %>
+  <%= f.input :relation,               as: :multi_value, label: "External links", input_html: {class: 'input-xlarge'} %>
 </fieldset>

--- a/app/views/curation_concern/base/_form_additional_information.html.erb
+++ b/app/views/curation_concern/base/_form_additional_information.html.erb
@@ -12,5 +12,4 @@
   <%= f.input :source,                 as: :multi_value, input_html: { class: 'input-xlarge' } %>
   <%= f.input :relation,                as: :multi_value, label: "Related Resource(s)", input_html: {class: 'input-xlarge', type:'url'} %>
   <%= f.input :language,               as: :multi_value, input_html: { class: 'input-xlarge' } %>
-  <%= f.input :relation,               as: :multi_value, label: "Related Resource(s)", input_html: {class: 'input-xlarge'} %>
 </fieldset>

--- a/app/views/curation_concern/base/_form_additional_information.html.erb
+++ b/app/views/curation_concern/base/_form_additional_information.html.erb
@@ -10,6 +10,7 @@
   <%= f.input :publisher,               as: :multi_value, label: "Publisher", input_html: { class: 'input-xlarge', id: 'publisher' } %>
   <%= f.input :bibliographic_citation, as: :multi_value, input_html: { class: 'input-xlarge' } %>
   <%= f.input :source,                 as: :multi_value, input_html: { class: 'input-xlarge' } %>
+  <%= f.input :relation,                as: :multi_value, label: "Related Resource(s)", input_html: {class: 'input-xlarge', type:'url'} %>
   <%= f.input :language,               as: :multi_value, input_html: { class: 'input-xlarge' } %>
-  <%= f.input :relation,               as: :multi_value, label: "External links", input_html: {class: 'input-xlarge'} %>
+  <%= f.input :relation,               as: :multi_value, label: "Related Resource(s)", input_html: {class: 'input-xlarge'} %>
 </fieldset>

--- a/app/views/curation_concern/base/_form_files_and_links.html.erb
+++ b/app/views/curation_concern/base/_form_files_and_links.html.erb
@@ -5,7 +5,7 @@
     </h2>
 
     <p class="help-block">
-      The subject of your <%= curation_concern.human_readable_type.downcase %> can either be a file <em>or</em> a URL.
+      The subject of your <%= curation_concern.human_readable_type.downcase %> can either be a file.
     </p>
   </div>
 </div>
@@ -24,13 +24,6 @@
       <legend>Upload a File</legend>
       <%= render 'file_size_warning' %>
       <%= f.input :files, as: :file %>
-    </fieldset>
-
-    <strong class="span1 field-choice">OR</strong>
-
-    <fieldset class="span6">
-      <legend>Link to External Content</legend>
-      <%= f.input :linked_resource_urls, as: :multi_value, label: "External links", input_html: {class: 'input-xlarge'} %>
     </fieldset>
   </div>
 <% end %>

--- a/app/views/curation_concern/base/show.html.erb
+++ b/app/views/curation_concern/base/show.html.erb
@@ -24,7 +24,6 @@
   <%= render 'doi', curation_concern: curation_concern %>
 
   <%= render 'related_files', curation_concern: curation_concern, with_actions: true %>
-  <%= render 'related_resources', curation_concern: curation_concern, with_actions: true %>
   <%= render 'related_works', curation_concern: curation_concern, with_actions: true %>
   <%= render 'collections', curation_concern: curation_concern %>
 <% end %>

--- a/app/views/curation_concern/datasets/_form_additional_information.html.erb
+++ b/app/views/curation_concern/datasets/_form_additional_information.html.erb
@@ -13,6 +13,7 @@
   <%= f.input :recommended_citation,    as: :multi_value, input_html: { class: 'input-xlarge' } %>
   <%= f.input :language,                as: :multi_value, input_html: { class: 'input-xlarge' } %>
   <%= f.input :source,                  as: :multi_value, input_html: { class: 'input-xlarge' } %>
+  <%= f.input :relation,                as: :multi_value, label: "Related Resource(s)", input_html: {class: 'input-xlarge', type:'url'} %>
   <%= f.input :temporal_coverage,       as: :multi_value, input_html: { class: 'input-xlarge' } %>
   <%= f.input :spatial_coverage,        as: :multi_value, input_html: { class: 'input-xlarge' } %>
   <%= f.input :repository_name,         as: :multi_value, input_html: { class: 'input-xlarge' } %>

--- a/app/views/curation_concern/datasets/_form_files_and_links.html.erb
+++ b/app/views/curation_concern/datasets/_form_files_and_links.html.erb
@@ -33,12 +33,5 @@
       <%= render 'file_size_warning' %>
       <%= f.input :files, as: :file %>
     </fieldset>
-
-    <strong class="span1 field-choice">OR</strong>
-
-    <fieldset class="span6">
-      <legend>Link to External Content</legend>
-      <%= f.input :linked_resource_urls, as: :multi_value, label: "External links", input_html: {class: 'input-xlarge'} %>
-    </fieldset>
   </div>
 <% end %>

--- a/app/views/curation_concern/documents/_form_additional_information.html.erb
+++ b/app/views/curation_concern/documents/_form_additional_information.html.erb
@@ -33,6 +33,7 @@
   <%= f.input :subject,                    as: :multi_value, input_html: { class: 'input-xlarge' } %>
   <%= f.input :lc_subject,                 label: 'Subject (Library of Congress)', as: :multi_value, input_html: { class: 'input-xlarge' }, wrapper_html: { :'data-input-mask' => 'book-attribute' } %>
   <%= f.input :source,                     as: :multi_value, input_html: { class: 'input-xlarge' } %>
+  <%= f.input :relation,                   as: :multi_value, label: "Related Resource(s)", input_html: {class: 'input-xlarge', type: 'url'} %>
   <%= f.input :language,                   as: :multi_value, input_html: { class: 'input-xlarge' } %>
   <%= f.input :temporal_coverage,          label: 'Temporal Coverage', as: :multi_value, input_html: { class: 'input-xlarge' } %>
   <%= f.input :spatial_coverage,           label: 'Spatial Coverage', as: :multi_value, input_html: { class: 'input-xlarge' } %>

--- a/app/views/curation_concern/finding_aids/_form.html.erb
+++ b/app/views/curation_concern/finding_aids/_form.html.erb
@@ -12,6 +12,7 @@
         <%= f.input :title, input_html: { class: 'input-xxlarge'}, required: true %>
         <%= f.input :creator, input_html: { class: 'input-xlarge', placeholder: 'George Washington' }, required: true %>
         <%= f.input :source, input_html: { class: 'input-xlarge'}, required: false %>
+        <%= f.input :relation, as: :multi_value, label: "Related Resource(s)", input_html: {class: 'input-xlarge', type: 'url'} %>
         <%= f.input :abstract, input_html: { class: 'input-xxxlarge rich-textarea-js', rows: '9' }, as: :text, required: true %>
         <%= f.hidden_field :visibility, value: 'open' %>
       </fieldset>

--- a/app/views/curation_concern/images/_form_descriptive_fields.erb
+++ b/app/views/curation_concern/images/_form_descriptive_fields.erb
@@ -66,8 +66,9 @@
                   as: :multi_value,
                   input_html: { class: 'input-xlarge' }
       %>
+      <%= f.input :relation,  as: :multi_value, label: "Related Resource(s)", input_html: {class: 'input-xlarge', type: 'url'} %>
 
-      <%= f.input :publisher,               as: :multi_value, label: "Publisher (Required for DOI)", input_html: { class: 'input-xlarge', id: 'publisher' } %>
+      <%= f.input :publisher, as: :multi_value, label: "Publisher (Required for DOI)", input_html: { class: 'input-xlarge', id: 'publisher' } %>
 
       <%= f.input :subject,
                   as: :multi_value,

--- a/app/views/curation_concern/library_collections/_attributes.html.erb
+++ b/app/views/curation_concern/library_collections/_attributes.html.erb
@@ -14,7 +14,7 @@
                                             :relation,
                                             "Related Resource(s)",
                                             callout_pattern: /\Ahttps?:\/\/collections\.library\.nd\.edu/,
-                                            callout_text: "View in DEC"
+                                            callout_text: "View on the Digital Exhibits and Collections Site"
                                           ) %>
     <%= curation_concern_attribute_to_html(curation_concern, :based_near, "Based Near") %>
     <%= curation_concern_attribute_to_html(curation_concern, :part_of, "Part of") %>

--- a/app/views/curation_concern/library_collections/_attributes.html.erb
+++ b/app/views/curation_concern/library_collections/_attributes.html.erb
@@ -11,8 +11,8 @@
     <%= curation_concern_attribute_to_html(curation_concern, :curator, 'Curator') %>
     <%= curation_concern_attribute_to_html(
                                             curation_concern,
-                                            :tag,
-                                            "Tag",
+                                            :relation,
+                                            "Related Resource(s)",
                                             callout_pattern: /\Ahttps?:\/\/collections\.library\.nd\.edu/,
                                             callout_text: "View in DEC"
                                           ) %>

--- a/app/views/curation_concern/library_collections/_splash.html.erb
+++ b/app/views/curation_concern/library_collections/_splash.html.erb
@@ -45,7 +45,7 @@
         <%= curation_concern_attribute_to_html(curation_concern, :rights, 'Rights', template: 'dl') %>
         <%= curation_concern_attribute_to_html(curation_concern, :identifier, 'Identifier', template: 'dl') %>
         <%= curation_concern_attribute_to_html(curation_concern, :language, 'Language', template: 'dl') %>
-        <%= curation_concern_attribute_to_html(curation_concern, :tag, 'Tag', template: 'dl') %>
+        <%= curation_concern_attribute_to_html(curation_concern, :relation, 'Related Source(s)', template: 'dl') %>
         <%= curation_concern_attribute_to_html(curation_concern, :related_url, 'Related URL', template: 'dl') %>
         <%= curation_concern_attribute_to_html(curation_concern, :source, 'Source', template: 'dl') %>
       </dl>

--- a/app/views/curation_concern/library_collections/_splash.html.erb
+++ b/app/views/curation_concern/library_collections/_splash.html.erb
@@ -45,7 +45,7 @@
         <%= curation_concern_attribute_to_html(curation_concern, :rights, 'Rights', template: 'dl') %>
         <%= curation_concern_attribute_to_html(curation_concern, :identifier, 'Identifier', template: 'dl') %>
         <%= curation_concern_attribute_to_html(curation_concern, :language, 'Language', template: 'dl') %>
-        <%= curation_concern_attribute_to_html(curation_concern, :relation, 'Related Source(s)', template: 'dl') %>
+        <%= curation_concern_attribute_to_html(curation_concern, :relation, 'Related Resource(s)', template: 'dl') %>
         <%= curation_concern_attribute_to_html(curation_concern, :related_url, 'Related URL', template: 'dl') %>
         <%= curation_concern_attribute_to_html(curation_concern, :source, 'Source', template: 'dl') %>
       </dl>

--- a/app/views/curation_concern/patents/show.html.erb
+++ b/app/views/curation_concern/patents/show.html.erb
@@ -22,7 +22,6 @@
 <% details = capture do %>
   <%= render 'attributes', curation_concern: curation_concern %>
   <%= render 'related_files', curation_concern: curation_concern, with_actions: true %>
-  <%= render 'related_resources', curation_concern: curation_concern, with_actions: true %>
   <%= render 'related_works', curation_concern: curation_concern, with_actions: true %>
   <%= render 'collections', curation_concern: curation_concern %>
 <% end %>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -105,6 +105,7 @@ en:
         publication_date: 'The year in which the resource was published, if it differs from the copyright date, e.g. 1983.'
         edition: 'A description of the resource’s edition, e.g. “2nd edition.”'
         lc_subject: 'The topic of the resource’s content as taken from Library of Congress Subject Headings. Sections of a subject heading may be separated by a space and a pair of hyphens, e.g. “Amnesia -- Fiction.”'
+        relation: 'Link to External Content'
       profile_connection:
         text: "Search the following ORCID fields: IDs, names, emails, DOIs, work titles, and keywords. Any ORCID fields marked as private may be skipped."
       user:

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -75,6 +75,7 @@ en:
         repository_name: "The name of the organization or institution that holds the original physical object, if applicable."
         publisher: "An entity responsible for making the original resource available."
         source: "A related resource from which the described resource is derived. The described resource may be derived from the related resource in whole or in part. Recommended best practice is to identify the related resource by means of a string conforming to a formal identification system."
+        relation: "A link or other reference to a related resource that may provide context or additional content related to this resource. In addition to depositing files, you may add links to related resources which add context but which you do not have the rights to deposit. Please consider the stability of the links you provide. Publisher-provided DOIs are preferred. NetID file space is not."
         rights: "Set the license which governs how others may use your files. The main questions are whether others can reuse your work in derivatives, and whether you want attribution as the original creator."
         contributor_institution: "A consistent reference to the Institution that contributes the material."
         format: "The media type of the item. The system stored and registered MIME type of the file uploaded. Comments: This is an automatically system generated field so it does not need to be filled in. The field is present here so that metadata contributor knows how it is captured."
@@ -105,7 +106,6 @@ en:
         publication_date: 'The year in which the resource was published, if it differs from the copyright date, e.g. 1983.'
         edition: 'A description of the resource’s edition, e.g. “2nd edition.”'
         lc_subject: 'The topic of the resource’s content as taken from Library of Congress Subject Headings. Sections of a subject heading may be separated by a space and a pair of hyphens, e.g. “Amnesia -- Fiction.”'
-        relation: 'A link or other reference to a related resource that may provide context or additional content related to this resource.'
       profile_connection:
         text: "Search the following ORCID fields: IDs, names, emails, DOIs, work titles, and keywords. Any ORCID fields marked as private may be skipped."
       user:

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -105,7 +105,7 @@ en:
         publication_date: 'The year in which the resource was published, if it differs from the copyright date, e.g. 1983.'
         edition: 'A description of the resource’s edition, e.g. “2nd edition.”'
         lc_subject: 'The topic of the resource’s content as taken from Library of Congress Subject Headings. Sections of a subject heading may be separated by a space and a pair of hyphens, e.g. “Amnesia -- Fiction.”'
-        relation: 'Link to External Content'
+        relation: 'A link or other reference to a related resource that may provide context or additional content related to this resource.'
       profile_connection:
         text: "Search the following ORCID fields: IDs, names, emails, DOIs, work titles, and keywords. Any ORCID fields marked as private may be skipped."
       user:

--- a/spec/helpers/curate_helper_spec.rb
+++ b/spec/helpers/curate_helper_spec.rb
@@ -126,17 +126,17 @@ RSpec.describe CurateHelper do
       end
     end
 
-    context 'for #tag' do
+    context 'for #relation' do
       it 'will generate the appropriate callout text for the given link' do
         href = "http://collections.library.nd.edu/somewhere"
-        curation_concern = double('Curation Concern', tag: ["Hello", href])
+        curation_concern = double('Curation Concern', relation: ["Hello", href])
         callout_text = "View in DEC"
         output = helper.curation_concern_attribute_to_html(
-          curation_concern, :tag, "Tag",
+          curation_concern, :relation, "Related Resource(s)",
           callout_pattern: /\Ahttp:\/\/collections\.library\.nd\.edu/,
           callout_text: callout_text
         )
-        expect(output).to have_tag("tr td ul.tabular li.attribute.tag span.callout-text", text: callout_text, count: 1)
+        expect(output).to have_tag("tr td ul.tabular li.attribute.relation span.callout-text", text: callout_text, count: 1)
       end
     end
     context 'for #library_collection' do

--- a/spec/repository_models/collection_spec.rb
+++ b/spec/repository_models/collection_spec.rb
@@ -67,12 +67,6 @@ describe Collection do
     @collection.save
     Collection.find(@collection.pid).description.should == @collection.description
   end
-  it "should have the expected display terms" do
-    @collection.terms_for_display.should == [:part_of, :contributor, :creator, :title, :description, :publisher, :administrative_unit, :curator, :date, :date_created, :date_uploaded, :date_modified, :subject, :language, :rights, :resource_type, :identifier, :based_near, :relation, :related_url, :source]
-  end
-  it "should have the expected edit terms" do
-    @collection.terms_for_editing.should == [:part_of, :contributor, :creator, :title, :description, :publisher, :administrative_unit, :curator, :date, :date_created, :subject, :language, :rights, :resource_type, :identifier, :based_near, :relation, :related_url, :source]
-  end
   it "should not delete member work when deleted" do
     @collection.members = [generic_work1, generic_work2]
     @collection.save

--- a/spec/repository_models/collection_spec.rb
+++ b/spec/repository_models/collection_spec.rb
@@ -68,10 +68,10 @@ describe Collection do
     Collection.find(@collection.pid).description.should == @collection.description
   end
   it "should have the expected display terms" do
-    @collection.terms_for_display.should == [:part_of, :contributor, :creator, :title, :description, :publisher, :administrative_unit, :curator, :date, :date_created, :date_uploaded, :date_modified, :subject, :language, :rights, :resource_type, :identifier, :based_near, :tag, :related_url, :source]
+    @collection.terms_for_display.should == [:part_of, :contributor, :creator, :title, :description, :publisher, :administrative_unit, :curator, :date, :date_created, :date_uploaded, :date_modified, :subject, :language, :rights, :resource_type, :identifier, :based_near, :relation, :related_url, :source]
   end
   it "should have the expected edit terms" do
-    @collection.terms_for_editing.should == [:part_of, :contributor, :creator, :title, :description, :publisher, :administrative_unit, :curator, :date, :date_created, :subject, :language, :rights, :resource_type, :identifier, :based_near, :tag, :related_url, :source]
+    @collection.terms_for_editing.should == [:part_of, :contributor, :creator, :title, :description, :publisher, :administrative_unit, :curator, :date, :date_created, :subject, :language, :rights, :resource_type, :identifier, :based_near, :relation, :related_url, :source]
   end
   it "should not delete member work when deleted" do
     @collection.members = [generic_work1, generic_work2]

--- a/spec/repository_models/library_collection_spec.rb
+++ b/spec/repository_models/library_collection_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe LibraryCollection do
       contributor: ['The Contributor', 'The Other Contributor'], based_near: ['The Nearby', 'The Other Nearby'],
       part_of: ['The Part of', 'The Other Part of'], publisher: ['The Publisher', 'The Other Publisher'],
       date_created: ['2016-06-10', '2016-06-09'], subject: ['The Subject', 'The Other Subject'], resource_type: ["RT1", 'RT2'],
-      rights: ["Rights1", 'Rights2'], identifier: ["ID1", "ID2"], language: ["Lang1", 'Lang2'], tag: ["Tag1", 'Tag2'],
+      rights: ["Rights1", 'Rights2'], identifier: ["ID1", "ID2"], language: ["Lang1", 'Lang2'], relation: ["Tag1", 'Tag2'],
       related_url: ['URL1', 'URL2'], administrative_unit: ["AU1", "AU2"], source: ['Source1', 'Source2'],
       curator: ['Curator1', 'Curator2'], date: ['Date1', 'Date2'],
       representative: 'und:1234'


### PR DESCRIPTION
## Initial version of adding relation to metadata still need more work

@07f23a1e23f756dd44a8c3b87db3b7720086d18b


## Adding dc:relation metadata mapping to datastream

@7b07d7f7044b9e6309d2c0cf48bfd2c2f083b169


## configure relation metadata attributes in repository_model

@98b04d942d0539653381ee565eff1ab5b6496a55


## Adding dc:relation attribute to view

@4a0901d20c2d11c7503a4cb0c90fc9c2ca96775c

Adding the new metadata field to edit and show page. Configure help message as well.

## DLTP-552 As a Librarian, I want to see dc:relation labeled as "Related Resource(s)", not "Tag" for collections

@c14bd88febc965f7a27726ca186880b1cdbdf17f

Altered repository_datastreams mapping from tag to relation and related changes. Modified view label from Tag to Related Resources.

## DLTP-569 As a Librarian, I want 4 changes made to Collections Show page before I show them to stakeholders

@d2f58ae7bd4f89985e6751a003802b02abed640c


## DLTP-428 Add Language around external links/related source  explaining when appropriate

@f15e16782a68f5dfb52062ada1ff789a8fb36a2d


## Word smithing on label and removing external link option from dataset

@4ab514e089a25a5098cd4cc0543a11a3465d9a53

Fixing failing spec and removing log statements and removing irrelevant spec from collection
