### PR TITLE
Rendering Rights input for Finding Aid

### DIFF
--- a/app/views/curation_concern/finding_aids/_form.html.erb
+++ b/app/views/curation_concern/finding_aids/_form.html.erb
@@ -58,6 +58,12 @@
       </fieldset>
     </div>
 
+  <div class="row with-headroom">
+    <div class="span12">
+      <%= render "form_content_license", curation_concern: curation_concern, f: f %>
+    </div>
+  </div>
+
   <%= render 'form_contributor_agreement', curation_concern: curation_concern, contributor_agreement: contributor_agreement, f: f %>
 
   <div class="row">


### PR DESCRIPTION
Prior to this change, if I were to edit the finding aid, and
the object did not have Rights already set, the data would
be invalid.