### PR TITLE
Guard for missing title metadata on generic file

### DIFF
--- a/app/views/curation_concern/finding_aids/_form_representative_file.html.erb
+++ b/app/views/curation_concern/finding_aids/_form_representative_file.html.erb
@@ -6,7 +6,7 @@
           Assign an EAD
         </legend>
         <p>Select the EAD file which should be displayed for this <%= curation_concern.human_readable_type %>.</p>
-        <%= f.select( :representative, Hash[ curation_concern.generic_files.map {|file| [file.title.first, file.pid] } ] ) %>
+        <%= f.select( :representative, Hash[ curation_concern.generic_files.map {|file| [file.title.try(:first).nil? ? 'file title is missing' : file.title.first, file.pid] } ] ) %>
       </fieldset>
     </div>
   </div>


### PR DESCRIPTION
## Guard for missing title metadata on generic file

@bb8c0cdb6441a73d1440dfe86f63eb697956154c

A finding aid file with no title caused the edit page to receive a
500 error. Curate caught a registered error: NoMethodError - undefined
method `first' for nil:NilClass.
