### PR TITLE
Show OSF archive

### DIFF
--- a/app/controllers/curation_concern/osf_archives_controller.rb
+++ b/app/controllers/curation_concern/osf_archives_controller.rb
@@ -1,0 +1,3 @@
+class CurationConcern::OsfArchivesController < CurationConcern::GenericWorksController
+  self.curation_concern_type = OsfArchive
+end

--- a/app/helpers/curate_helper.rb
+++ b/app/helpers/curate_helper.rb
@@ -247,7 +247,7 @@ module CurateHelper
   def richly_formatted_text(text, options = {})
     return if text.blank?
     options.reverse_merge!(block: false)
-    markup = Curate::TextFormatter.call(text: text, block: options[:block])
+    markup = Curate::TextFormatter.call(text: text.to_s, block: options[:block])
     markup.html_safe unless markup.nil?
   end
 

--- a/app/repository_datastreams/osf_archive_datastream.rb
+++ b/app/repository_datastreams/osf_archive_datastream.rb
@@ -1,5 +1,8 @@
 class OsfArchiveDatastream < ActiveFedora::NtriplesRDFDatastream
   map_predicates do |map|
+    map.identifier({to: 'identifier#doi', in: RDF::QualifiedDC}) do |index|
+      index.as :stored_searchable, :facetable
+    end
 
     map.creator(to: 'creator', in: RDF::DC) do |index|
       index.as :stored_searchable
@@ -19,6 +22,14 @@ class OsfArchiveDatastream < ActiveFedora::NtriplesRDFDatastream
 
     map.language(to: 'language', in: RDF::DC)
 
+    map.administrative_unit(to: 'creator#administrative_unit', in: RDF::QualifiedDC) do |index|
+      index.as :stored_searchable, :facetable
+    end
+
+    map.affiliation(to: 'creator#affiliation', in: RDF::QualifiedDC) do |index|
+      index.as :stored_searchable, :facetable
+    end
+
     map.department(to: 'creator#administrative_unit', in: RDF::QualifiedDC) do |index|
       index.as :stored_searchable
     end
@@ -35,7 +46,6 @@ class OsfArchiveDatastream < ActiveFedora::NtriplesRDFDatastream
     end
 
     map.date_archived(to: 'dateSubmitted', in: RDF::DC) do |index|
-      index.type :date
       index.as :stored_sortable
     end
 

--- a/app/repository_datastreams/osf_archive_datastream.rb
+++ b/app/repository_datastreams/osf_archive_datastream.rb
@@ -46,6 +46,7 @@ class OsfArchiveDatastream < ActiveFedora::NtriplesRDFDatastream
     end
 
     map.date_archived(to: 'dateSubmitted', in: RDF::DC) do |index|
+      index.type :date
       index.as :stored_sortable
     end
 

--- a/app/repository_models/osf_archive.rb
+++ b/app/repository_models/osf_archive.rb
@@ -27,6 +27,16 @@ class OsfArchive < ActiveFedora::Base
 
   has_metadata 'descMetadata', type: OsfArchiveDatastream
 
+  attribute :administrative_unit,
+    datastream: :descMetadata, multiple: true,
+    label: "Departments and Units",
+    hint: "Departments and Units that creator belong to."
+
+  attribute :affiliation,
+    datastream: :descMetadata,
+    hint: "Creator's Affiliation to the Institution.",
+    multiple: false
+
   attribute :creator,
     datastream: :descMetadata, multiple: true
 

