### PR TITLE
Ingest OSF Project UI

### DIFF
--- a/app/controllers/admin/ingest_osf_archives_controller.rb
+++ b/app/controllers/admin/ingest_osf_archives_controller.rb
@@ -1,0 +1,30 @@
+class Admin::IngestOsfArchivesController < ApplicationController
+  with_themed_layout('1_column')
+
+  # GET /admin/ingest_osf_archives/new
+  def new
+    @archive = Admin::IngestOSFArchive.new
+  end
+
+  # POST /admin/ingest_osf_archives
+  def create
+    @archive = Admin::IngestOSFArchive.new(admin_ingest_osf_archives_params)
+
+    if IngestOSFTools.create_osf_job(@archive)
+      redirect_to admin_ingest_osf_archives_path, notice: 'Archive ingest was successfully created.'
+    else
+      render action: 'new'
+    end
+  end
+
+  # GET /admin/ingest_osf_archives
+  def index
+    @archives = IngestOSFTools.get_osf_jobs
+  end
+
+  private
+
+  def admin_ingest_osf_archives_params
+    params.require(:import_osf_archive).permit(:project_url, :project_identifier, :department, :owner)
+  end
+end

--- a/app/controllers/admin/ingest_osf_archives_controller.rb
+++ b/app/controllers/admin/ingest_osf_archives_controller.rb
@@ -8,7 +8,7 @@ class Admin::IngestOsfArchivesController < ApplicationController
 
   # POST /admin/ingest_osf_archives
   def create
-    @archive = Admin::IngestOSFArchive.new(admin_ingest_osf_archive_params)
+    @archive = Admin::IngestOSFArchive.build_with_id_or_url(admin_ingest_osf_archive_params)
 
     if @archive.valid? && IngestOSFTools.create_osf_job(@archive)
       redirect_to admin_ingest_osf_archives_path, notice: 'Project ingest job was successfully created.'
@@ -35,9 +35,6 @@ class Admin::IngestOsfArchivesController < ApplicationController
   helper_method :curation_concern
 
   def admin_ingest_osf_archive_params
-    cleaned_params = params.require(:admin_ingest_osf_archive).permit(:project_identifier, :affiliation, :owner, administrative_unit: [])
-    match = /^https?:\/\/[^\/]*\/([^\/]*).*$/.match cleaned_params[:project_identifier]
-    cleaned_params[:project_identifier] = match[1] if match && match.length > 1
-    cleaned_params
+    params.require(:admin_ingest_osf_archive).permit(:project_identifier, :affiliation, :owner, administrative_unit: [])
   end
 end

--- a/app/controllers/admin/ingest_osf_archives_controller.rb
+++ b/app/controllers/admin/ingest_osf_archives_controller.rb
@@ -8,12 +8,12 @@ class Admin::IngestOsfArchivesController < ApplicationController
 
   # POST /admin/ingest_osf_archives
   def create
-    @archive = Admin::IngestOSFArchive.new(admin_ingest_osf_archives_params)
+    @archive = Admin::IngestOSFArchive.new(admin_ingest_osf_archive_params)
 
-    if IngestOSFTools.create_osf_job(@archive)
-      redirect_to admin_ingest_osf_archives_path, notice: 'Archive ingest was successfully created.'
+    if @archive.valid? && IngestOSFTools.create_osf_job(@archive)
+      redirect_to admin_ingest_osf_archives_path, notice: 'Project ingest job was successfully created.'
     else
-      render action: 'new'
+      render :new
     end
   end
 
@@ -24,7 +24,20 @@ class Admin::IngestOsfArchivesController < ApplicationController
 
   private
 
-  def admin_ingest_osf_archives_params
-    params.require(:import_osf_archive).permit(:project_url, :project_identifier, :department, :owner)
+  def affiliations
+    @affiliations ||= Affiliation.values.collect{|entity|[entity.label,entity.human_name]}
+  end
+  helper_method :affiliations
+
+  def curation_concern
+    GenericWork.new
+  end
+  helper_method :curation_concern
+
+  def admin_ingest_osf_archive_params
+    cleaned_params = params.require(:admin_ingest_osf_archive).permit(:project_identifier, :affiliation, :owner, administrative_unit: [])
+    match = /^https?:\/\/[^\/]*\/([^\/]*).*$/.match cleaned_params[:project_identifier]
+    cleaned_params[:project_identifier] = match[1] if match && match.length > 1
+    cleaned_params
   end
 end

