### PR TITLE
Removing etd from self deposit

### DIFF
--- a/app/models/work_type_policy.rb
+++ b/app/models/work_type_policy.rb
@@ -2,6 +2,8 @@
 # whether a user is authorized to create a given work type.
 #
 # Rules are defined in config/work_type_policy_rules.yml
+#
+# @see Ability for implementation details (./app/models/ability.rb)
 class WorkTypePolicy
   def initialize(user: current_user, policy_rules: WORK_TYPE_POLICY_RULES)
     self.user = user

--- a/config/initializers/curate_config.rb
+++ b/config/initializers/curate_config.rb
@@ -1,5 +1,14 @@
 Curate.configure do |config|
   # Injected via `rails g curate:work SeniorThesis`
+
+  # ***************************************************************************************************************************************
+  # ***************************************************************************************************************************************
+  #
+  # Note: These are all of the curation concerns. They are a superset of what can be self-deposited.
+  # To remove something from self-deposit, see WorkTypePolicy (./app/models/work_type_policy.rb)
+  #
+  # ***************************************************************************************************************************************
+  # ***************************************************************************************************************************************
   config.register_curation_concern :senior_thesis
   config.register_curation_concern :finding_aid
   config.register_curation_concern :etd

--- a/config/initializers/curate_config.rb
+++ b/config/initializers/curate_config.rb
@@ -2,6 +2,7 @@ Curate.configure do |config|
   # Injected via `rails g curate:work SeniorThesis`
   config.register_curation_concern :senior_thesis
   config.register_curation_concern :finding_aid
+  config.register_curation_concern :etd
   config.register_curation_concern :dataset
   config.register_curation_concern :article
   config.register_curation_concern :audio

--- a/config/work_type_policy_rules.yml
+++ b/config/work_type_policy_rules.yml
@@ -9,7 +9,7 @@ Dataset:
 Document:
   open: all
 Etd:
-  open: all
+  open: nobody
 FindingAid:
   open: all
 Image:


### PR DESCRIPTION
@banurekha the QA process encountered a problem with @50007102ba2b229541116a9143b59b13833db05b. I believe these changes are what was needed.

## Revert "removing etd from self deposit"

@db3ddc9be4dc91f295dad438605f5d0694d03241

This reverts commit 50007102ba2b229541116a9143b59b13833db05b.

## Updating documentation and ETD deposit behavior

@e272c00137efb7593317fe1f0569fbecf3aa2fc2

* Adding explanation about how the constituent parts work together
* Ensuring ETDs are not part of the testing deposit (though that is
  not a burning need)
