### PR TITLE
Removing project_url from OSF Ingest request

### DIFF
--- a/app/models/admin/ingest_osf_archive.rb
+++ b/app/models/admin/ingest_osf_archive.rb
@@ -24,18 +24,11 @@ class Admin::IngestOSFArchive
       project_identifier: project_identifier,
       administrative_unit: administrative_unit,
       owner: owner,
-      affiliation: affiliation,
-      project_url: project_url
+      affiliation: affiliation
     }
   end
 
   def ==(object)
     as_hash == object.as_hash
-  end
-
-  def project_url
-    osf_host_name = ENV.fetch('OSF_HOST_NAME', 'osf.io')
-    osf_scheme = ENV.fetch('OSF_SCHEME', 'https')
-    "#{osf_scheme}://#{osf_host_name}/#{project_identifier}/"
   end
 end

--- a/spec/models/admin/ingest_osf_archive_spec.rb
+++ b/spec/models/admin/ingest_osf_archive_spec.rb
@@ -24,10 +24,7 @@ describe Admin::IngestOSFArchive do
     subject { ingest_osf_archive.as_hash }
     it { is_expected.to be_a(Hash) }
     it "is expected to equal the input attributes along with the project_url" do
-      expect(subject).to eq(attributes.merge(project_url: ingest_osf_archive.project_url))
-    end
-    it "is expected to include the :project_url key" do
-      expect(subject.keys).to include(:project_url)
+      expect(subject).to eq(attributes)
     end
   end
 


### PR DESCRIPTION
Per discussions with Mark and Don, sending the project URL is the path of confusion.