--- a/app/models/admin/ingest_osf_archive.rb
+++ b/app/models/admin/ingest_osf_archive.rb
@@ -6,4 +6,16 @@ class Admin::IngestOSFArchive
   validates :administrative_unit, presence: true
   validates :owner, presence: true
   validates :affiliation, presence: true
+
+  # Supports constructing an IngestOSFArchive using a URL or an ID
+  # for the project_identifier attribute.
+  # Expects an OSF URL of the form:
+  #   http(s)://hostname/:id
+  def self.build_with_id_or_url(attributes)
+    if attributes.include?(:project_identifier)
+      match = /^https?:\/\/[^\/]*\/([^\/]*).*$/.match attributes[:project_identifier]
+      attributes[:project_identifier] = match[1] if match && match.length > 1
+    end
+    new(attributes)
+  end
 end

--- a/app/models/admin/ingest_osf_archive.rb
+++ b/app/models/admin/ingest_osf_archive.rb
@@ -1,9 +1,9 @@
 class Admin::IngestOSFArchive
   include ActiveModel::Model
-  attr_accessor :project_url, :project_identifier, :department, :owner
+  attr_accessor :project_identifier, :administrative_unit, :owner, :affiliation, :status
 
-  validates :project_url, presence: true
   validates :project_identifier, presence: true
-  validates :department, presence: true
+  validates :administrative_unit, presence: true
   validates :owner, presence: true
+  validates :affiliation, presence: true
 end

--- a/app/models/admin/ingest_osf_archive.rb
+++ b/app/models/admin/ingest_osf_archive.rb
@@ -1,0 +1,9 @@
+class Admin::IngestOSFArchive
+  include ActiveModel::Model
+  attr_accessor :project_url, :project_identifier, :department, :owner
+
+  validates :project_url, presence: true
+  validates :project_identifier, presence: true
+  validates :department, presence: true
+  validates :owner, presence: true
+end

--- a/app/services/ingest_osf_tools.rb
+++ b/app/services/ingest_osf_tools.rb
@@ -1,0 +1,14 @@
+# Probably will mostly do some sort of translation to batch ingest tool
+# For now it just manipulates a class variable
+class IngestOSFTools
+  def self.create_osf_job(archive)
+    # Do something with the Admin::IngestOSFArchive object
+    @@archive_array ||= []
+    @@archive_array.push(archive)
+  end
+
+  def self.get_osf_jobs
+    @@archive_array ||= []
+    @@archive_array
+  end
+end

--- a/app/views/admin/ingest_osf_archives/_form.html.erb
+++ b/app/views/admin/ingest_osf_archives/_form.html.erb
@@ -1,10 +1,14 @@
-<%= simple_form_for :import_osf_archive, url: admin_ingest_osf_archives_path do |f| %>
+<%= simple_form_for @archive, url: admin_ingest_osf_archives_path do |f| %>
   <%= f.error_notification %>
 
   <div class="form-inputs">
-    <%= f.input :project_url, label: 'Project URL' %>
-    <%= f.input :project_identifier %>
-    <%= f.input :department %>
+    <%= f.input :project_identifier, label: 'Project URL or Identifier' %>
+    <%= f.input :affiliation,
+                as: :select,
+                collection: affiliations,
+                input_html: { class: 'input-xlarge' }
+    %>
+    <%= render 'curation_concern/base/form_administrative_unit', curation_concern: curation_concern, f: f, select_label_id: 'add-to-administrative-unit', button_class: 'btn btn-primary' %>
     <%= f.input :owner %>
   </div>
 

--- a/app/views/admin/ingest_osf_archives/_form.html.erb
+++ b/app/views/admin/ingest_osf_archives/_form.html.erb
@@ -8,7 +8,7 @@
                 collection: affiliations,
                 input_html: { class: 'input-xlarge' }
     %>
-    <%= render 'curation_concern/base/form_administrative_unit', curation_concern: curation_concern, f: f, select_label_id: 'add-to-administrative-unit', button_class: 'btn btn-primary' %>
+    <%= render 'curation_concern/base/form_administrative_unit', curation_concern: curation_concern, required: true, f: f, select_label_id: 'add-to-administrative-unit', button_class: 'btn btn-primary' %>
     <%= f.input :owner %>
   </div>
 

