### PR TITLE
Favoring common object path to polymorphic path

### DIFF
--- a/app/controllers/curation_concern/base_controller.rb
+++ b/app/controllers/curation_concern/base_controller.rb
@@ -9,7 +9,7 @@ module CurationConcern
       when 'new', 'create'
         add_breadcrumb "New #{curation_concern.human_readable_type}", request.path
       else
-        add_breadcrumb curation_concern.human_readable_type, polymorphic_path([:curation_concern, curation_concern])
+        add_breadcrumb curation_concern.human_readable_type, common_object_path(curation_concern)
         add_breadcrumb action_name.titleize, request.path
       end
     end

--- a/app/controllers/curation_concern/generic_files_controller.rb
+++ b/app/controllers/curation_concern/generic_files_controller.rb
@@ -4,7 +4,7 @@ class CurationConcern::GenericFilesController < CurationConcern::BaseController
   respond_to(:html)
 
   def attach_action_breadcrumb
-    add_breadcrumb "#{parent.human_readable_type}", polymorphic_path([:curation_concern, parent])
+    add_breadcrumb "#{parent.human_readable_type}", common_object_path(parent)
     super
   end
 

--- a/app/controllers/curation_concern/permissions_controller.rb
+++ b/app/controllers/curation_concern/permissions_controller.rb
@@ -7,7 +7,7 @@ class CurationConcern::PermissionsController < CurationConcern::BaseController
   def copy
     Sufia.queue.push(VisibilityCopyWorker.new(curation_concern.id))
     flash_message = 'Updating file permissions. This may take a few minutes. You may want to refresh your browser or return to this record later to see the updated file permissions.'
-    redirect_to polymorphic_path([:curation_concern, curation_concern]), notice: flash_message
+    redirect_to common_object_path(curation_concern), notice: flash_message
   end
 
   self.curation_concern_type = ActiveFedora::Base

--- a/app/views/catalog/_index_partials/_identifier_and_action.html.erb
+++ b/app/views/catalog/_index_partials/_identifier_and_action.html.erb
@@ -1,5 +1,5 @@
 <% solr_doc          ||= document.inner_object.solr_doc                                                    %>
-<% title_link_target ||= polymorphic_path([:curation_concern, document])                                   %>
+<% title_link_target ||= common_object_path(document) %>
 <% if document.respond_to?(:name) %>
   <% title_link_text   ||= document.name %>
 <% else %>
@@ -42,5 +42,3 @@
     <% end %>
   </div>
 </div>
-
-

--- a/app/views/catalog/_index_partials/_thumbnail_display.html.erb
+++ b/app/views/catalog/_index_partials/_thumbnail_display.html.erb
@@ -1,4 +1,4 @@
-<% title_link_target ||= polymorphic_path([:curation_concern, document]) %>
+<% title_link_target ||= common_object_path(document) %>
 <% if document.respond_to?(:representative_image_url) && document.representative_image_url.present? %>
   <%= link_to title_link_target do %>
     <div class="thumbnail-wrapper">

--- a/app/views/catalog/_thumbnail_result_tile.html.erb
+++ b/app/views/catalog/_thumbnail_result_tile.html.erb
@@ -2,7 +2,7 @@
   # This is a search result with a prominant thumbnail
 
   solr_doc          ||= document.inner_object.solr_doc
-  title_link_target ||= polymorphic_path([:curation_concern, document])
+  title_link_target ||= common_object_path(document)
 
   if document.respond_to?(:user)
     edit_path = ''

--- a/app/views/curation_concern/base/_form.html.erb
+++ b/app/views/curation_concern/base/_form.html.erb
@@ -21,7 +21,7 @@
       <%- if curation_concern.new_record? -%>
         <%= link_to 'Cancel', root_path, class: 'btn btn-link' %>
       <%- else -%>
-        <%= link_to 'Cancel', polymorphic_path([:curation_concern, curation_concern]), class: 'btn btn-link' %>
+        <%= link_to 'Cancel', common_object_path(curation_concern), class: 'btn btn-link' %>
       <%- end -%>
     </div>
   </div>

--- a/app/views/curation_concern/base/_form_files_and_links.html.erb
+++ b/app/views/curation_concern/base/_form_files_and_links.html.erb
@@ -8,7 +8,7 @@
 <% if curation_concern.persisted? %>
 <p><em>Files are managed from the <%= link_to(
   "#{curation_concern.human_readable_type.downcase} record view",
-  polymorphic_path([:curation_concern, curation_concern])
+  common_object_path(curation_concern)
   )%>.
   <% unless curation_concern.generic_files.present? %>
     <br />You must attach at least one file to choose a thumbnail for this <%= curation_concern.human_readable_type.downcase %>.

