### PR TITLE
Bugfix for "Import OSF Archive" link

### DIFF
--- a/app/views/shared/_add_content.html.erb
+++ b/app/views/shared/_add_content.html.erb
@@ -19,7 +19,10 @@
       </li>
     <% end %>
     <li><%= link_to 'More Options', deposit_path, class: 'link-to-full-list', role: 'menuitem' %></li>
-    <li class="divider"></li>
-    <li><%= link_to 'Import OSF archive', new_admin_ingest_osf_archive_path %></li>
+
+    <% if CurateND::AdminConstraint.is_admin?(current_user) %>
+      <li class="divider"></li>
+      <li><%= link_to 'Import OSF archive', new_admin_ingest_osf_archive_path %></li>
+    <% end %>
   </ul>
 </div>


### PR DESCRIPTION
The add content drop down menu was showing the "Import OSF Archive" link for non-admin users. Changed to limit to rendering the link only when the user is an admin.