--- a/app/views/admin/ingest_osf_archives/_form.html.erb
+++ b/app/views/admin/ingest_osf_archives/_form.html.erb
@@ -1,0 +1,14 @@
+<%= simple_form_for :import_osf_archive, url: admin_ingest_osf_archives_path do |f| %>
+  <%= f.error_notification %>
+
+  <div class="form-inputs">
+    <%= f.input :project_url, label: 'Project URL' %>
+    <%= f.input :project_identifier %>
+    <%= f.input :department %>
+    <%= f.input :owner %>
+  </div>
+
+  <div class="form-actions">
+    <%= f.button :submit, 'Import', class: 'btn btn-primary' %>
+  </div>
+<% end %>

--- a/app/views/admin/ingest_osf_archives/index.html.erb
+++ b/app/views/admin/ingest_osf_archives/index.html.erb
@@ -1,38 +1,35 @@
-<% content_for :page_title, construct_page_title('OSF Archive Ingest Jobs', 'Administrative Functions') %>
+<% content_for :page_title, construct_page_title('OSF Project Ingest Jobs', 'Administrative Functions') %>
 <% content_for :page_header do %>
-  <h1>OSF Archive Ingest Jobs</h1>
+  <h1>OSF Project Ingest Jobs</h1>
 
   <ul class="breadcrumb">
     <li><%= link_to 'CurateND', root_path %> <span class="divider">/</span></li>
     <li><%= link_to 'Administrative Functions', admin_path %> <span class="divider">/</span></li>
-    <li class="active">OSF Archive Ingest Jobs</li>
+    <li class="active">OSF Project Ingest Jobs</li>
   </ul>
 <% end %>
 
 <table class="table table-striped">
-  <caption class="accessible-hidden">List of All OSF Archive Ingest Jobs</caption>
+  <caption class="accessible-hidden">List of All OSF Project Ingest Jobs</caption>
   <thead>
     <tr>
-      <th>Project URL</th>
       <th>Project Identifier</th>
-      <th>Department</th>
       <th>Owner</th>
-      <th>&nbsp;</th>
+      <th>Status</th>
     </tr>
   </thead>
 
   <tbody>
     <% @archives.each do |archive| %>
       <tr>
-        <td><%= archive.project_url %></td>
         <td><%= archive.project_identifier %></td>
-        <td><%= archive.department %></td>
         <td><%= archive.owner %></td>
+        <td><%= archive.status %></td>
       </tr>
     <% end %>
   </tbody>
 </table>
 
 <div class="form-actions">
-  <%= link_to 'Import New OSF Archive', new_admin_ingest_osf_archive_path, class: 'btn btn-primary' %>
+  <%= link_to 'Archive New OSF Project', new_admin_ingest_osf_archive_path, class: 'btn btn-primary' %>
 </div>

--- a/app/views/admin/ingest_osf_archives/index.html.erb
+++ b/app/views/admin/ingest_osf_archives/index.html.erb
@@ -1,0 +1,38 @@
+<% content_for :page_title, construct_page_title('OSF Archive Ingest Jobs', 'Administrative Functions') %>
+<% content_for :page_header do %>
+  <h1>OSF Archive Ingest Jobs</h1>
+
+  <ul class="breadcrumb">
+    <li><%= link_to 'CurateND', root_path %> <span class="divider">/</span></li>
+    <li><%= link_to 'Administrative Functions', admin_path %> <span class="divider">/</span></li>
+    <li class="active">OSF Archive Ingest Jobs</li>
+  </ul>
+<% end %>
+
+<table class="table table-striped">
+  <caption class="accessible-hidden">List of All OSF Archive Ingest Jobs</caption>
+  <thead>
+    <tr>
+      <th>Project URL</th>
+      <th>Project Identifier</th>
+      <th>Department</th>
+      <th>Owner</th>
+      <th>&nbsp;</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @archives.each do |archive| %>
+      <tr>
+        <td><%= archive.project_url %></td>
+        <td><%= archive.project_identifier %></td>
+        <td><%= archive.department %></td>
+        <td><%= archive.owner %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<div class="form-actions">
+  <%= link_to 'Import New OSF Archive', new_admin_ingest_osf_archive_path, class: 'btn btn-primary' %>
+</div>

--- a/app/views/admin/ingest_osf_archives/new.html.erb
+++ b/app/views/admin/ingest_osf_archives/new.html.erb
@@ -1,0 +1,5 @@
+<% content_for :page_header do %>
+  <h1>Ingest New OSF Archive</h1>
+<% end %>
+
+<%= render 'form' %>

