### PR TITLE
Add OSF archives to search

### DIFF
--- a/app/repository_datastreams/osf_archive_datastream.rb
+++ b/app/repository_datastreams/osf_archive_datastream.rb
@@ -34,7 +34,10 @@ class OsfArchiveDatastream < ActiveFedora::NtriplesRDFDatastream
       index.as :stored_searchable
     end
 
-    map.description(to: 'description', in: RDF::DC)
+    map.description(in: RDF::DC) do |index|
+      index.type :text
+      index.as :stored_searchable
+    end
 
     map.date_created(to: 'created', in: RDF::DC) do |index|
       index.as :stored_searchable

--- a/app/repository_models/osf_archive.rb
+++ b/app/repository_models/osf_archive.rb
@@ -71,7 +71,7 @@ class OsfArchive < ActiveFedora::Base
     validates: {presence: { message: 'Department is required.' }}
 
   attribute :description,
-    datastream: :descMetadata, multiple: true,
+    datastream: :descMetadata, multiple: false,
     validates: {presence: { message: 'Your archive must have a description.' }}
 
   attribute :date_created,

--- a/app/views/curation_concern/osf_archives/_attributes.html.erb
+++ b/app/views/curation_concern/osf_archives/_attributes.html.erb
@@ -1,3 +1,4 @@
+<%= curation_concern_attribute_to_formatted_text(curation_concern, :description, 'Description') %>
 <table class="table table-striped <%= dom_class(curation_concern) %> attributes">
   <caption class="table-heading"><h2>Attributes</h2></caption>
   <thead>

--- a/app/views/curation_concern/osf_archives/_form_required_information.html.erb
+++ b/app/views/curation_concern/osf_archives/_form_required_information.html.erb
@@ -4,4 +4,13 @@
   <%= f.input :title, input_html: { class: 'input-xlarge' } %>
 
   <%= f.input :creator, as: :multi_value, required: true, input_html: { class: 'input-xlarge' } %>
+  <%= f.input :description,
+              as: :text,
+              required: true,
+              input_html: {
+                class: 'input-xxxlarge rich-textarea-js',
+                rows: '14'
+              },
+              label: 'Description'
+  %>
 </fieldset>

--- a/app/views/curation_concern/osf_archives/_osf_archive.html.erb
+++ b/app/views/curation_concern/osf_archives/_osf_archive.html.erb
@@ -17,14 +17,16 @@
           <dd><%= render_index_field_value(document: solr_doc, field: 'desc_metadata__creator_tesim') %></dd>
         <% end %>
 
-        <% if solr_doc.has?('desc_metadata__abstract_tesim') %>
-          <dt>Abstract:</dt>
-          <dd class="readmore"><%= escape_html_for_solr_text(truncate(render_index_field_value(document: solr_doc, field: 'desc_metadata__abstract_tesim'), length: 500)).html_safe %></dd>
+        <% if solr_doc.has?('desc_metadata__description_tesim') %>
+          <dt>Description:</dt>
+          <dd class="readmore"><%= escape_html_for_solr_text(truncate(render_index_field_value(document: solr_doc, field: 'desc_metadata__description_tesim'), length: 500)).html_safe %></dd>
         <% end %>
+
         <% if solr_doc.has?('desc_metadata__date_created_tesim') %>
           <dt>Date Created:</dt>
           <dd><%= render_index_field_value(document: solr_doc, field: 'desc_metadata__date_created_tesim') %></dd>
         <% end %>
+
       </dl>
 
     </div>


### PR DESCRIPTION
The basic view for showing OSF archives in search was added in PR #527. This change adds an additional description field to that view.

Changes:
- Added Description to the search results view for OSF Archives
- In prior work on show/edit forms, there was no mention of description, so I'm adding here as well. This meant changing the model and datastream a bit:
  - The model was set to allow multiple values for description, which is not a requirement and causes problems with the input fields.
  - The description wasn't being added to the solr doc, so changed the datastream to index the field.