### PR TITLE
Change the default primary key type for mysql2 gem

### DIFF
--- a/config/initializers/abstract_mysql2_adapter.rb
+++ b/config/initializers/abstract_mysql2_adapter.rb
@@ -1,0 +1,5 @@
+require 'active_record/connection_adapters/mysql2_adapter'
+
+class ActiveRecord::ConnectionAdapters::Mysql2Adapter
+  NATIVE_DATABASE_TYPES[:primary_key] = "int(11) auto_increment PRIMARY KEY"
+end


### PR DESCRIPTION
Unsure if this should go into the repository or not. but documenting what I needed to do to run `db:migrate` on my local machine, which is using MySQL 5.7.18 (the current homebrew version).

It seems that MySQL 5.7 enforces a non-NULL contraints on primary keys.
The version of the mysql gem we are using defaults to primary keys that
are NULL-able. I think this is only an issue when running migrations.

see https://github.com/brianmario/mysql2/issues/784