### PR TITLE
Fixing handling of collection URLs

### DIFF
--- a/app/services/catalog/collection_decorator.rb
+++ b/app/services/catalog/collection_decorator.rb
@@ -7,14 +7,24 @@ module Catalog
 
     def self.pid_from_scope(scope, delimiter: '/')
       return '' if scope.nil? || scope.empty?
-      slug = scope.split(delimiter).last
+      slug = split_scope(scope, delimiter: delimiter).last
       extract_id(slug)
     end
 
     def self.title_from_scope(scope, delimiter: '/')
       return '' if scope.nil? || scope.empty?
-      slug = scope.split(delimiter).last
+      slug = split_scope(scope, delimiter: delimiter).last
       extract_title(slug)
+    end
+
+    # @note I'm checking Hash in this case as the tests are very fast (and I don't want to load ActionController::Parameters for those tests)
+    # @see ./lib/curate/action_controller-parameters_spec.rb for assertion that ActionController::Parameters is a Hash
+    def self.split_scope(scope, delimiter: '/')
+      if scope.is_a?(Hash)
+        split_scope(scope.values.first, delimiter: delimiter)
+      else
+        scope.split(delimiter)
+      end
     end
 
     def self.extract_id(slug, delimiter: '|')

--- a/spec/lib/curate/action_controller-parameters_spec.rb
+++ b/spec/lib/curate/action_controller-parameters_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe ActionController::Parameters do
+  subject { ActionController::Parameters.new }
+  it 'is a Hash' do
+    # @note This is important for the behavior of ./app/services/catalog/collection_decorator.rb
+    expect(subject).to be_a(Hash)
+  end
+end

--- a/spec/services/catalog/collection_decorator_spec.rb
+++ b/spec/services/catalog/collection_decorator_spec.rb
@@ -22,6 +22,24 @@ module Catalog
         it { is_expected.to eq('und:1234') }
       end
 
+      context 'with a hash' do
+        let(:params) do
+          {
+            "action" => "index",
+            "controller" => "catalog",
+            "f" => {
+              "library_collections_pathnames_hierarchy_with_titles_sim" => {
+                "0" => "Institute for Latino Studies Sponsored Research and Publications Archive|und:j098z893451"
+              }
+            }
+          }
+        end
+        # Applying logic of app/services/catalog/search_splash_presenter.rb
+        let(:value) { [params['f']['library_collections_pathnames_hierarchy_with_titles_sim']].first }
+        subject { described_class.call(value, data_source: described_class::FakeAdapter) }
+        it { is_expected.to eq('und:j098z893451') }
+      end
+
       context 'with tile and embedded pid' do
         let(:single_slug) { 'Helpful Title|und:1337' }
         subject { described_class.call(single_slug, data_source: described_class::FakeAdapter) }


### PR DESCRIPTION
Prior to this fix, there were cases in which a Hash was passed to the
title/pid extractor. The code as written broke. This change handles that
case.

Closes DLTP-1028