### PR TITLE
View ingest jobs

### DIFF
--- a/app/controllers/admin/batch_ingest_controller.rb
+++ b/app/controllers/admin/batch_ingest_controller.rb
@@ -2,6 +2,6 @@ class Admin::BatchIngestController < ApplicationController
   with_themed_layout('1_column')
 
   def index
-    @jobs = BatchIngestTools.get_jobs
+    @jobs = BatchIngestor.get_jobs
   end
 end

--- a/app/controllers/admin/batch_ingest_controller.rb
+++ b/app/controllers/admin/batch_ingest_controller.rb
@@ -1,0 +1,7 @@
+class Admin::BatchIngestController < ApplicationController
+  with_themed_layout('1_column')
+
+  def index
+    @jobs = BatchIngestTools.get_jobs
+  end
+end

--- a/app/controllers/admin/batch_ingest_controller.rb
+++ b/app/controllers/admin/batch_ingest_controller.rb
@@ -2,6 +2,6 @@ class Admin::BatchIngestController < ApplicationController
   with_themed_layout('1_column')
 
   def index
-    @jobs = BatchIngestor.get_jobs
+    @jobs = BatchIngestor.new.get_jobs
   end
 end

--- a/app/services/batch_ingestor.rb
+++ b/app/services/batch_ingestor.rb
@@ -50,6 +50,19 @@ class BatchIngestor
     return as_of.strftime(time_format)
   end
 
+  def self.get_jobs
+    url = 'http://localhost:15000/jobs'
+    uri = URI.parse(url)
+    http = Net::HTTP.new(uri.host, uri.port)
+
+    response = http.request_get(uri.path)
+    if response.code == "200"
+      JSON.parse(http.request_get(uri.path).body, symbolize_names: true)
+    else
+      fail "An error occurred while retrieving jobs from the Batch Ingest system."
+    end
+  end
+
   private
 
   def default_http

--- a/app/services/batch_ingestor.rb
+++ b/app/services/batch_ingestor.rb
@@ -3,25 +3,18 @@ require 'net/http'
 require 'time'
 
 class BatchIngestor
+  class BatchIngestHTTPError < RuntimeError
+  end
 
-  attr_reader :content_data, :task_function_name, :job_id_prefix, :content_file_name, :job_id, :http, :job_id_builder
+  attr_reader :job_id, :http, :job_id_builder
 
   SERVER_URL = 'http://localhost:15000/'.freeze
-
-  def initialize(job_id_prefix, task_function_name, content_file_name, content_data, options = {})
-    @job_id_prefix = job_id_prefix
-    @task_function_name = task_function_name
-    @content_file_name = content_file_name
-    @content_data = content_data
-    @http = options.fetch(:http) { default_http }
-    @job_id_builder = options.fetch(:job_id_builder) { self.class.method(:default_job_id_builder) }
-  end
 
   def self.start_reingest(content_data, options = {})
     job_id_prefix = 'reingest'
     task_function_name = 'start-reingest'
     content_file_name = 'fedora_pids'
-    new(job_id_prefix, task_function_name, content_file_name, content_data).submit_ingest
+    new(options).submit_ingest(job_id_prefix, task_function_name, content_file_name, content_data)
   end
 
   def self.start_osf_archive_ingest(content_data, options = {})
@@ -29,15 +22,7 @@ class BatchIngestor
     task_function_name = 'start-osf-archive-ingest'
     content_file_name = 'osf_projects'
     content_data[:project_url] = get_osf_url(content_data.fetch(:project_identifier))
-    new(job_id_prefix, task_function_name, content_file_name, content_data).submit_ingest
-  end
-
-  def submit_ingest
-    @job_id = make_job_id
-    create_batch_job
-    add_job_file(content_file_name, content_data)
-    add_job_file('JOB', task_list)
-    submit_batch_job
+    new(options).submit_ingest(job_id_prefix, task_function_name, content_file_name, content_data)
   end
 
   def self.get_osf_url(project_identifier)