--- a/app/views/curation_concern/osf_archives/_attributes.html.erb
+++ b/app/views/curation_concern/osf_archives/_attributes.html.erb
@@ -1,0 +1,26 @@
+<table class="table table-striped <%= dom_class(curation_concern) %> attributes">
+  <caption class="table-heading"><h2>Attributes</h2></caption>
+  <thead>
+    <tr><th>Attribute Name</th><th>Values</th></tr>
+  </thead>
+  <tbody>
+    <%= curation_concern_attribute_to_html(curation_concern, :creator, 'Creator') %>
+    <%= curation_concern_attribute_to_html(curation_concern, :subject, "Subject") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :date_archived, "Archive Date") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :source, "Original Project") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :language, "Language") %>
+    <%= decode_administrative_unit(curation_concern, :administrative_unit, "Departments and Units") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :library_collections, "Member of") %>
+    <tr>
+      <th>Access Rights</th>
+      <td>
+        <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern } %>
+      </td>
+    </tr>
+    <%= curation_concern_attribute_to_html(curation_concern, :embargo_release_date, "Embargo Release Date") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :rights, "Content License") %>
+    <% if curation_concern.type_of_license == "Independently Licensed" %>
+      <%= curation_concern_attribute_to_html(curation_concern, :license, "License Agreement") %>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/curation_concern/osf_archives/_osf_archive.html.erb
+++ b/app/views/curation_concern/osf_archives/_osf_archive.html.erb
@@ -1,0 +1,34 @@
+<%# This is a search result view %>
+<% solr_doc = osf_archive.inner_object.solr_doc %>
+<li id="document_<%= osf_archive.noid %>" class="search-result">
+
+  <%= render :partial => 'catalog/_index_partials/identifier_and_action', locals: {document: osf_archive, counter: osf_archive_counter} %>
+
+  <div class="row-fluid">
+
+    <div class="span2">
+      <%= render :partial => 'catalog/_index_partials/thumbnail_display', locals: {document: osf_archive} %>
+    </div>
+
+    <div class="span10">
+      <dl class="attribute-list">
+        <% if solr_doc.has?('desc_metadata__creator_tesim') %>
+          <dt>Author(s):</dt>
+          <dd><%= render_index_field_value(document: solr_doc, field: 'desc_metadata__creator_tesim') %></dd>
+        <% end %>
+
+        <% if solr_doc.has?('desc_metadata__abstract_tesim') %>
+          <dt>Abstract:</dt>
+          <dd class="readmore"><%= escape_html_for_solr_text(truncate(render_index_field_value(document: solr_doc, field: 'desc_metadata__abstract_tesim'), length: 500)).html_safe %></dd>
+        <% end %>
+        <% if solr_doc.has?('desc_metadata__date_created_tesim') %>
+          <dt>Date Created:</dt>
+          <dd><%= render_index_field_value(document: solr_doc, field: 'desc_metadata__date_created_tesim') %></dd>
+        <% end %>
+      </dl>
+
+    </div>
+
+  </div>
+
+</li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ CurateNd::Application.routes.draw do
   get '/classify_concerns/new', to: redirect('deposit')
 
   # Some ETDs are not loading correctly on the curation concern page
-  ['etds', 'articles', 'datasets', 'senior_theses', 'images', 'patents', 'generic_files', 'finding_aids', 'documents'].each do |curation_concern|
+  ['etds', 'articles', 'datasets', 'senior_theses', 'images', 'patents', 'generic_files', 'finding_aids', 'documents', 'osf_archive'].each do |curation_concern|
     get "/concern/#{curation_concern}/new", to: "curation_concern/#{curation_concern}#new"
     get "/concern/#{curation_concern}/:id", to: redirect { |params, request|
       "/show/#{params[:id]}"

--- a/spec/repository_models/osf_archive_spec.rb
+++ b/spec/repository_models/osf_archive_spec.rb
@@ -22,7 +22,8 @@ describe OsfArchive do
     it "should set initialize dates on create" do
       archive.valid?
       expect(archive.date_modified).to eq(Date.today)
-      expect(archive.date_archived).to eq(Date.today)
+      expect(Date.parse(archive.date_archived)).to eq(Date.today)
+
     end
   end
 end

--- a/spec/repository_models/osf_archive_spec.rb
+++ b/spec/repository_models/osf_archive_spec.rb
@@ -22,7 +22,7 @@ describe OsfArchive do
     it "should set initialize dates on create" do
       archive.valid?
       expect(archive.date_modified).to eq(Date.today)
-      expect(Date.parse(archive.date_archived)).to eq(Date.today)
+      expect(archive.date_archived).to eq(Date.today)
 
     end
   end

--- a/spec/repository_models/osf_archive_spec.rb
+++ b/spec/repository_models/osf_archive_spec.rb
@@ -23,7 +23,6 @@ describe OsfArchive do
       archive.valid?
       expect(archive.date_modified).to eq(Date.today)
       expect(archive.date_archived).to eq(Date.today)
-
     end
   end
 end


### PR DESCRIPTION
This change adds the ability to view existing OSF archives. 

Summary of changes:
- Created a controller/routes to handle OsfArchive actions
- Changed the CurateHelper to handle date fields from a data stream
- Added identifier, Administrative Unit, and Affiliation to the model since these are fields required in the design doc
- Added views to handle rendering of an OSF archive in search results, and to show a detailed view of an archive