### PR TITLE
Show OSF archive

### DIFF
--- a/app/controllers/curation_concern/osf_archives_controller.rb
+++ b/app/controllers/curation_concern/osf_archives_controller.rb
@@ -1,0 +1,16 @@
+class CurationConcern::OsfArchivesController < CurationConcern::GenericWorksController
+  self.curation_concern_type = OsfArchive
+
+  def setup_form
+    if action_name == 'new'
+      curation_concern.creator << current_user.name if curation_concern.creator.empty? && !current_user.can_make_deposits_for.any?
+      curation_concern.record_editors << current_user.person unless curation_concern.record_editors.present?
+    end
+    curation_concern.record_editors.build
+    curation_concern.record_editor_groups.build
+    curation_concern.record_viewers.build
+    curation_concern.record_viewer_groups.build
+  end
+  protected :setup_form
+
+end

--- a/app/repository_datastreams/osf_archive_datastream.rb
+++ b/app/repository_datastreams/osf_archive_datastream.rb
@@ -47,7 +47,6 @@ class OsfArchiveDatastream < ActiveFedora::NtriplesRDFDatastream
     end
 
     map.date_archived(to: 'dateSubmitted', in: RDF::DC) do |index|
-      index.type :date
       index.as :stored_sortable
     end
 

--- a/app/repository_datastreams/osf_archive_datastream.rb
+++ b/app/repository_datastreams/osf_archive_datastream.rb
@@ -1,6 +1,10 @@
 class OsfArchiveDatastream < ActiveFedora::NtriplesRDFDatastream
   map_predicates do |map|
 
+    map.identifier({to: 'identifier#doi', in: RDF::QualifiedDC}) do |index|
+      index.as :stored_searchable, :facetable
+    end
+
     map.creator(to: 'creator', in: RDF::DC) do |index|
       index.as :stored_searchable
     end
@@ -19,6 +23,14 @@ class OsfArchiveDatastream < ActiveFedora::NtriplesRDFDatastream
 
     map.language(to: 'language', in: RDF::DC)
 
+    map.administrative_unit(to: 'creator#administrative_unit', in: RDF::QualifiedDC) do |index|
+      index.as :stored_searchable, :facetable
+    end
+
+    map.affiliation(to: 'creator#affiliation', in: RDF::QualifiedDC) do |index|
+      index.as :stored_searchable, :facetable
+    end
+
     map.department(to: 'creator#administrative_unit', in: RDF::QualifiedDC) do |index|
       index.as :stored_searchable
     end
@@ -35,6 +47,11 @@ class OsfArchiveDatastream < ActiveFedora::NtriplesRDFDatastream
     end
 
     map.date_archived(to: 'dateSubmitted', in: RDF::DC) do |index|
+      index.type :date
+      index.as :stored_sortable
+    end
+
+    map.date_uploaded(to: "dateSubmitted", in: RDF::DC) do |index|
       index.type :date
       index.as :stored_sortable
     end

--- a/app/repository_models/osf_archive.rb
+++ b/app/repository_models/osf_archive.rb
@@ -27,8 +27,22 @@ class OsfArchive < ActiveFedora::Base
 
   has_metadata 'descMetadata', type: OsfArchiveDatastream
 
+  attribute :administrative_unit,
+    datastream: :descMetadata, multiple: true,
+    label: "Departments and Units",
+    hint: "Departments and Units that creator belong to."
+
+  attribute :affiliation,
+    datastream: :descMetadata,
+    hint: "Creator's Affiliation to the Institution.",
+    multiple: false
+
   attribute :creator,
     datastream: :descMetadata, multiple: true
+
+  attribute :identifier,
+    datastream: :descMetadata, multiple: false,
+    editable: false
 
   attribute :title,
     datastream: :descMetadata, multiple: false,
@@ -76,6 +90,9 @@ class OsfArchive < ActiveFedora::Base
     datastream: :descMetadata, multiple: false,
     label: "Date Archived",
     validates: {presence: { message: 'Archived date is required.' }}
+
+  attribute :date_uploaded,
+    datastream: :descMetadata, multiple: false
 
   attribute :rights,
     datastream: :descMetadata, multiple: true