@@ -50,17 +35,23 @@ class BatchIngestor
     return as_of.strftime(time_format)
   end
 
-  def self.get_jobs
-    url = 'http://localhost:15000/jobs'
-    uri = URI.parse(url)
-    http = Net::HTTP.new(uri.host, uri.port)
+  def initialize(options = {})
+    @http = options.fetch(:http) { default_http }
+    @job_id_builder = options.fetch(:job_id_builder) { self.class.method(:default_job_id_builder) }
+  end
 
-    response = http.request_get(uri.path)
-    if response.code == "200"
-      JSON.parse(http.request_get(uri.path).body, symbolize_names: true)
-    else
-      fail "An error occurred while retrieving jobs from the Batch Ingest system."
-    end
+  def submit_ingest(job_id_prefix, task_function_name, content_file_name, content_data)
+    job_id = job_id_builder.call(job_id_prefix)
+    create_batch_job(job_id)
+    add_job_file(job_id, content_file_name, content_data)
+    add_job_file(job_id, 'JOB', { 'Todo' => [task_function_name] })
+    submit_batch_job(job_id)
+  end
+
+  def get_jobs
+    response = http.request_get('/jobs')
+    handle_response({}, response)
+    JSON.parse(response.body, symbolize_names: true)
   end
 
   private
@@ -70,47 +61,35 @@ class BatchIngestor
     Net::HTTP.new(uri.host, uri.port)
   end
 
-  def make_job_id
-    job_id_builder.call(job_id_prefix)
-  end
-
-  # create Contents of JOB file to start reingest in batch ingest system
-  def task_list
-    { 'Todo' => [task_function_name] }
-  end
-
   # does PUT /jobs/:jobid to create data dir on batch ingest side
-  def create_batch_job
+  def create_batch_job(job_id)
     request = Net::HTTP::Put.new("/jobs/#{job_id}")
     response = http.request(request)
     handle_response('create_batch_job', response)
   end
 
   # does PUT /jobs/:jobid to create data dir on batch ingest side
-  def add_job_file(name, data)
+  def add_job_file(job_id, name, data)
     request = Net::HTTP::Put.new("/jobs/#{job_id}/files/#{name}")
     request.body = JSON.generate(data)
     response = http.request(request)
-    handle_response('add_job_file', response)
+    handle_response({ task_name: name, method_name: 'add_job_file', job_input: data }, response)
   end
 
   # does POST /jobs/:jobid/queue to start process on batch ingest side
-  def submit_batch_job
+  def submit_batch_job(job_id)
     response = http.request_post("/jobs/#{job_id}/queue", "submit")
     handle_response('submit_batch_job', response)
   end
 
-  def handle_response(method_name, response)
+  def handle_response(params, response)
     return true if response.code.to_s == '200'
-    report_to_airbrake(method_name, response.code)
+    report_to_airbrake(params, response.code)
   end
 
-  class SubmitError < RuntimeError
-  end
-
-  def report_to_airbrake(method_name, code)
-    exception = SubmitError.new("HTTP request failed with status #{code}")
-    Airbrake.notify_or_ignore(error_class: exception.class, error_message: exception, parameters: { task_name: task_function_name, method_name: method_name ,job_input: content_data })
+  def report_to_airbrake(params, code)
+    exception = BatchIngestHTTPError.new("HTTP request failed with status #{code}")
+    Airbrake.notify_or_ignore(error_class: exception.class, error_message: exception, parameters: params)
     raise exception
   end
 end

--- a/app/services/batch_ingestor.rb
+++ b/app/services/batch_ingestor.rb
@@ -51,7 +51,11 @@ class BatchIngestor
   def get_jobs
     response = http.request_get('/jobs')
     handle_response({}, response)
-    JSON.parse(response.body, symbolize_names: true)
+    if response.body.present?
+      JSON.parse(response.body, symbolize_names: true)
+    else
+      []
+    end
   end
 
   private