--- a/app/views/admin/ingest_osf_archives/new.html.erb
+++ b/app/views/admin/ingest_osf_archives/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_header do %>
-  <h1>Ingest New OSF Archive</h1>
+  <h1>Archive OSF Project</h1>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/curation_concern/base/_form_administrative_unit.html.erb
+++ b/app/views/curation_concern/base/_form_administrative_unit.html.erb
@@ -1,13 +1,21 @@
+<% required ||= false %>
+
 <div class="control-group <%=curation_concern.class%>_administrative_unit">
-  <span class="control-label"><label name="<%=f.object_name%>administrative_unit[]" class="select optional">Departments and Units</label>
-  <span id="<%=f.object_name%>administrative_unit[]" class="field-hint" role="tooltip">
-    Identify <strong>all</strong> the department(s), center(s), or institute(s) <strong>primarily</strong> affiliated with this work.<br />
-    Choosing a department <strong>also</strong> associates the work with its college e.g. selecting <em>Africana Studies</em> will associate the work with the <em>College of Arts and Letters</em> as well.
-  </span>
+  <span class="control-label">
+    <label for="<%=f.object_name%>administrative_unit[]" class="select <%= required ? 'required' : 'optional' %>">
+      <% if required %>
+      <abbr class="required-indicator" title="" data-placement="right" data-original-title="Required">★</abbr>
+      <% end %>
+      <span id="<%=f.object_name%>administrative_unit[]_label">Departments and Units</span>
+    </label>
+    <span id="<%=f.object_name%>administrative_unit[]" class="field-hint" role="tooltip">
+      Identify <strong>all</strong> the department(s), center(s), or institute(s) <strong>primarily</strong> affiliated with this work.<br />
+      Choosing a department <strong>also</strong> associates the work with its college e.g. selecting <em>Africana Studies</em> will associate the work with the <em>College of Arts and Letters</em> as well.
+    </span>
   </span>
   <div class="controls">
     <% options = "" %>
     <% options << administrative_unit_option_listing(curation_concern) %>
-    <%=select_tag "#{f.object_name}[administrative_unit][]", options, {prompt: 'Please select one or more; type to search', class: 'input-xxlarge department-select', :size =>10, multiple:true}  %>
+    <%=select_tag "#{f.object_name}[administrative_unit][]", options, {prompt: 'Please select one or more; type to search', class: 'input-xxlarge department-select', :size =>10, multiple:true, required: required }  %>
   </div>
 </div>

--- a/app/views/shared/_add_content.html.erb
+++ b/app/views/shared/_add_content.html.erb
@@ -19,5 +19,7 @@
       </li>
     <% end %>
     <li><%= link_to 'More Options', deposit_path, class: 'link-to-full-list', role: 'menuitem' %></li>
+    <li class="divider"></li>
+    <li><%= link_to 'Import OSF archive', new_admin_ingest_osf_archive_path %></li>
   </ul>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,6 +96,7 @@ CurateNd::Application.routes.draw do
       end
 
       resource :repo_manager, only: [:edit, :update], path: :privledges
+      resources :ingest_osf_archives #, only: [:new, :create, :index, :edit, :update]
     end
 
     constraints CurateND::AdminAPIConstraint do

--- a/spec/controllers/admin/ingest_osf_archives_controller_spec.rb
+++ b/spec/controllers/admin/ingest_osf_archives_controller_spec.rb
@@ -1,0 +1,75 @@
+require 'spec_helper'
+
+describe Admin::IngestOsfArchivesController, type: :controller do
+  let(:archive) { instance_double(Admin::IngestOSFArchive, valid?: true) }
+
+  describe 'new' do
+    let(:subject) { get :new }
+
+    it 'assigns @archive' do
+      allow(Admin::IngestOSFArchive).to receive(:new).and_return(archive)
+      subject
+      expect(assigns(:archive)).to eq(archive)
+    end
+  end
+
+  describe '#create' do
+    let(:params) { { admin_ingest_osf_archive: { project_identifier: 'id' } } }
+    let(:subject) { post :create, params }
+
+    it 'assigns @archive' do
+      allow(Admin::IngestOSFArchive).to receive(:new).and_return(archive)
+      subject
+      expect(assigns(:archive)).to eq(archive)
+    end
+
+    it 'creates a new archive with the given params' do
+      expect(Admin::IngestOSFArchive).to receive(:new).with(params[:admin_ingest_osf_archive])
+      subject
+    end
+
+    context 'when the parameters are valid' do
+      before(:each) do
+        allow(archive).to receive(:valid?).and_return(true)
+        allow(Admin::IngestOSFArchive).to receive(:new).and_return(archive)
+      end
+
+      it 'uses IngestOSFTools to create a job with the new archive' do
+        expect(IngestOSFTools).to receive(:create_osf_job).with(archive)
+        subject
+      end
+
+      it 'redirects to the index' do
+        expect(subject).to redirect_to(action: :index)
+      end
+    end
+
+    context 'when the parameters are invalid' do
+      before(:each) do
+        allow(archive).to receive(:valid?).and_return(false)
+        allow(Admin::IngestOSFArchive).to receive(:new).and_return(archive)
+      end
+
+      it 'uses IngestOSFTools to create a job with the new archive' do
+        expect(IngestOSFTools).not_to receive(:create_osf_job).with(archive)
+        subject
+      end
+
+      it 're-renders new' do
+        expect(subject).to render_template(:new)
+      end
+    end
+
+    context 'when it fails to create the job' do
+      before(:each) do
+        allow(archive).to receive(:valid?).and_return(true)
+        allow(Admin::IngestOSFArchive).to receive(:new).and_return(archive)
+        allow(IngestOSFTools).to receive(:create_osf_job).and_return(false)
+      end
+
+      it 're-renders new' do
+        expect(subject).to render_template(:new)
+      end
+    end
+  end
+end