--- a/app/services/curation_concern/osf_archive_actor.rb
+++ b/app/services/curation_concern/osf_archive_actor.rb
@@ -1,0 +1,12 @@
+module CurationConcern
+  class OsfArchiveActor < GenericWorkActor
+    def create
+      record_editors = attributes.delete('record_editors_attributes')
+      groups = attributes.delete('record_editor_groups_attributes')
+      record_viewers = attributes.delete('record_viewers_attributes')
+      record_viewer_groups = attributes.delete('record_viewer_groups_attributes')
+
+      assign_pid && super 
+    end
+  end
+end

--- a/app/views/curation_concern/osf_archives/_attributes.html.erb
+++ b/app/views/curation_concern/osf_archives/_attributes.html.erb
@@ -6,9 +6,9 @@
   <tbody>
     <%= curation_concern_attribute_to_html(curation_concern, :creator, 'Creator') %>
     <%= curation_concern_attribute_to_html(curation_concern, :subject, "Subject") %>
-    <%= curation_concern_attribute_to_html(curation_concern, :date_created, "Date Created") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :date_archived, "Archive Date") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :source, "Original Project") %>
     <%= curation_concern_attribute_to_html(curation_concern, :language, "Language") %>
-    <%= curation_concern_attribute_to_html(curation_concern, :source, "Source") %>
     <%= decode_administrative_unit(curation_concern, :administrative_unit, "Departments and Units") %>
     <%= curation_concern_attribute_to_html(curation_concern, :library_collections, "Member of") %>
     <tr>

--- a/app/views/curation_concern/osf_archives/_attributes.html.erb
+++ b/app/views/curation_concern/osf_archives/_attributes.html.erb
@@ -1,0 +1,26 @@
+<table class="table table-striped <%= dom_class(curation_concern) %> attributes">
+  <caption class="table-heading"><h2>Attributes</h2></caption>
+  <thead>
+    <tr><th>Attribute Name</th><th>Values</th></tr>
+  </thead>
+  <tbody>
+    <%= curation_concern_attribute_to_html(curation_concern, :creator, 'Creator') %>
+    <%= curation_concern_attribute_to_html(curation_concern, :subject, "Subject") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :date_created, "Date Created") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :language, "Language") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :source, "Source") %>
+    <%= decode_administrative_unit(curation_concern, :administrative_unit, "Departments and Units") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :library_collections, "Member of") %>
+    <tr>
+      <th>Access Rights</th>
+      <td>
+        <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern } %>
+      </td>
+    </tr>
+    <%= curation_concern_attribute_to_html(curation_concern, :embargo_release_date, "Embargo Release Date") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :rights, "Content License") %>
+    <% if curation_concern.type_of_license == "Independently Licensed" %>
+      <%= curation_concern_attribute_to_html(curation_concern, :license, "License Agreement") %>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/curation_concern/osf_archives/_form_additional_information.html.erb
+++ b/app/views/curation_concern/osf_archives/_form_additional_information.html.erb
@@ -1,0 +1,13 @@
+<fieldset class="optional prompt">
+  <legend>Additional Information</legend>
+  <%= f.input :affiliation,
+              as: :select,
+              collection: affiliations,
+              input_html: { class: 'input-xlarge' }
+  %>
+  <%= render 'form_administrative_unit', curation_concern: curation_concern, f: f, select_label_id: 'add-to-administrative-unit', button_class: 'btn btn-primary' %>
+  <%= f.input :date_created,            input_html: { class: 'input-xlarge datepicker' } %>
+  <%= f.input :subject,                 as: :multi_value, input_html: { class: 'input-xlarge' } %>
+  <%= f.input :language,                as: :multi_value, input_html: { class: 'input-xlarge' } %>
+  <%= f.input :source,                  as: :multi_value, input_html: { class: 'input-xlarge' } %>
+</fieldset>

--- a/app/views/curation_concern/osf_archives/_form_additional_information.html.erb
+++ b/app/views/curation_concern/osf_archives/_form_additional_information.html.erb
@@ -6,7 +6,7 @@
               input_html: { class: 'input-xlarge' }
   %>
   <%= render 'form_administrative_unit', curation_concern: curation_concern, f: f, select_label_id: 'add-to-administrative-unit', button_class: 'btn btn-primary' %>
-  <%= f.input :date_created,            input_html: { class: 'input-xlarge datepicker' } %>
+  <%= f.input :date_archived,           input_html: { class: 'input-xlarge datepicker' } %>
   <%= f.input :subject,                 as: :multi_value, input_html: { class: 'input-xlarge' } %>
   <%= f.input :language,                as: :multi_value, input_html: { class: 'input-xlarge' } %>
   <%= f.input :source,                  as: :multi_value, input_html: { class: 'input-xlarge' } %>