--- a/app/services/ingest_osf_tools.rb
+++ b/app/services/ingest_osf_tools.rb
@@ -8,7 +8,7 @@ class IngestOSFTools
   end
 
   def self.get_osf_jobs
-    @@archive_array ||= []
-    @@archive_array
+    #TODO: Filter for just osf jobs
+    BatchIngestor.new.get_jobs.select { |job| job[:status] != 'success' }
   end
 end

--- a/app/views/admin/base/index.html.erb
+++ b/app/views/admin/base/index.html.erb
@@ -15,3 +15,4 @@
 <hr />
 <p class="lead"><%= link_to 'Application Exceptions', "https://errbit.library.nd.edu" %></p>
 <p class="lead"><%= link_to 'Resque Queue', admin_resque_server_path %></p>
+<p class="lead"><%= link_to 'Batch Ingest Jobs', admin_batch_ingest_index_path %></p>

--- a/app/views/admin/batch_ingest/index.html.erb
+++ b/app/views/admin/batch_ingest/index.html.erb
@@ -1,0 +1,29 @@
+<% content_for :page_title, construct_page_title('Batch Ingest Jobs', 'Administrative Functions') %>
+<% content_for :page_header do %>
+  <h1>Batch Ingest Jobs</h1>
+
+  <ul class="breadcrumb">
+    <li><%= link_to 'CurateND', root_path %> <span class="divider">/</span></li>
+    <li><%= link_to 'Administrative Functions', admin_path %> <span class="divider">/</span></li>
+    <li class="active">Batch Ingest Jobs</li>
+  </ul>
+<% end %>
+
+<table class="table table-striped">
+  <caption class="accessible-hidden">List of All Ingest Jobs</caption>
+  <thead>
+    <tr>
+      <th>Job</th>
+      <th>Status</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @jobs.sort_by!{ |job| [job[:status], job[:job]] }.each do |job| %>
+      <tr>
+        <td><%= job[:job] %></td>
+        <td><%= job[:status] %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin/ingest_osf_archives/index.html.erb
+++ b/app/views/admin/ingest_osf_archives/index.html.erb
@@ -13,8 +13,7 @@
   <caption class="accessible-hidden">List of All OSF Project Ingest Jobs</caption>
   <thead>
     <tr>
-      <th>Project Identifier</th>
-      <th>Owner</th>
+      <th>Job</th>
       <th>Status</th>
     </tr>
   </thead>
@@ -22,9 +21,8 @@
   <tbody>
     <% @archives.each do |archive| %>
       <tr>
-        <td><%= archive.project_identifier %></td>
-        <td><%= archive.owner %></td>
-        <td><%= archive.status %></td>
+        <td><%= archive[:job] %></td>
+        <td><%= archive[:status] %></td>
       </tr>
     <% end %>
   </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -97,6 +97,7 @@ CurateNd::Application.routes.draw do
 
       resource :repo_manager, only: [:edit, :update], path: :privledges
       resources :ingest_osf_archives #, only: [:new, :create, :index, :edit, :update]
+      resources :batch_ingest, only: [:index]
     end
 
     constraints CurateND::AdminAPIConstraint do

--- a/spec/controllers/admin/batch_ingest_controller_spec.rb
+++ b/spec/controllers/admin/batch_ingest_controller_spec.rb
@@ -4,10 +4,10 @@ describe Admin::BatchIngestController, type: :controller do
   describe "#index" do
     let(:subject) { get :index }
 
-    it "assigns @jobs using BatchIngestTools#get_jobs" do
-      allow(BatchIngestTools).to receive(:get_jobs).and_return("stuff from BatchIngestTools.get_jobs")
+    it "assigns @jobs using BatchIngestor#get_jobs" do
+      allow(BatchIngestor).to receive(:get_jobs).and_return("stuff from BatchIngestor.get_jobs")
       subject
-      expect(assigns(:jobs)).to eq("stuff from BatchIngestTools.get_jobs")
+      expect(assigns(:jobs)).to eq("stuff from BatchIngestor.get_jobs")
     end
   end
 end

