### PR TITLE
Display publication date before create_date when available

### DIFF
--- a/app/repository_datastreams/article_metadata_datastream.rb
+++ b/app/repository_datastreams/article_metadata_datastream.rb
@@ -75,7 +75,7 @@ class ArticleMetadataDatastream < ActiveFedora::NtriplesRDFDatastream
     end
 
     map.publication_date({to: 'issued', in: RDF::DC}) do |index|
-      index.as :displayable #This is a test to see if it will show up in a way that makes it more useful in Search Results Display than "Created"
+      index.as :stored_searchable
     end
 
     map.is_part_of({to: 'isPartOf', in: RDF::DC}) do |index|

--- a/app/repository_datastreams/audio_datastream.rb
+++ b/app/repository_datastreams/audio_datastream.rb
@@ -96,7 +96,9 @@ class AudioDatastream < ActiveFedora::NtriplesRDFDatastream
       index.as :stored_searchable, :facetable
     end
 
-    map.publication_date({to: 'issued', in: RDF::DC})
+    map.publication_date({to: 'issued', in: RDF::DC}) do |index|
+      index.as :stored_searchable
+    end
 
     map.administrative_unit(to: 'creator#administrative_unit', in: RDF::QualifiedDC) do |index|
       index.as :stored_searchable, :facetable

--- a/app/repository_datastreams/dataset_metadata_datastream.rb
+++ b/app/repository_datastreams/dataset_metadata_datastream.rb
@@ -30,6 +30,10 @@ class DatasetMetadataDatastream < ActiveFedora::NtriplesRDFDatastream
       index.as :stored_searchable, :facetable
     end
 
+    map.publication_date({to: 'issued', in: RDF::DC}) do |index|
+      index.as :stored_searchable
+    end
+
     map.date_uploaded(to: "dateSubmitted", in: RDF::DC) do |index|
       index.type :date
       index.as :stored_sortable

--- a/app/repository_datastreams/document_datastream.rb
+++ b/app/repository_datastreams/document_datastream.rb
@@ -165,7 +165,9 @@ class DocumentDatastream < ActiveFedora::NtriplesRDFDatastream
       index.as :stored_searchable
     end
 
-    map.publication_date(to: 'issued', in: RDF::DC)
+    map.publication_date(to: 'issued', in: RDF::DC) do |index|
+      index.as :stored_searchable
+    end
 
     map.edition(to: 'isVersionOf#edition', in: RDF::QualifiedDC)
 

--- a/app/repository_datastreams/video_datastream.rb
+++ b/app/repository_datastreams/video_datastream.rb
@@ -94,7 +94,9 @@ class VideoDatastream < ActiveFedora::NtriplesRDFDatastream
       index.as :stored_searchable, :facetable
     end
 
-    map.publication_date({to: 'issued', in: RDF::DC})
+    map.publication_date({to: 'issued', in: RDF::DC}) do |index|
+      index.as :stored_searchable
+    end
 
     map.administrative_unit(to: 'creator#administrative_unit', in: RDF::QualifiedDC) do |index|
       index.as :stored_searchable, :facetable

--- a/app/views/curation_concern/articles/_article.html.erb
+++ b/app/views/curation_concern/articles/_article.html.erb
@@ -21,9 +21,9 @@
           <dt>Abstract:</dt>
           <dd class="readmore"><%= escape_html_for_solr_text(truncate(render_index_field_value(document: solr_doc, field: 'desc_metadata__abstract_tesim'), length: 500)).html_safe %></dd>
         <% end %>
-        <% if solr_doc.has?('desc_metadata__publication_date_ssm') %>
+        <% if solr_doc.has?('desc_metadata__publication_date_tesim') %>
           <dt>Date Published:</dt>
-          <dd><%= render_index_field_value(document: solr_doc, field: 'desc_metadata__publication_date_ssm') %></dd>
+          <dd><%= render_index_field_value(document: solr_doc, field: 'desc_metadata__publication_date_tesim') %></dd>
         <% end %>
       </dl>
 

--- a/app/views/curation_concern/audios/_audio.html.erb
+++ b/app/views/curation_concern/audios/_audio.html.erb
@@ -56,6 +56,10 @@
           <dt>Contributor(s):</dt>
           <dd><%= render_index_field_value(document: solr_doc, field: 'desc_metadata__contributor_tesim') %></dd>
         <% end %>
+        <% if solr_doc.has?('desc_metadata__publication_date_tesim') %>
+          <dt>Date Published:</dt>
+          <dd><%= render_index_field_value(document: solr_doc, field: 'desc_metadata__publication_date_tesim') %></dd>
+        <% end %>
 
       </dl>
 

--- a/app/views/curation_concern/datasets/_dataset.html.erb
+++ b/app/views/curation_concern/datasets/_dataset.html.erb
@@ -21,6 +21,10 @@
           <dt>Description:</dt>
           <dd class="readmore"><%= escape_html_for_solr_text(truncate(render_index_field_value(document: solr_doc, field: 'desc_metadata__description_tesim'), length: 500)).html_safe %></dd>
         <% end %>
+        <% if solr_doc.has?('desc_metadata__publication_date_tesim') %>
+          <dt>Date Published:</dt>
+          <dd><%= render_index_field_value(document: solr_doc, field: 'desc_metadata__publication_date_tesim') %></dd>
+        <% end %>
         <% if solr_doc.has?('desc_metadata__date_created_tesim') %>
           <dt>Date Created:</dt>
           <dd><%= render_index_field_value(document: solr_doc, field: 'desc_metadata__date_created_tesim') %></dd>

--- a/app/views/curation_concern/documents/_document.html.erb
+++ b/app/views/curation_concern/documents/_document.html.erb
@@ -34,6 +34,12 @@
           <dt>Abstract:</dt>
           <dd class="readmore"><%= escape_html_for_solr_text(truncate(render_index_field_value(document: solr_doc, field: 'desc_metadata__abstract_tesim'), length: 500)).html_safe %></dd>
         <% end %>
+
+        <% if solr_doc.has?('desc_metadata__publication_date_tesim') %>
+          <dt>Date Published:</dt>
+          <dd><%= render_index_field_value(document: solr_doc, field: 'desc_metadata__publication_date_tesim') %></dd>
+        <% end %>
+
         <% if solr_doc.has?('desc_metadata__date_created_tesim') %>
           <dt>Date Created:</dt>
           <dd><%= render_index_field_value(document: solr_doc, field: 'desc_metadata__date_created_tesim') %></dd>

--- a/app/views/curation_concern/videos/_video.html.erb
+++ b/app/views/curation_concern/videos/_video.html.erb
@@ -52,6 +52,10 @@
           <dt>Contributor(s):</dt>
           <dd><%= render_index_field_value(document: solr_doc, field: 'desc_metadata__contributor_tesim') %></dd>
         <% end %>
+        <% if solr_doc.has?('desc_metadata__publication_date_tesim') %>
+          <dt>Date Published:</dt>
+          <dd><%= render_index_field_value(document: solr_doc, field: 'desc_metadata__publication_date_tesim') %></dd>
+        <% end %>
 
       </dl>
 


### PR DESCRIPTION
Currently publication date is applicable to article, audio, video, dataset and documents only. changes involve only in associated work type. 