--- a/app/views/curation_concern/osf_archives/_form_required_information.html.erb
+++ b/app/views/curation_concern/osf_archives/_form_required_information.html.erb
@@ -1,0 +1,7 @@
+<fieldset class="required">
+  <legend>Required Information</legend>
+
+  <%= f.input :title, input_html: { class: 'input-xlarge' } %>
+
+  <%= f.input :creator, as: :multi_value, required: true, input_html: { class: 'input-xlarge' } %>
+</fieldset>

--- a/app/views/curation_concern/osf_archives/_osf_archive.html.erb
+++ b/app/views/curation_concern/osf_archives/_osf_archive.html.erb
@@ -1,0 +1,34 @@
+<%# This is a search result view %>
+<% solr_doc = osf_archive.inner_object.solr_doc %>
+<li id="document_<%= osf_archive.noid %>" class="search-result">
+
+  <%= render :partial => 'catalog/_index_partials/identifier_and_action', locals: {document: osf_archive, counter: osf_archive_counter} %>
+
+  <div class="row-fluid">
+
+    <div class="span2">
+      <%= render :partial => 'catalog/_index_partials/thumbnail_display', locals: {document: osf_archive} %>
+    </div>
+
+    <div class="span10">
+      <dl class="attribute-list">
+        <% if solr_doc.has?('desc_metadata__creator_tesim') %>
+          <dt>Author(s):</dt>
+          <dd><%= render_index_field_value(document: solr_doc, field: 'desc_metadata__creator_tesim') %></dd>
+        <% end %>
+
+        <% if solr_doc.has?('desc_metadata__abstract_tesim') %>
+          <dt>Abstract:</dt>
+          <dd class="readmore"><%= escape_html_for_solr_text(truncate(render_index_field_value(document: solr_doc, field: 'desc_metadata__abstract_tesim'), length: 500)).html_safe %></dd>
+        <% end %>
+        <% if solr_doc.has?('desc_metadata__date_created_tesim') %>
+          <dt>Date Created:</dt>
+          <dd><%= render_index_field_value(document: solr_doc, field: 'desc_metadata__date_created_tesim') %></dd>
+        <% end %>
+      </dl>
+
+    </div>
+
+  </div>
+
+</li>

--- a/app/views/curation_concern/osf_archives/edit.html.erb
+++ b/app/views/curation_concern/osf_archives/edit.html.erb
@@ -1,0 +1,13 @@
+<% content_for :page_title, curation_concern_page_title(curation_concern) %>
+<% content_for :page_header do %>
+  <h2>Manage Your Work</h2>
+  <p>
+    You can enrich the metadata describing your work at any time.
+    The more complete the description the easier it will be to find by yourself and others.
+  </p>
+  <p>
+    Please consider releasing your article as an Open Access work.
+  </p>
+<% end %>
+
+<%= render 'form' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ CurateNd::Application.routes.draw do
   get '/classify_concerns/new', to: redirect('deposit')
 
   # Some ETDs are not loading correctly on the curation concern page
-  ['etds', 'articles', 'datasets', 'senior_theses', 'images', 'patents', 'generic_files', 'finding_aids', 'documents'].each do |curation_concern|
+  ['etds', 'articles', 'datasets', 'senior_theses', 'images', 'patents', 'generic_files', 'finding_aids', 'documents', 'osf_archive'].each do |curation_concern|
     get "/concern/#{curation_concern}/new", to: "curation_concern/#{curation_concern}#new"
     get "/concern/#{curation_concern}/:id", to: redirect { |params, request|
       "/show/#{params[:id]}"

--- a/spec/repository_models/osf_archive_spec.rb
+++ b/spec/repository_models/osf_archive_spec.rb
@@ -22,7 +22,7 @@ describe OsfArchive do
     it "should set initialize dates on create" do
       archive.valid?
       expect(archive.date_modified).to eq(Date.today)
-      expect(archive.date_archived).to eq(Date.today)
+      expect(Date.parse(archive.date_archived)).to eq(Date.today)
     end
   end
 end


### PR DESCRIPTION
This change adds the ability to view existing OSF archives. The primary changes to make this happen were the additional view files, routes, and controllers. There are other changes to the model, datastream, and actor that were required in order to create test data. Those changes might collide with work someone else is doing.

Note: This also adds a basic edit form, which is technically part of DLTP-538, but will likely need more work.