--- a/spec/controllers/admin/batch_ingest_controller_spec.rb
+++ b/spec/controllers/admin/batch_ingest_controller_spec.rb
@@ -5,7 +5,7 @@ describe Admin::BatchIngestController, type: :controller do
     let(:subject) { get :index }
 
     it "assigns @jobs using BatchIngestor#get_jobs" do
-      allow(BatchIngestor).to receive(:get_jobs).and_return("stuff from BatchIngestor.get_jobs")
+      allow_any_instance_of(BatchIngestor).to receive(:get_jobs).and_return("stuff from BatchIngestor.get_jobs")
       subject
       expect(assigns(:jobs)).to eq("stuff from BatchIngestor.get_jobs")
     end

--- a/spec/controllers/admin/batch_ingest_controller_spec.rb
+++ b/spec/controllers/admin/batch_ingest_controller_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe Admin::BatchIngestController, type: :controller do
+  describe "#index" do
+    let(:subject) { get :index }
+
+    it "assigns @jobs using BatchIngestTools#get_jobs" do
+      allow(BatchIngestTools).to receive(:get_jobs).and_return("stuff from BatchIngestTools.get_jobs")
+      subject
+      expect(assigns(:jobs)).to eq("stuff from BatchIngestTools.get_jobs")
+    end
+  end
+end

--- a/spec/services/batch_ingestor_spec.rb
+++ b/spec/services/batch_ingestor_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe BatchIngestor do
     let(:http) { instance_double(Net::HTTP, request_get: response) }
     let(:subject) { described_class.new(http: http).get_jobs }
 
-    it 'returns symbolized copy of the response from the API' do
+    it 'returns symbolized copy of the response from the API, without any other transformations' do
       expect(subject).to eq(expected_array)
     end
 

--- a/spec/services/ingest_osf_tools_spec.rb
+++ b/spec/services/ingest_osf_tools_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+RSpec.describe IngestOSFTools do
+  let(:all_jobs) do
+    [
+      { job: "Job1", status: "success" },
+      { job: "Job2", status: "error" },
+      { job: "Job3", status: "queue" },
+      { job: "Job4", status: "processing" },
+      { job: "Job5", status: "ready" },
+    ]
+  end
+
+  describe '#create_osf_job' do
+    it 'creates the job using BatchIngestor'
+  end
+
+  describe '#get_osf_jobs' do
+    let(:subject) { IngestOSFTools.get_osf_jobs }
+
+    before(:each) do
+      allow_any_instance_of(BatchIngestor).to receive(:get_jobs).and_return(all_jobs)
+    end
+
+    it 'filters to incomplete jobs' do
+      jobs = subject
+      expect(jobs).not_to include({ job: "Job1", status: "success" })
+      expect(jobs).to include({ job: "Job2", status: "error" })
+      expect(jobs).to include({ job: "Job3", status: "queue" })
+      expect(jobs).to include({ job: "Job4", status: "processing" })
+      expect(jobs).to include({ job: "Job5", status: "ready" })
+    end
+
+    it 'filters to just OSF Archive jobs'
+  end
+end


### PR DESCRIPTION
Adds the admin ability to see the status of all batch ingest jobs.

Summary of changes:
- Added controller/routes/view for handling /admin/batch_ingest
- BatchIngestor was primarily used for puts of data to the Batch Ingest System, so methods such as initialize and error handling required data for those types of actions. We now need methods for doing simpler things such as gets of the /jobs from the system, so I had to refactor some of these common methods to be a bit more generic.
- Rewired IngestOSFTools #get_osf_jobs to use the BatchIngestor to perform the actual query. This will still need to be modified to filter for just OSF jobs. As a reminder, this code path is used by /admin/ingest_osf_archives which is a view that was intended to render only OSF jobs, and is currently serving as the landing area after a user submits a new OSF job. It may make sense to just remove this view and provide a generic way within /admin/batch_ingest to filter for job types.