--- a/spec/controllers/admin/ingest_osf_archives_controller_spec.rb
+++ b/spec/controllers/admin/ingest_osf_archives_controller_spec.rb
@@ -23,9 +23,10 @@ describe Admin::IngestOsfArchivesController, type: :controller do
       expect(assigns(:archive)).to eq(archive)
     end
 
-    it 'creates a new archive with the given params' do
-      expect(Admin::IngestOSFArchive).to receive(:new).with(params[:admin_ingest_osf_archive])
+    it 'uses build_with_id_or_url to create the new archive with the given params' do
+      allow(Admin::IngestOSFArchive).to receive(:build_with_id_or_url).with(params[:admin_ingest_osf_archive]).and_return('archive')
       subject
+      expect(assigns(:archive)).to eq('archive')
     end
 
     context 'when the parameters are valid' do

--- a/spec/models/admin/ingest_osf_archive_spec.rb
+++ b/spec/models/admin/ingest_osf_archive_spec.rb
@@ -18,4 +18,63 @@ describe Admin::IngestOSFArchive do
       subject.should_not be_valid
     end
   end
+
+  describe '#build_with_id_or_url' do
+    let(:subject){ Admin::IngestOSFArchive.build_with_id_or_url(attributes) }
+
+    it 'uses the id as is when it does not match a url' do
+      attributes[:project_identifier] = 'theid'
+      expect(subject.project_identifier).to eq('theid')
+    end
+
+    it 'uses the id as is when it does not match the two slashes' do
+      attributes[:project_identifier] = 'http:/hostname/theid'
+      expect(subject.project_identifier).to eq('http:/hostname/theid')
+    end
+
+    it 'uses the id as is when it does not have a scheme' do
+      attributes[:project_identifier] = 'hostname/theid'
+      expect(subject.project_identifier).to eq('hostname/theid')
+    end
+
+    it 'matches http' do
+      attributes[:project_identifier] = 'http://hostname/theid'
+      expect(subject.project_identifier).to eq('theid')
+    end
+
+    it 'matches https' do
+      attributes[:project_identifier] = 'https://hostname/theid'
+      expect(subject.project_identifier).to eq('theid')
+    end
+
+    it 'matches with trailing slash' do
+      attributes[:project_identifier] = 'http://hostname/theid/'
+      expect(subject.project_identifier).to eq('theid')
+    end
+
+    it 'matches with additional path' do
+      attributes[:project_identifier] = 'http://hostname/theid/other/stuff'
+      expect(subject.project_identifier).to eq('theid')
+    end
+
+    it 'matches when id is blank' do
+      attributes[:project_identifier] = 'http://hostname//other/stuff'
+      expect(subject.project_identifier).to eq('')
+    end
+
+    it 'matches when the port is given' do
+      attributes[:project_identifier] = 'http://hostname:8080/theid/other/stuff'
+      expect(subject.project_identifier).to eq('theid')
+    end
+
+    it 'matches when full authority is given' do
+      attributes[:project_identifier] = 'http://user:pass@hostname.com:8080/theid'
+      expect(subject.project_identifier).to eq('theid')
+    end
+
+    it 'matches when full authority and additional path is given' do
+      attributes[:project_identifier] = 'http://user:pass@hostname.com:8080/theid/other/stuff/'
+      expect(subject.project_identifier).to eq('theid')
+    end
+  end
 end