--- a/app/views/curation_concern/base/_related_works.html.erb
+++ b/app/views/curation_concern/base/_related_works.html.erb
@@ -13,7 +13,7 @@
       <tbody>
       <% curation_concern.related_works.each do |related_work| %>
         <tr class="referenced_by_works attributes">
-          <td class="attribute title"><%= link_to related_work.title, polymorphic_path([:curation_concern, related_work]) %></td>
+          <td class="attribute title"><%= link_to related_work.title, common_object_path(related_work) %></td>
         </tr>
       <% end %>
       </tbody>
@@ -46,7 +46,7 @@
       <tbody>
       <% curation_concern.referenced_by_works.each do |related_work| %>
         <tr class="referenced_by_works attributes">
-          <td class="attribute title"><%= link_to related_work.title, polymorphic_path([:curation_concern, related_work]) %></td>
+          <td class="attribute title"><%= link_to related_work.title, common_object_path(related_work) %></td>
         </tr>
       <% end %>
       </tbody>

--- a/app/views/curation_concern/datasets/_form_files_and_links.html.erb
+++ b/app/views/curation_concern/datasets/_form_files_and_links.html.erb
@@ -15,7 +15,7 @@
 <% if curation_concern.persisted? %>
 <p><em>Files are managed from the <%= link_to(
   "#{curation_concern.human_readable_type.downcase} record view",
-  polymorphic_path([:curation_concern, curation_concern])
+    common_object_path(curation_concern)
   )%>.
   <% unless curation_concern.generic_files.present? %>
     <br />You must attach at least one file to choose a thumbnail for this <%= curation_concern.human_readable_type.downcase %>.

--- a/app/views/curation_concern/etds/_form.html.erb
+++ b/app/views/curation_concern/etds/_form.html.erb
@@ -1,5 +1,5 @@
 <%= simple_form_for [:curation_concern, curation_concern] do |f| %>
-  
+
   <% if f.error_notification -%>
     <div class="alert alert-error fade in">
       <strong>Wait don't go!</strong> There was a problem with your submission. Please review the errors below:
@@ -19,7 +19,7 @@
       <%- if curation_concern.new_record? -%>
         <%= link_to 'Cancel', root_path, class: 'btn btn-link' %>
       <%- else -%>
-        <%= link_to 'Cancel', polymorphic_path([:curation_concern, curation_concern]), class: 'btn btn-link' %>
+        <%= link_to 'Cancel', common_object_path(curation_concern), class: 'btn btn-link' %>
       <%- end -%>
     </div>
   </div>

--- a/app/views/curation_concern/etds/_form_files_and_links.html.erb
+++ b/app/views/curation_concern/etds/_form_files_and_links.html.erb
@@ -8,7 +8,7 @@
 <% if curation_concern.persisted? %>
 <p><em>Files are managed from the <%= link_to(
   "#{curation_concern.human_readable_type.downcase} record view",
-  polymorphic_path([:curation_concern, curation_concern])
+  common_object_path(curation_concern)
   )%>.
   <% unless curation_concern.generic_files.present? %>
     <br />You must attach at least one file to choose a thumbnail for this <%= curation_concern.human_readable_type.downcase %>.

--- a/app/views/curation_concern/generic_files/_empty_file.html.erb
+++ b/app/views/curation_concern/generic_files/_empty_file.html.erb
@@ -12,6 +12,5 @@
         <i class="icon icon-warning-sign icon-white"></i> Resolve
       <% end %>
     <% end %>
-    <%= link_to "Back to #{parent.human_readable_type}", polymorphic_path([:curation_concern, parent]), class: 'btn btn-primary' %>
+    <%= link_to "Back to #{parent.human_readable_type}", common_object_path(parent), class: 'btn btn-primary' %>
   </div>
-

--- a/app/views/curation_concern/generic_files/_form.html.erb
+++ b/app/views/curation_concern/generic_files/_form.html.erb
@@ -27,7 +27,7 @@
         (curation_concern.persisted? ? "Update Attached File" : %(Attach to #{parent.human_readable_type})),
         class: 'btn btn-primary'
       ) %>
-      <%= link_to 'Cancel', polymorphic_path([:curation_concern, parent]), class: 'btn btn-link' %>
+      <%= link_to 'Cancel', common_object_path(parent), class: 'btn btn-link' %>
     </div>
   </div>
 <% end %>

--- a/app/views/curation_concern/generic_files/versions.html.erb
+++ b/app/views/curation_concern/generic_files/versions.html.erb
@@ -24,9 +24,9 @@
       ) %>
       <%# TODO Cancel button behavior should be context aware.
         Going back to the dashboard isn't always the expected behavior. %>
-      <%= link_to 'Cancel', polymorphic_path([:curation_concern, parent]), class: 'btn btn-link' %>
+      <%= link_to 'Cancel', common_object_path(parent), class: 'btn btn-link' %>
     <% unless curation_concern.new_record? -%>
-      <%= link_to 'Go to File Record View', polymorphic_path([:curation_concern, curation_concern]), class: 'btn btn-info pull-right' %>
+      <%= link_to 'Go to File Record View', common_object_path(curation_concern), class: 'btn btn-info pull-right' %>
     <% end -%>
     </div>
   </div>

--- a/app/views/curation_concern/images/_form_files_and_links.html.erb
+++ b/app/views/curation_concern/images/_form_files_and_links.html.erb
@@ -8,7 +8,7 @@
 <% if curation_concern.persisted? %>
 <p><em>Files are managed from the <%= link_to(
   "#{curation_concern.human_readable_type.downcase} record view",
-  polymorphic_path([:curation_concern, curation_concern])
+  common_object_path(curation_concern)
   )%>.
   <% unless curation_concern.generic_files.present? %>
     <br />You must attach at least one file to choose a thumbnail for this <%= curation_concern.human_readable_type.downcase %>.

--- a/app/views/curation_concern/osf_archives/_attributes.html.erb
+++ b/app/views/curation_concern/osf_archives/_attributes.html.erb
@@ -51,7 +51,7 @@
     <tr class="referenced_by_works attributes <%= 'selected-row' if is_viewing_version %>">
       <td class="modifier current"><%= is_viewing_version ? 'Viewing' : '&nbsp;'.html_safe %></td>
       <td class="attribute noid">
-        <%= link_to_unless(is_viewing_version, archived_version.noid, polymorphic_path([:curation_concern, archived_version])) %>
+        <%= link_to_unless(is_viewing_version, archived_version.noid, common_object_path(archived_version)) %>
       </td>
       <td class="attribute date_archived"><%= content_tag :time, archived_version.date_archived.strftime('%Y-%m-%d'), datetime: archived_version.date_archived.iso8601 %></td>
     </tr>

--- a/app/views/curation_concern/patents/_form.html.erb
+++ b/app/views/curation_concern/patents/_form.html.erb
@@ -1,5 +1,5 @@
 <%= simple_form_for [:curation_concern, curation_concern] do |f| %>
-  
+
   <% if f.error_notification -%>
     <div class="alert alert-error fade in">
       <strong>Wait don't go!</strong> There was a problem with your submission. Please review the errors below:
@@ -57,7 +57,7 @@
       <%- if curation_concern.new_record? -%>
         <%= link_to 'Cancel', root_path, class: 'btn btn-link' %>
       <%- else -%>
-        <%= link_to 'Cancel', polymorphic_path([:curation_concern, curation_concern]), class: 'btn btn-link' %>
+        <%= link_to 'Cancel', common_object_path(curation_concern), class: 'btn btn-link' %>
       <%- end -%>
     </div>
   </div>

--- a/app/views/curation_concern/permissions/confirm.html.erb
+++ b/app/views/curation_concern/permissions/confirm.html.erb
@@ -4,5 +4,5 @@
 
 <div class="form-actions">
   <%= button_to "Yes please.", copy_curation_concern_permission_path(curation_concern), class: 'btn btn-primary' %>
-  <%= link_to "No. I'll update it manually.", polymorphic_path([:curation_concern, curation_concern]), class: 'btn' %>
+  <%= link_to "No. I'll update it manually.", common_object_path(curation_concern), class: 'btn' %>
 </div>


### PR DESCRIPTION
The `common_object_path` for any Fedora object should work; This is not
the case with polymorphic_path. The route /curation_concern/etds/:id
has been removed (as it is no longer something that can be deposited).

There was an unintentional upstream bugga boo. This commit resolves
that.