--- a/spec/models/admin/ingest_osf_archive_spec.rb
+++ b/spec/models/admin/ingest_osf_archive_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe Admin::IngestOSFArchive do
+  let(:attributes) do
+    {
+      project_identifier: 'id',
+      administrative_unit: 'admin unit',
+      owner: 'owner',
+      affiliation: 'affiliation',
+      status: 'status'
+    }
+  end
+  let(:subject){ Admin::IngestOSFArchive.new(attributes) }
+
+  [:project_identifier, :administrative_unit, :owner, :affiliation].each do |attribute|
+    it "is invalid when #{attribute} is not present" do
+      attributes.delete(attribute)
+      subject.should_not be_valid
+    end
+  end
+end

--- a/spec/routing/admin/ingest_osf_archive_routing_spec.rb
+++ b/spec/routing/admin/ingest_osf_archive_routing_spec.rb
@@ -1,0 +1,76 @@
+require "spec_helper"
+
+describe Admin::IngestOsfArchivesController do
+  describe "routing" do
+    context 'as admin' do
+      before(:each) do
+        CurateND::AdminConstraint.stub(:matches?).and_return(true)
+      end
+
+      it "routes to #index" do
+        get("/admin/ingest_osf_archives").should route_to("admin/ingest_osf_archives#index")
+      end
+
+      it "routes to #new" do
+        get("/admin/ingest_osf_archives/new").should route_to("admin/ingest_osf_archives#new")
+      end
+
+      it "routes to #show" do
+        get("/admin/ingest_osf_archives/1").should route_to("admin/ingest_osf_archives#show", :id => "1")
+      end
+
+      it "routes to #edit" do
+        get("/admin/ingest_osf_archives/1/edit").should route_to("admin/ingest_osf_archives#edit", :id => "1")
+      end
+
+      it "routes to #create" do
+        post("/admin/ingest_osf_archives").should route_to("admin/ingest_osf_archives#create")
+      end
+
+      it "routes to #update" do
+        put("/admin/ingest_osf_archives/1").should route_to("admin/ingest_osf_archives#update", :id => "1")
+      end
+
+      it "routes to #destroy" do
+        delete("/admin/ingest_osf_archives/1").should route_to("admin/ingest_osf_archives#destroy", :id => "1")
+      end
+    end
+  end
+
+  describe "routing" do
+    context 'as admin' do
+      before(:each) do
+        CurateND::AdminConstraint.stub(:matches?).and_return(false)
+      end
+
+      it "does not route to #index" do
+        get("/admin/ingest_osf_archives").should_not route_to("admin/ingest_osf_archives#index")
+      end
+
+      it "does not route to #new" do
+        get("/admin/ingest_osf_archives/new").should_not route_to("admin/ingest_osf_archives#new")
+      end
+
+      it "does not route to #show" do
+        get("/admin/ingest_osf_archives/1").should_not route_to("admin/ingest_osf_archives#show", :id => "1")
+      end
+
+      it "does not route to #edit" do
+        get("/admin/ingest_osf_archives/1/edit").should_not route_to("admin/ingest_osf_archives#edit", :id => "1")
+      end
+
+      it "does not route to #create" do
+        post("/admin/ingest_osf_archives").should_not route_to("admin/ingest_osf_archives#create")
+      end
+
+      it "does not route to #update" do
+        put("/admin/ingest_osf_archives/1").should_not route_to("admin/ingest_osf_archives#update", :id => "1")
+      end
+
+      it "does not route to #destroy" do
+        delete("/admin/ingest_osf_archives/1").should_not route_to("admin/ingest_osf_archives#destroy", :id => "1")
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
This adds the UI needed to create an ingest job that will (eventually) import data from an OSF project.

Summary of changes:
- Created a new model to encapsulate the properties of the request. The model has no associated database entity as this will just be passed through to the batch ingest system.
- Created a controller to handle requests for ingesting new projects and showing existing ingest jobs. 
- The new form uses existing partials such as the administrative unit form. I modified this to allow rendering as a required input, so this change will affect other views and should be QA'd with this in mind.
- It does not actually add the job to the batch ingest system. For now, the creation and querying of OSF jobs is mocked out in the IngestOSFTools service class. This part of the code path may be rewritten or moved to another service class as part of DLTP-584.
