### PR TITLE
ORCID v2.0 update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # Ignore bundler config
 /.bundle
+/vendor/bundle
 
 # Ignore the default SQLite database.
 /db/*.sqlite3

--- a/Gemfile
+++ b/Gemfile
@@ -51,8 +51,6 @@ group :default do
   gem 'net-ldap'
   gem 'noids_client', git: 'git://github.com/ndlib/noids_client'
   gem 'nokogiri', "~>1.6.0"
-  #gem 'orcid', path: '../ndlib/orcid'
-  gem 'orcid', github: 'ndlib/orcid'
   gem 'qa'
   gem 'rails', '~>4.0.2'
   gem 'rails_autolink'
@@ -76,6 +74,16 @@ end
 
 group :headless do
   gem 'clamav'
+end
+
+group :orcid do
+  gem 'railties', '~> 4.0'
+  gem 'omniauth-orcid', '0.6'
+  gem 'mappy'
+  gem 'virtus'
+  gem 'email_validator'
+  gem 'omniauth-oauth2', '< 1.4'
+  gem 'hashie', '3.4.6'
 end
 
 # Hack to work around some bundler strangeness

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,23 +51,6 @@ GIT
       json (~> 1.8)
       rest-client (~> 1.6)
 
-GIT
-  remote: git://github.com/ndlib/orcid.git
-  revision: ee2106c6c5b6bc6b51cc37e9c5f96055521d3da9
-  specs:
-    orcid (0.9.1)
-      devise-multi_auth (~> 0.1)
-      email_validator
-      figaro
-      hashie (= 3.4.6)
-      mappy
-      nokogiri (= 1.6.8)
-      omniauth-oauth2 (< 1.4)
-      omniauth-orcid (= 0.6)
-      railties (~> 4.0)
-      simple_form
-      virtus
-
 GEM
   remote: https://rubygems.org/
   remote: https://rails-assets.org/
@@ -399,8 +382,8 @@ GEM
       activesupport (>= 3.2.18)
       i18n
       nokogiri
-    oauth2 (1.3.1)
-      faraday (>= 0.8, < 0.12)
+    oauth2 (1.4.0)
+      faraday (>= 0.8, < 0.13)
       jwt (~> 1.0)
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
@@ -716,10 +699,12 @@ DEPENDENCIES
   devise-multi_auth!
   devise_cas_authenticatable
   devise_masquerade
+  email_validator
   factory_girl_rails (~> 4.2.0)
   figaro
   flipper
   harbinger!
+  hashie (= 3.4.6)
   httparty
   hydra-batch-edit (~> 1.1.1)
   hydra-collections (~> 1.3.0)
@@ -736,6 +721,7 @@ DEPENDENCIES
   lograge
   logstash-event
   logstash-logger
+  mappy
   meta_request
   method_locator
   method_source
@@ -746,7 +732,8 @@ DEPENDENCIES
   net-ldap
   noids_client!
   nokogiri (~> 1.6.0)
-  orcid!
+  omniauth-oauth2 (< 1.4)
+  omniauth-orcid (= 0.6)
   poltergeist (~> 1.5)
   qa
   quiet_assets
@@ -756,6 +743,7 @@ DEPENDENCIES
   rails-erb-lint
   rails_autolink
   rails_best_practices
+  railties (~> 4.0)
   rake (~> 11.0)
   redcarpet
   resque-pool
@@ -786,4 +774,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.14.6
+   1.15.4

--- a/app/controllers/orcid/application_controller.rb
+++ b/app/controllers/orcid/application_controller.rb
@@ -1,0 +1,30 @@
+module Orcid
+  # The foundation for Orcid controllers. A few helpful accessors.
+  class ApplicationController < Orcid.parent_controller.constantize
+    # Providing a mechanism for overrding the default path in an implementing
+    # application
+    def path_for(named_path, *args)
+      return send(named_path, *args).to_s if respond_to?(named_path)
+      yield(*args)
+    end
+
+    private
+
+    def redirecting_because_user_has_connected_orcid_profile
+      if orcid_profile
+        flash[:notice] = I18n.t(
+          'orcid.requests.messages.previously_connected_profile',
+          orcid_profile_id: orcid_profile.orcid_profile_id
+        )
+        redirect_to path_for(:orcid_settings_path) { main_app.root_path }
+        return true
+      else
+        return false
+      end
+    end
+
+    def orcid_profile
+      @orcid_profile ||= Orcid.profile_for(current_user)
+    end
+  end
+end

--- a/app/controllers/orcid/create_profile_controller.rb
+++ b/app/controllers/orcid/create_profile_controller.rb
@@ -13,7 +13,6 @@ module Orcid
 
       unless Orcid.auth_user_with_code(params[:code], current_user) then
         flash[:error] = "Something went wrong when trying to retrieve your ORCID iD. Please try again later."
-        logger.error "Error retrieving ORCID iD: #{response.body}"
       end
 
       redirect_to(orcid_settings_path)

--- a/app/controllers/orcid/create_profile_controller.rb
+++ b/app/controllers/orcid/create_profile_controller.rb
@@ -1,0 +1,24 @@
+require 'net/http'
+module Orcid
+  class CreateProfileController < Orcid::ApplicationController
+    respond_to :html
+    before_filter :authenticate_user!
+
+    def create
+      uri = URI.parse(Orcid.provider.token_url)
+
+      request = Net::HTTP::Post.new(uri)
+      request["Accept"] = "application/json"
+      request.set_form_data( "client_id" => ENV['ORCID_APP_ID'],
+           "client_secret" => ENV['ORCID_APP_SECRET'],
+           "grant_type" => "authorization_code",
+           "code" => params[:code],
+           "redirect_uri" => config.application_root_url ) 
+      response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == "https") do |http|
+        http.request(request)
+      end
+
+      redirect_to(user_omniauth_authorize_path(:orcid))
+    end
+  end
+end

--- a/app/controllers/orcid/profile_connections_controller.rb
+++ b/app/controllers/orcid/profile_connections_controller.rb
@@ -1,0 +1,85 @@
+module Orcid
+  # Responsible for negotiating a user request Profile Creation.
+  #
+  # @TODO - Leverage the Orcid::ProfileStatus object instead of the really
+  # chatty method names. The method names are fine, but the knowledge of
+  # Orcid::ProfileStatus is encapsulated in that class.
+  class ProfileConnectionsController < Orcid::ApplicationController
+    respond_to :html
+    before_filter :authenticate_user!
+
+    def index
+      redirecting_because_user_does_not_have_a_connected_orcid_profile ||
+        redirecting_because_user_must_verify_their_connected_profile ||
+        redirecting_because_user_has_verified_their_connected_profile
+    end
+
+    def new
+      return false if redirecting_because_user_has_connected_orcid_profile
+      assign_attributes(new_profile_connection)
+      respond_with(new_profile_connection)
+    end
+
+    def create
+      return false if redirecting_because_user_has_connected_orcid_profile
+      assign_attributes(new_profile_connection)
+      create_profile_connection(new_profile_connection)
+      respond_with(new_profile_connection)
+    end
+
+    SUCCESS_NOTICE = "You have been disconnected from your ORCID record."
+    def destroy
+      Orcid.disconnect_user_and_orcid_profile(current_user)
+      redirect_to root_path, notice: SUCCESS_NOTICE
+    end
+
+    protected
+
+    attr_reader :profile_connection
+    helper_method :profile_connection
+
+    def assign_attributes(profile_connection)
+      profile_connection.attributes = profile_connection_params
+      profile_connection.user = current_user
+    end
+
+    def profile_connection_params
+      params[:profile_connection] || {}
+    end
+
+    def create_profile_connection(profile_connection)
+      profile_connection.save
+    end
+
+    def new_profile_connection
+      @profile_connection ||= begin
+        Orcid::ProfileConnection.new(params[:profile_connection])
+      end
+    end
+
+    def redirecting_because_user_does_not_have_a_connected_orcid_profile
+      return false if orcid_profile
+      flash[:notice] = I18n.t(
+        'orcid.connections.messages.profile_connection_not_found'
+      )
+      redirect_to orcid_new_profile_connection_path
+    end
+
+    def redirecting_because_user_must_verify_their_connected_profile
+      return false unless orcid_profile
+      return false if orcid_profile.verified_authentication?
+
+      redirect_to user_omniauth_authorize_url('orcid')
+    end
+
+    def redirecting_because_user_has_verified_their_connected_profile
+      orcid_profile = Orcid.profile_for(current_user)
+      notice = I18n.t(
+        'orcid.connections.messages.verified_profile_connection_exists',
+        orcid_profile_id: orcid_profile.orcid_profile_id
+      )
+      location = path_for(:orcid_settings_path) { main_app.root_path }
+      redirect_to(location, flash: { notice: notice })
+    end
+  end
+end

--- a/app/helpers/orcid/on_demand_url_helper.rb
+++ b/app/helpers/orcid/on_demand_url_helper.rb
@@ -1,0 +1,15 @@
+module Orcid::OnDemandUrlHelper
+  def on_demand_url(user)
+    connector_params = {
+      client_id: ENV['ORCID_APP_ID'],
+      response_type: 'code',
+      scope: Orcid.provider.authentication_scope,
+      redirect_uri: create_orcid_url,
+      family_names: (user.last_name if user.respond_to? :last_name),
+      given_names: (user.first_name if user.respond_to? :first_name),
+      email: user.email
+    }
+
+    "#{Orcid.provider.authorize_url}?#{connector_params.to_query}"
+  end
+end

--- a/app/models/orcid/profile.rb
+++ b/app/models/orcid/profile.rb
@@ -1,0 +1,71 @@
+module Orcid
+  # Provides a container around an Orcid Profile and its relation to the Orcid
+  # Works.
+  class Profile
+    attr_reader :orcid_profile_id, :mapper, :remote_service, :xml_renderer, :xml_parser
+    private :mapper, :remote_service, :xml_renderer, :xml_parser
+    def initialize(orcid_profile_id, collaborators = {})
+      @orcid_profile_id = orcid_profile_id
+      @mapper = collaborators.fetch(:mapper) { default_mapper }
+      @remote_service = collaborators.fetch(:remote_service) { default_remote_service }
+      @xml_renderer = collaborators.fetch(:xml_renderer) { default_xml_renderer }
+      @xml_parser = collaborators.fetch(:xml_parser) { default_xml_parser }
+    end
+
+    # Answers the question: Has the user been authenticated via the ORCID
+    # system.
+    #
+    # @TODO - Extract this to the Orcid::ProfileStatus object. As the method
+    # is referenced via a controller, this can easily be moved.
+    def verified_authentication?
+      Orcid.authenticated_orcid?(orcid_profile_id)
+    end
+
+    def remote_works(options = {})
+      @remote_works = nil if options.fetch(:force, false)
+      @remote_works ||= begin
+        response = remote_service.call(orcid_profile_id, request_method: :get)
+        xml_parser.call(response)
+      end
+    end
+
+    def append_new_work(*works)
+      request_work_changes_via(:post, *works)
+    end
+
+    def replace_works_with(*works)
+      request_work_changes_via(:put, *works)
+    end
+
+    protected
+
+    def request_work_changes_via(request_method, *works)
+      orcid_works = normalize_work(*works)
+      xml = xml_renderer.call(orcid_works)
+      remote_service.call(orcid_profile_id, request_method: request_method, body: xml)
+    end
+
+    def default_mapper
+      Orcid.mapper
+    end
+
+    def default_remote_service
+      Orcid::Remote::WorkService
+    end
+
+    def default_xml_renderer
+      Orcid::Work::XmlRenderer
+    end
+
+    def default_xml_parser
+      Orcid::Work::XmlParser
+    end
+
+    # Note: We can handle
+    def normalize_work(*works)
+      Array.wrap(works).map do |work|
+        mapper.map(work, target: 'orcid/work')
+      end
+    end
+  end
+end

--- a/app/models/orcid/profile_connection.rb
+++ b/app/models/orcid/profile_connection.rb
@@ -1,0 +1,94 @@
+require 'virtus'
+require 'active_model'
+module Orcid
+  # Responsible for connecting an authenticated user to the ORCID profile that
+  # the user searched for and selected.
+  class ProfileConnection
+    include Virtus.model
+    include ActiveModel::Validations
+    include ActiveModel::Conversion
+    extend ActiveModel::Naming
+
+    # See: http://support.orcid.org/knowledgebase/articles/132354-tutorial-searching-with-the-api
+    class_attribute :available_query_attribute_names
+    self.available_query_attribute_names = [:text]
+
+    available_query_attribute_names.each do |attribute_name|
+      attribute attribute_name
+    end
+
+    attribute :orcid_profile_id
+    attribute :user
+
+    validates :user, presence: true
+    validates :orcid_profile_id, presence: true
+
+    def save
+      valid? ? persister.call(user, orcid_profile_id) : false
+    end
+
+    def persisted?
+      false
+    end
+
+    attr_writer :persister
+    def persister
+      @persister ||= default_persister
+    end
+    private :persister
+
+    def default_persister
+      require 'orcid'
+      Orcid.method(:connect_user_and_orcid_profile)
+    end
+
+    attr_writer :profile_query_service
+    def profile_query_service
+      @profile_query_service ||= default_profile_query_service
+    end
+    private :profile_query_service
+
+    def default_profile_query_service
+      Remote::ProfileQueryService.new do |on|
+        on.found { |results| self.orcid_profile_candidates = results }
+        on.not_found { self.orcid_profile_candidates = [] }
+      end
+    end
+    private :default_profile_query_service
+
+    def with_orcid_profile_candidates
+      yield(orcid_profile_candidates) if query_requested?
+    end
+
+    attr_writer :orcid_profile_candidates
+    private :orcid_profile_candidates=
+    def orcid_profile_candidates
+      @orcid_profile_candidates || lookup_profile_candidates
+    end
+
+    def lookup_profile_candidates
+      profile_query_service.call(query_attributes) if query_requested?
+    end
+    private :lookup_profile_candidates
+
+    def query_requested?
+      available_query_attribute_names.any? do |attribute_name|
+        attributes[attribute_name].present?
+      end
+    end
+    private :query_requested?
+
+    def query_attributes
+      available_query_attribute_names.each_with_object({}) do |name, mem|
+        orcid_formatted_name = convert_attribute_name_to_orcid_format(name)
+        mem[orcid_formatted_name] = attributes.fetch(name)
+        mem
+      end
+    end
+
+    def convert_attribute_name_to_orcid_format(name)
+      name.to_s.gsub(/_+/, '-')
+    end
+    private :convert_attribute_name_to_orcid_format
+  end
+end

--- a/app/models/orcid/profile_request.rb
+++ b/app/models/orcid/profile_request.rb
@@ -1,0 +1,41 @@
+module Orcid
+  # Responsible for:
+  # * acknowledging that an ORCID Profile was requested
+  # * submitting a request for an ORCID Profile
+  # * handling the response for the ORCID Profile creation
+  class ProfileRequest < ActiveRecord::Base
+    ERROR_STATUS = 'error'.freeze
+    def self.find_by_user(user)
+      where(user: user).first
+    end
+
+    self.table_name = :orcid_profile_requests
+
+    alias_attribute :email, :primary_email
+    validates :user_id, presence: true, uniqueness: true
+    validates :given_names, presence: true
+    validates :family_name, presence: true
+    validates :primary_email, presence: true, email: true, confirmation: true
+
+    belongs_to :user
+
+    def successful_profile_creation(orcid_profile_id)
+      self.class.transaction do
+        update_column(:orcid_profile_id, orcid_profile_id)
+        Orcid.connect_user_and_orcid_profile(user, orcid_profile_id)
+      end
+    end
+
+    def error_on_profile_creation(error_message)
+      update_column(:response_text, error_message)
+      update_column(:response_status, ERROR_STATUS)
+    end
+
+    alias_attribute :error_message, :response_text
+
+    def error_on_profile_creation?
+      error_message.present? || response_status == ERROR_STATUS
+    end
+
+  end
+end

--- a/app/models/orcid/profile_status.rb
+++ b/app/models/orcid/profile_status.rb
@@ -1,0 +1,77 @@
+module Orcid
+  # Responsible for determining a given user's orcid profile state as it
+  # pertains to the parent application.
+  #
+  # @TODO - There are quite a few locations where the state related behavior
+  # has leaked out (i.e. the Orcid::ProfileConnectionsController and Orcid::
+  # ProfileRequestsController)
+  #
+  # ProfileStatus.status
+  # **:authenticated_connection** - User has authenticated against the Orcid
+  #   remote system
+  # **:pending_connection** - User has indicated there is a connection, but has
+  #   not authenticated against the Orcid remote system
+  # **:profile_request_pending** - User has requested a profile be created on
+  #   their behalf
+  # **:unknown** - None of the above
+  class ProfileStatus
+    def self.for(user, collaborators = {}, &block)
+      new(user, collaborators, &block).status
+    end
+
+    attr_reader :user, :profile_finder, :request_finder, :callback_handler
+
+    def initialize(user, collaborators = {})
+      @user = user
+      @profile_finder = collaborators.fetch(:profile_finder) { default_profile_finder }
+      @request_finder = collaborators.fetch(:request_finder) { default_request_finder }
+      @callback_handler = collaborators.fetch(:callback_handler) { default_callback_handler }
+      yield(callback_handler) if block_given?
+    end
+
+    def status
+      return callback(:unknown) if user.nil?
+      profile = profile_finder.call(user)
+      if profile
+        if profile.verified_authentication?
+          return callback(:authenticated_connection, profile)
+        else
+          return callback(:pending_connection, profile)
+        end
+      else
+        request = request_finder.call(user)
+        if request
+          if request.error_on_profile_creation?
+            return callback(:profile_request_in_error, request)
+          else
+            return callback(:profile_request_pending, request)
+          end
+        else
+          return callback(:unknown)
+        end
+      end
+    end
+
+    private
+
+    def callback(name, *args)
+      callback_handler.call(name, *args)
+      name
+    end
+
+    def default_callback_handler
+      require 'orcid/named_callbacks'
+      NamedCallbacks.new
+    end
+
+    def default_profile_finder
+      require 'orcid'
+      Orcid.method(:profile_for)
+    end
+
+    def default_request_finder
+      require 'orcid/profile_request'
+      ProfileRequest.method(:find_by_user)
+    end
+  end
+end

--- a/app/models/orcid/work.rb
+++ b/app/models/orcid/work.rb
@@ -1,0 +1,80 @@
+module Orcid
+  # A well-defined data structure that coordinates with its :template in order
+  # to generate XML that can be POSTed/PUT as an Orcid Work.
+  class Work
+    VALID_WORK_TYPES =
+    %w(artistic-performance book-chapter book-review book
+       conference-abstract conference-paper conference-poster
+       data-set dictionary-entry disclosure dissertation
+       edited-book encyclopedia-entry invention journal-article
+       journal-issue lecture-speech license magazine-article
+       manual newsletter-article newspaper-article online-resource
+       other patent registered-copyright report research-technique
+       research-tool spin-off-company standards-and-policy
+       supervised-student-publication technical-standard test
+       translation trademark website working-paper
+       ).freeze
+
+    # An Orcid Work's external identifier is not represented in a single
+    # attribute.
+    class ExternalIdentifier
+      include Virtus.value_object
+      values do
+        attribute :type,  String
+        attribute :identifier, String
+      end
+    end
+
+    include Virtus.model
+    include ActiveModel::Validations
+    extend ActiveModel::Naming
+
+    attribute :title, String
+    validates :title, presence: true
+
+    attribute :work_type, String
+    validates :work_type, presence: true, inclusion: { in: VALID_WORK_TYPES }
+
+    attribute :subtitle, String
+    attribute :journal_title, String
+    attribute :short_description, String
+    attribute :citation_type, String
+    attribute :citation, String
+    attribute :publication_year, Integer
+    attribute :publication_month, Integer
+    attribute :url, String
+    attribute :language_code, String
+    attribute :country, String
+    attribute :put_code, String
+    attribute :external_identifiers, Array[ExternalIdentifier]
+
+    def work_citation?
+      citation_type.present? || citation.present?
+    end
+
+    def publication_date?
+      publication_year.present? || publication_month.present?
+    end
+
+    def to_xml
+      XmlRenderer.call(self)
+    end
+
+    def ==(other)
+      super ||
+        other.instance_of?(self.class) &&
+        id.present? &&
+        other.id == id
+    end
+
+    def id
+      if put_code.present?
+        put_code
+      elsif title.present? && work_type.present?
+        [title, work_type]
+      else
+        nil
+      end
+    end
+  end
+end

--- a/app/models/orcid/work/xml_parser.rb
+++ b/app/models/orcid/work/xml_parser.rb
@@ -1,0 +1,45 @@
+module Orcid
+  class Work
+    # Responsible for taking an Orcid Work and extracting the value/text from
+    # the document and reifying an Orcid::Work object.
+    class XmlParser
+      def self.call(xml)
+        new(xml).call
+      end
+
+      attr_reader :xml
+      def initialize(xml)
+        @xml = xml
+      end
+
+      def call
+        document.css('orcid-works orcid-work').map do |node|
+          transform(node)
+        end
+      end
+
+      private
+
+      def document
+        @document ||= Nokogiri::XML.parse(xml)
+      end
+
+      def transform(node)
+        Work.new.tap do |work|
+          work.put_code = node.attributes.fetch('put-code').value
+          work.title = node.css('work-title title').text
+          work.work_type = node.css('work-type').text
+          work.journal_title = node.css('journal-title').text
+          work.short_description = node.css('short-description').text
+          work.citation_type = node.css('work-citation work-citation-type').text
+          work.citation = node.css('work-citation citation').text
+          work.publication_year = node.css('publication-date year').text
+          work.publication_month = node.css('publication-date month').text
+          work.url = node.css('url').text
+          work.language_code = node.css('language_code').text
+          work.country = node.css('country').text
+        end
+      end
+    end
+  end
+end

--- a/app/models/orcid/work/xml_renderer.rb
+++ b/app/models/orcid/work/xml_renderer.rb
@@ -1,0 +1,31 @@
+module Orcid
+  class Work
+    # Responsible for transforming a Work into an Orcid Work XML document
+    class XmlRenderer
+      def self.call(works, collaborators = {})
+        new(works, collaborators).call
+      end
+
+      attr_reader :works, :template
+      def initialize(works, collaborators = {})
+        self.works = works
+        @template = collaborators.fetch(:template) { default_template }
+      end
+
+      def call
+        ERB.new(template).result(binding)
+      end
+
+      protected
+
+      def works=(thing)
+        @works = Array.wrap(thing)
+      end
+
+      def default_template
+        template_name = 'app/templates/orcid/work.template.v1.2.xml.erb'
+        Orcid::Engine.root.join(template_name).read
+      end
+    end
+  end
+end

--- a/app/services/orcid/remote/profile_creation_service.rb
+++ b/app/services/orcid/remote/profile_creation_service.rb
@@ -1,0 +1,65 @@
+require 'orcid/remote/service'
+require 'oauth2/error'
+require 'nokogiri'
+module Orcid
+  module Remote
+    # Responsible for minting a new ORCID for the given payload.
+    class ProfileCreationService < Orcid::Remote::Service
+      def self.call(payload, config = {}, &callback_config)
+        new(config, &callback_config).call(payload)
+      end
+
+      attr_reader :token, :path, :headers
+      def initialize(config = {}, &callback_config)
+        super(&callback_config)
+        @token = config.fetch(:token) { default_token }
+        @path = config.fetch(:path) { 'v1.1/orcid-profile' }
+        @headers = config.fetch(:headers) { default_headers }
+      end
+
+      def call(payload)
+        response = deliver(payload)
+        parse(response)
+      rescue ::OAuth2::Error => e
+        parse_exception(e)
+      end
+
+      protected
+
+      def deliver(body)
+        token.post(path, body: body, headers: headers)
+      end
+
+      def parse(response)
+        uri = URI.parse(response.headers.fetch(:location))
+        orcid_profile_id = uri.path.sub(/\A\//, '').split('/').first
+        if orcid_profile_id
+          callback(:success, orcid_profile_id)
+          orcid_profile_id
+        else
+          callback(:failure)
+          false
+        end
+      end
+
+      def parse_exception(exception)
+        doc = Nokogiri::XML.parse(exception.response.body)
+        error_text = doc.css('error-desc').text
+        if error_text.to_s.size > 0
+          callback(:orcid_validation_error, error_text)
+          false
+        else
+          fail exception
+        end
+      end
+
+      def default_headers
+        { 'Accept' => 'application/xml', 'Content-Type' => 'application/vdn.orcid+xml' }
+      end
+
+      def default_token
+        Orcid.client_credentials_token('/orcid-profile/create')
+      end
+    end
+  end
+end

--- a/app/services/orcid/remote/profile_query_service.rb
+++ b/app/services/orcid/remote/profile_query_service.rb
@@ -1,0 +1,60 @@
+require_dependency 'json'
+require 'orcid/remote/service'
+module Orcid
+  module Remote
+    # Responsible for querying Orcid to find various ORCiDs
+    class ProfileQueryService < Orcid::Remote::Service
+      def self.call(query, config = {}, &callbacks)
+        new(config, &callbacks).call(query)
+      end
+
+      attr_reader :token, :path, :headers, :response_builder, :query_builder
+      attr_reader :parser
+      def initialize(config = {}, &callbacks)
+        super(&callbacks)
+        @query_builder = config.fetch(:query_parameter_builder) { QueryParameterBuilder }
+        @token = config.fetch(:token) { default_token }
+        @parser = config.fetch(:parser) { ResponseParser }
+        @path = config.fetch(:path) { 'v1.2/search/orcid-bio/' }
+        @headers = config.fetch(:headers) { default_headers }
+      end
+
+      def call(input)
+        parameters = query_builder.call(input)
+        response = deliver(parameters)
+        parsed_response = parse(response.body)
+        issue_callbacks(parsed_response)
+        parsed_response
+      end
+      alias_method :search, :call
+
+      protected
+
+      def default_token
+        Orcid.client_credentials_token('/read-public')
+      end
+
+      def default_headers
+        { :accept => 'application/orcid+json', 'Content-Type' => 'application/orcid+xml' }
+      end
+
+      def issue_callbacks(search_results)
+        if Array.wrap(search_results).any?(&:present?)
+          callback(:found, search_results)
+        else
+          callback(:not_found)
+        end
+      end
+
+      attr_reader :host, :access_token
+      def deliver(parameters)
+        token.get(path, headers: headers, params: parameters)
+      end
+
+      def parse(document)
+        parser.call(document)
+      end
+
+    end
+  end
+end

--- a/app/services/orcid/remote/profile_query_service/query_parameter_builder.rb
+++ b/app/services/orcid/remote/profile_query_service/query_parameter_builder.rb
@@ -1,0 +1,43 @@
+require_dependency 'orcid/remote/profile_query_service'
+module Orcid
+  module Remote
+    class ProfileQueryService
+      # http://support.orcid.org/knowledgebase/articles/132354-searching-with-the-public-api
+      module QueryParameterBuilder
+
+        module_function
+        # Responsible for converting an arbitrary query string to the acceptable
+        # Orcid query format.
+        #
+        # @TODO - Note this is likely not correct, but is providing the singular
+        # point of entry
+        def call(input = {})
+          params = {}
+          q_params = []
+          text_params = []
+          input.each do |key, value|
+            next if value.nil? || value.to_s.strip == ''
+            case key.to_s
+            when 'start', 'row'
+              params[key] = value
+            when 'q', 'text'
+              text_params << "#{value}"
+            else
+              q_params << "#{key.to_s.gsub('_', '-')}:#{value}"
+            end
+          end
+
+          case text_params.size
+          when 0; then nil
+          when 1
+            q_params << "text:#{text_params.first}"
+          else
+            q_params << "text:((#{text_params.join(') AND (')}))"
+          end
+          params[:q] = q_params.join(' AND ')
+          params
+        end
+      end
+    end
+  end
+end

--- a/app/services/orcid/remote/profile_query_service/response_parser.rb
+++ b/app/services/orcid/remote/profile_query_service/response_parser.rb
@@ -1,0 +1,78 @@
+require_dependency 'orcid/remote/profile_query_service'
+module Orcid
+  module Remote
+    class ProfileQueryService
+      # Responsible for parsing a response document
+      class ResponseParser
+
+        # A convenience method to expose entry into the ResponseParser function
+        def self.call(document, collaborators = {})
+          new(collaborators).call(document)
+        end
+
+        attr_reader :response_builder, :logger
+        private :response_builder, :logger
+        def initialize(collaborators = {})
+          @response_builder = collaborators.fetch(:response_builder) { default_response_builder }
+          @logger = collaborators.fetch(:logger) { default_logger }
+        end
+
+        def call(document)
+          json = JSON.parse(document)
+          json.fetch('orcid-search-results').fetch('orcid-search-result')
+          .each_with_object([]) do |result, returning_value|
+            profile = result.fetch('orcid-profile')
+            begin
+              identifier = extract_identifier(profile)
+              label = extract_label(identifier, profile)
+              biography = extract_biography(profile)
+              returning_value << response_builder.new('id' => identifier, 'label' => label, 'biography' => biography)
+            rescue KeyError => e
+              logger.warn("Unexpected ORCID JSON Response, part of the response has been ignored.\tException Encountered:#{e.class}\t#{e}")
+            end
+            returning_value
+          end
+        end
+
+        private
+        def extract_identifier(profile)
+          profile.fetch('orcid-identifier').fetch('path')
+        end
+
+        def extract_label(identifier, profile)
+          orcid_bio = profile.fetch('orcid-bio')
+          given_names = orcid_bio.fetch('personal-details').fetch('given-names').fetch('value')
+          # family name is not a required field on orcid record
+          family_name = orcid_bio.try(:[], 'personal-details').try(:[], 'family-name').try(:[], 'value')
+          emails = []
+          contact_details = orcid_bio['contact-details']
+          if contact_details
+            emails = (contact_details['email'] || []).map {|email| email.fetch('value') }
+          end
+          label = "#{given_names} #{family_name}"
+          label << ' (' << emails.join(', ') << ')' if emails.any?
+          label << " [ORCID: #{identifier}]"
+          label << " <a class=\"orcid-profile-id\" target=\"_blank\" href=\"#{ Orcid.url_for_orcid_id(identifier)}\"> Look Up Orcid Profile</a>"
+          label.html_safe
+        end
+
+        def extract_biography(profile)
+          orcid_bio = profile.fetch('orcid-bio')
+          if orcid_bio['biography']
+            orcid_bio['biography'].fetch('value')
+          else
+            ''
+          end
+        end
+
+        def default_logger
+          Rails.logger
+        end
+
+        def default_response_builder
+          SearchResponse
+        end
+      end
+    end
+  end
+end

--- a/app/services/orcid/remote/profile_query_service/search_response.rb
+++ b/app/services/orcid/remote/profile_query_service/search_response.rb
@@ -1,0 +1,31 @@
+require_dependency 'orcid/remote/profile_query_service'
+module Orcid
+  module Remote
+    class ProfileQueryService
+      # A search response against Orcid. This should implement the Questioning
+      # Authority query response object interface.
+      class SearchResponse
+        delegate :[], :has_key?, :key?, :fetch, to: :@records
+        def initialize(attributes = {})
+          @attributes = attributes.with_indifferent_access
+        end
+
+        def id
+          @attributes.fetch(:id)
+        end
+
+        def orcid_profile_id
+          @attributes.fetch(:id)
+        end
+
+        def label
+          @attributes.fetch(:label)
+        end
+
+        def biography
+          @attributes.fetch(:biography)
+        end
+      end
+    end
+  end
+end

--- a/app/services/orcid/remote/service.rb
+++ b/app/services/orcid/remote/service.rb
@@ -1,0 +1,22 @@
+require 'orcid/named_callbacks'
+module Orcid
+  module Remote
+    # An abstract service class, responsible for making remote calls and
+    # issuing a callback.
+    class Service
+      def initialize
+        @callbacks = Orcid::NamedCallbacks.new
+        yield(@callbacks) if block_given?
+      end
+
+      def call
+        fail NotImplementedError, ("Define #{self.class}#call")
+      end
+
+      def callback(name, *args)
+        @callbacks.call(name, *args)
+        args
+      end
+    end
+  end
+end

--- a/app/services/orcid/remote/work_service.rb
+++ b/app/services/orcid/remote/work_service.rb
@@ -1,0 +1,64 @@
+require 'orcid/exceptions'
+module Orcid
+  module Remote
+    # Responsible for interacting with the Orcid works endpoint
+    class WorkService
+      def self.call(orcid_profile_id, options = {})
+        new(orcid_profile_id, options).call
+      end
+
+      attr_reader(
+        :headers, :token, :orcid_profile_id, :body, :request_method, :path
+      )
+      def initialize(orcid_profile_id, options = {})
+        @orcid_profile_id = orcid_profile_id
+        @request_method = options.fetch(:request_method) { :get }
+        @body = options.fetch(:body) { '' }
+        @token = options.fetch(:token) { default_token }
+        @headers = options.fetch(:headers) { default_headers }
+        @path = options.fetch(:path) { default_path }
+      end
+
+      # :post will append works to the Orcid Profile
+      # :put will replace the existing Orcid Profile works with the payload
+      # :get will retrieve the Orcid Profile
+      # http://support.orcid.org/knowledgebase/articles/177528-add-works-technical-developer
+      def call
+        response = deliver
+        response.body
+      end
+
+      protected
+
+      def deliver
+        token.request(request_method, path, body: body, headers: headers)
+      rescue OAuth2::Error => e
+        handle_oauth_error(e)
+      end
+
+      def handle_oauth_error(e)
+        fail Orcid::RemoteServiceError,
+             response_body:    e.response.body,
+             response_status:  e.response.status,
+             client:           token.client,
+             token:            token,
+             request_method:   request_method,
+             request_path:     path,
+             request_body:     body,
+             request_headers:  headers
+      end
+
+      def default_token
+        Orcid.access_token_for(orcid_profile_id)
+      end
+
+      def default_headers
+        { 'Accept' => 'application/xml', 'Content-Type' => 'application/orcid+xml' }
+      end
+
+      def default_path
+        "v1.2/#{orcid_profile_id}/orcid-works/"
+      end
+    end
+  end
+end

--- a/app/views/orcid/profile_connections/_authenticated_connection.html.erb
+++ b/app/views/orcid/profile_connections/_authenticated_connection.html.erb
@@ -1,0 +1,4 @@
+<div class="authenticated-connection">
+  <%= t('orcid.views.authenticated_connection', orcid_profile_url: Orcid.url_for_orcid_id(authenticated_connection.orcid_profile_id), orcid_profile_id: authenticated_connection.orcid_profile_id).html_safe %>
+  <%= render partial: 'orcid/profile_connections/orcid_disconnector' %>
+</div>

--- a/app/views/orcid/profile_connections/_options_to_connect_orcid_profile.html.erb
+++ b/app/views/orcid/profile_connections/_options_to_connect_orcid_profile.html.erb
@@ -7,17 +7,4 @@
       Create or Connect your ORCID iD
     </a>
   </p>
-  <p>
-    <%= link_to t('orcid/profile_connection.look_up_your_existing_orcid', scope: 'helpers.label'), "#{Orcid.provider.search_url}?searchQuery=#{default_search_text}", target: :_blank %>
-  </p>
-  <p>
-    <%= form_for(profile_connection, as: :profile_connection, url: profile_connections_path, method: :post) do |f| %>
-      <%# Note the `scope: 'helpers.label'` option is the default for the label, but I want to call those specifically out %>
-      <%= f.label :orcid_profile_id, t('orcid/profile_connection.orcid_profile_id', scope: 'helpers.label') %>
-      <%= f.text_field :orcid_profile_id, class:"orcid-input" %>
-      <button type="submit" class="search-submit btn btn-primary" id="keyword-search-submit" tabindex="2">
-        <span class="orcid-connect"><%= t('orcid/profile_connection.connect_button_text', scope: 'helpers.label') %></span>
-      </button>
-    <% end %>
-  </p>
 </div>

--- a/app/views/orcid/profile_connections/_options_to_connect_orcid_profile.html.erb
+++ b/app/views/orcid/profile_connections/_options_to_connect_orcid_profile.html.erb
@@ -8,7 +8,7 @@
     </a>
   </p>
   <p>
-    <%= link_to t('orcid/profile_connection.look_up_your_existing_orcid', scope: 'helpers.label', target: :_blank), new_profile_connection_path(profile_connection:{text: default_search_text}) %>
+    <%= link_to t('orcid/profile_connection.look_up_your_existing_orcid', scope: 'helpers.label'), "#{Orcid.provider.search_url}?searchQuery=#{default_search_text}", target: :_blank %>
   </p>
   <p>
     <%= form_for(profile_connection, as: :profile_connection, url: profile_connections_path, method: :post) do |f| %>

--- a/app/views/orcid/profile_connections/_options_to_connect_orcid_profile.html.erb
+++ b/app/views/orcid/profile_connections/_options_to_connect_orcid_profile.html.erb
@@ -2,7 +2,7 @@
 <% default_search_text = '' unless defined?(default_search_text) %>
 <div class="options-to-connect-orcid-profile">
   <p>
-    <a id="connect-orcid-link" class="btn btn-default" target="_blank" href= <%=on_demand_url(current_user)%>>
+    <a id="connect-orcid-link" class="btn btn-default" href= <%= on_demand_url(current_user)%>>
       <img id="orcid-id-logo" src="http://orcid.org/sites/default/files/images/orcid_16x16.png" width='16' height='16' alt="ORCID logo"/>
       Create or Connect your ORCID iD
     </a>

--- a/app/views/orcid/profile_connections/_options_to_connect_orcid_profile.html.erb
+++ b/app/views/orcid/profile_connections/_options_to_connect_orcid_profile.html.erb
@@ -1,0 +1,23 @@
+<% profile_connection = Orcid::ProfileConnection.new %>
+<% default_search_text = '' unless defined?(default_search_text) %>
+<div class="options-to-connect-orcid-profile">
+  <p>
+    <a id="connect-orcid-link" class="btn btn-default" target="_blank" href= <%=on_demand_url(current_user)%>>
+      <img id="orcid-id-logo" src="http://orcid.org/sites/default/files/images/orcid_16x16.png" width='16' height='16' alt="ORCID logo"/>
+      Create or Connect your ORCID iD
+    </a>
+  </p>
+  <p>
+    <%= link_to t('orcid/profile_connection.look_up_your_existing_orcid', scope: 'helpers.label', target: :_blank), new_profile_connection_path(profile_connection:{text: default_search_text}) %>
+  </p>
+  <p>
+    <%= form_for(profile_connection, as: :profile_connection, url: profile_connections_path, method: :post) do |f| %>
+      <%# Note the `scope: 'helpers.label'` option is the default for the label, but I want to call those specifically out %>
+      <%= f.label :orcid_profile_id, t('orcid/profile_connection.orcid_profile_id', scope: 'helpers.label') %>
+      <%= f.text_field :orcid_profile_id, class:"orcid-input" %>
+      <button type="submit" class="search-submit btn btn-primary" id="keyword-search-submit" tabindex="2">
+        <span class="orcid-connect"><%= t('orcid/profile_connection.connect_button_text', scope: 'helpers.label') %></span>
+      </button>
+    <% end %>
+  </p>
+</div>

--- a/app/views/orcid/profile_connections/_orcid_connector.html.erb
+++ b/app/views/orcid/profile_connections/_orcid_connector.html.erb
@@ -1,0 +1,16 @@
+<% defined?(status_processor) || status_processor = Orcid::ProfileStatus.method(:for) %>
+<div class='orcid-connector'>
+  <h3><i class="icon-user"></i> <%= link_to t('orcid.verbose_name'), Orcid.provider.host_url, target: :_blank%></h3>
+  <% status_processor.call(current_user) do |on|%>
+    <% on.authenticated_connection do |profile| %>
+      <%= render partial: 'orcid/profile_connections/authenticated_connection', object: profile %>
+    <% end %>
+    <% on.pending_connection do |profile| %>
+      <%= render partial: 'orcid/profile_connections/pending_connection', object: profile %>
+    <% end %>
+    <% on.unknown do %>
+      <% defined?(default_search_text) || default_search_text = '' %>
+      <%= render template: 'orcid/profile_connections/_options_to_connect_orcid_profile', locals: { default_search_text: default_search_text } %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/orcid/profile_connections/_orcid_disconnector.html.erb
+++ b/app/views/orcid/profile_connections/_orcid_disconnector.html.erb
@@ -1,0 +1,3 @@
+<div class='orcid-connector'>
+	<%= link_to "Disconnect from ORCID record", disconnect_path, class: 'btn btn-primary', data: { confirm: "Are you sure you want to disconnect your ORCID record? (You can re-connect later)"} %>
+</div>

--- a/app/views/orcid/profile_connections/_pending_connection.html.erb
+++ b/app/views/orcid/profile_connections/_pending_connection.html.erb
@@ -1,0 +1,11 @@
+<div class="pending-connection">
+  <%= t(
+    'orcid.views.pending_connection',
+    orcid_profile_url: Orcid.url_for_orcid_id(pending_connection.orcid_profile_id),
+    orcid_profile_id: pending_connection.orcid_profile_id,
+    application_orcid_authorization_href: user_omniauth_authorize_path(provider: 'orcid'),
+    application_orcid_authorization_text: 'sign into this application'
+  ).html_safe
+  %>
+  <%= render partial: 'orcid/profile_connections/orcid_disconnector' %>
+</div>

--- a/app/views/orcid/profile_connections/new.html.erb
+++ b/app/views/orcid/profile_connections/new.html.erb
@@ -1,32 +1,19 @@
-
-<% content_for :page_title, 'Look Up Your Existing Profile // Orcid Settings // CurateND' %>
-<% content_for :page_header do %>
-  <h1>ORCID Settings &mdash; Look Up Your Existing Profile </h1>
-<% end %>
-
-<%= simple_form_for(profile_connection, as: :profile_connection, url: orcid.new_profile_connection_path, method: :get, html: {class: 'search-form'}) do |f| %>
-  <%= field_set_tag("Search ORCID Profiles") do %>
+<%= simple_form_for(profile_connection, as: :profile_connection, url: new_profile_connection_path, method: :get, html: {class: 'search-form'}) do |f| %>
+  <%= field_set_tag(t('orcid.views.profile_connections.fieldsets.search_orcid_profiles')) do %>
     <% profile_connection.available_query_attribute_names.each do |field_name| %>
       <%= f.input field_name, as: :search %>
     <% end %>
   <% end %>
-  <button type="submit" class="btn btn-primary" id="keyword-search-submit" tabindex="2">
-    <i class="icon-search icon-white"></i><span>Search</span>
+  <button type="submit" class="search-submit btn btn-primary" id="keyword-search-submit" tabindex="2">
+    <i class="icon-search icon-white"></i><span><%= t('orcid.views.profile_connections.buttons.search') %></span>
   </button>
 <% end %>
 
 <% profile_connection.with_orcid_profile_candidates do |candidates| %>
-  <%= simple_form_for(profile_connection, as: :profile_connection, url: orcid.profile_connections_path,) do |f| %>
-    <%= field_set_tag("Select an ORCID Profile") do %>
-      <% candidates.each do |candidate| %>
-        <div class="radio">
-          <label>
-            <%= f.radio_button(:orcid_profile_id, candidate.id) %>
-            <%= candidate.label %>
-          </label>
-        </div>
-      <% end %>
+  <%= simple_form_for(profile_connection, as: :profile_connection, url: profile_connections_path,) do |f| %>
+    <%= field_set_tag(t('orcid.views.profile_connections.fieldsets.select_an_orcid_profile')) do %>
+      <%= f.collection_radio_buttons :orcid_profile_id, candidates, :id, :label, item_wrapper_class: 'radio' %>
     <% end %>
-    <%= f.button :submit, class: 'btn btn-primary' %>
+    <%= f.submit class: 'btn btn-default' %>
   <% end %>
 <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,6 +21,7 @@ require 'flipper/adapters/memory'
 module CurateNd
   class Application < Rails::Application
     require 'curate'
+    require 'orcid'
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/config/application.yml
+++ b/config/application.yml
@@ -49,3 +49,4 @@ development:
   ORCID_REMOTE_SIGNIN_URL: "https://sandbox.orcid.org/signin/auth.json"
   ORCID_HOST_URL: "https://sandbox.orcid.org"
   ORCID_AUTHORIZE_URL: "https://sandbox.orcid.org/oauth/authorize"
+  ORCID_SEARCH_URL: "https://sandbox.orcid.org/orcid-search/quick-search"

--- a/config/application.yml
+++ b/config/application.yml
@@ -36,16 +36,16 @@ OSF_SCHEME: 'https'
 
 development:
   cas_base_url: "https://cas.library.nd.edu/cas"
-  cas_destination_url: "http://localhost:3000"
-  cas_follow_url: "http://localhost:3000"
+  cas_destination_url: "https://localhost:3000"
+  cas_follow_url: "https://localhost:3000"
   # Commented out because these create the requirement to start the noids server
-  # in order to run in localhost. 
+  # in order to run in localhost.
   # NOIDS_SERVER: "localhost:13001"
   # NOIDS_POOL: "test"
   ORCID_PERSISTENT_TOKENS_ENABLED: "false"
-  ORCID_REDIRECT_URI: "uri"
-  ORCID_SITE_URL: "orcid url"
-  ORCID_TOKEN_URL: "token url"
-  ORCID_REMOTE_SIGNIN_URL: "signin_url"
-  ORCID_HOST_URL: "host url"
-  ORCID_AUTHORIZE_URL: "Authorize url"
+  ORCID_REDIRECT_URI: "https://localhost:3000/users/auth/orcid/callback"
+  ORCID_SITE_URL: "https://sandbox.orcid.org"
+  ORCID_TOKEN_URL: "https://sandbox.orcid.org/oauth/token"
+  ORCID_REMOTE_SIGNIN_URL: "https://sandbox.orcid.org/signin/auth.json"
+  ORCID_HOST_URL: "https://sandbox.orcid.org"
+  ORCID_AUTHORIZE_URL: "https://sandbox.orcid.org/oauth/authorize"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -43,4 +43,6 @@ CurateNd::Application.configure do
       Rails.root.join('spec/support/files/default_fits_output.xml').read
     }
   end
+
+  config.logger = Logger.new(STDOUT)
 end

--- a/config/locales/orcid.en.yml
+++ b/config/locales/orcid.en.yml
@@ -35,6 +35,22 @@ en:
         profile_connection_not_found: "Unable to find an existing ORCID Profile connection."
         verified_profile_connection_exists: "You have already connected and verified your ORCID Profile (%{orcid_profile_id})."
     verbose_name: Open Researcher and Contributor ID (ORCID)
+    views:
+      profile_connections:
+        fieldsets:
+          search_orcid_profiles: "Search ORCID Profiles"
+          select_an_orcid_profile: "Select an ORCID Profile"
+        buttons:
+          search: 'Search'
+      authenticated_connection: "<p>Your ORCID (<a class='orcid-profile-id' href='%{orcid_profile_url}'>%{orcid_profile_id}</a>) has been authenticated for this application.</p>"
+      profile_request_pending: "<p>We are processing your ORCID Profile Request. It was submitted <time datetime='%{datetime}'>%{time_ago_in_words}</time> ago.</p>"
+      pending_connection: >
+        <p>You have an ORCID (<a class="orcid-profile-id" href="%{orcid_profile_url}">%{orcid_profile_id}</a>).</p>
+        <p>However, your ORCID has not been verified by this system. There are a few possibilities:</p>
+        <ul>
+          <li>You may not have claimed your ORCID. <a class="find-out-more" href="http://support.orcid.org/knowledgebase/articles/164480-creating-claiming-new-records">Find out more about claiming your ORCID.</a></li>
+          <li>You have claimed your ORCID, but have not used it to <a class="signin-via-orcid" href="%{application_orcid_authorization_href}">%{application_orcid_authorization_text}</a>.</li>
+        </ul>
   helpers:
     label:
       orcid/profile_connection:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,5 @@
 CurateNd::Application.routes.draw do
   mount_roboto
-  mount Orcid::Engine => "/orcid"
   Blacklight.add_routes(self)
   HydraHead.add_routes(self)
 
@@ -30,6 +29,14 @@ CurateNd::Application.routes.draw do
     match 'profile' => 'user_profiles#show', via: :get, as: 'user_profile'
   end
   #resources :downloads, only: [:show]
+
+  scope module: 'orcid', path: 'orcid' do
+    resource :profile_request, only: [:show, :new, :create, :destroy]
+    resources :profile_connections, only: [:new, :create, :index]
+
+    get 'create_orcid', to: 'create_profile#create'
+    get "disconnect", to: "profile_connections#destroy"
+  end
 
   match 'collections' => 'collections#index', via: :get, as: 'curation_concern_collections'
   get 'collection/:id', to: redirect('collections/%{id}')

--- a/lib/orcid.rb
+++ b/lib/orcid.rb
@@ -1,0 +1,109 @@
+require 'orcid/configuration'
+require 'orcid/exceptions'
+require 'figaro'
+require 'mappy'
+require 'devise_multi_auth'
+require 'virtus'
+require 'omniauth-orcid'
+require 'email_validator'
+require 'simple_form'
+
+# The namespace for all things related to Orcid integration
+module Orcid
+  class << self
+    attr_writer :configuration
+
+    def configuration
+      @configuration ||= Configuration.new
+    end
+  end
+
+  module_function
+  def configure
+    yield(configuration)
+  end
+
+  def mapper
+    configuration.mapper
+  end
+
+  def provider
+    configuration.provider
+  end
+
+  def parent_controller
+    configuration.parent_controller
+  end
+
+  def authentication_model
+    configuration.authentication_model
+  end
+
+  def connect_user_and_orcid_profile(user, orcid_profile_id)
+    authentication_model.create!(
+      provider: 'orcid', uid: orcid_profile_id, user: user
+    )
+  end
+
+  def access_token_for(orcid_profile_id, collaborators = {})
+    client = collaborators.fetch(:client) { oauth_client }
+    tokenizer = collaborators.fetch(:tokenizer) { authentication_model }
+    tokenizer.to_access_token(
+      uid: orcid_profile_id, provider: 'orcid', client: client
+    )
+  end
+
+  # Returns true if the person with the given ORCID has already obtained an
+  # ORCID access token by authenticating via ORCID.
+  def authenticated_orcid?(orcid_profile_id)
+    Orcid.access_token_for(orcid_profile_id).present?
+  rescue Devise::MultiAuth::AccessTokenError
+    return false
+  end
+
+  def disconnect_user_and_orcid_profile(user)
+    authentication_model.where(provider: 'orcid', user: user).destroy_all
+    Orcid::ProfileRequest.where(user: user).destroy_all
+    true
+  end
+
+  def profile_for(user)
+    auth = authentication_model.where(provider: 'orcid', user: user).first
+    auth && Orcid::Profile.new(auth.uid)
+  end
+
+  def enqueue(object)
+    object.run
+  end
+
+  def url_for_orcid_id(orcid_profile_id)
+    File.join(provider.host_url, orcid_profile_id)
+  end
+
+  def oauth_client
+    # passing the site: option as Orcid's Sandbox has an invalid certificate
+    # for the api.sandbox.orcid.org
+    @oauth_client ||= Devise::MultiAuth.oauth_client_for(
+      'orcid', options: { site: provider.site_url }
+    )
+  end
+
+  def client_credentials_token(scope, collaborators = {})
+    tokenizer = collaborators.fetch(:tokenizer) { oauth_client.client_credentials }
+    tokenizer.get_token(scope: scope)
+  end
+
+  # As per an isolated_namespace Rails engine.
+  # But the isolated namespace creates issues.
+  # @api private
+  def table_name_prefix
+    'orcid_'
+  end
+
+  # Because I am not using isolate_namespace for Orcid::Engine
+  # I need this for the application router to find the appropriate routes.
+  # @api private
+  def use_relative_model_naming?
+    true
+  end
+end

--- a/lib/orcid.rb
+++ b/lib/orcid.rb
@@ -114,6 +114,8 @@ module Orcid
       uri = URI.parse(Orcid.provider.token_url)
       request = Net::HTTP::Post.new(uri)
       request["Accept"] = "application/json"
+      # Note there is no redirect_uri here, since we won't follow it anyway and having one
+      # can cause an error if we use an invalid redirect. Less brittle to just leave it off
       request.set_form_data( "client_id" => provider.id,
            "client_secret" => provider.secret,
            "grant_type" => "authorization_code",

--- a/lib/orcid/configuration.rb
+++ b/lib/orcid/configuration.rb
@@ -1,0 +1,43 @@
+module Orcid
+  # Responsible for exposing the customization mechanism
+  class Configuration
+    attr_reader :mapper
+    def initialize(collaborators = {})
+      @mapper = collaborators.fetch(:mapper) { default_mapper }
+      @provider = collaborators.fetch(:provider) { default_provider }
+      @authentication_model = collaborators.fetch(:authentication_model) { default_authenticaton_model }
+      @parent_controller = collaborators.fetch(:parent_controller) { default_parent_controller }
+    end
+
+    attr_accessor :provider
+    attr_accessor :authentication_model
+    attr_accessor :parent_controller
+
+    def register_mapping_to_orcid_work(source_type, legend)
+      mapper.configure do |config|
+        config.register(source: source_type, target: 'orcid/work', legend: legend)
+      end
+    end
+
+    private
+
+    def default_parent_controller
+      '::ApplicationController'
+    end
+
+    def default_mapper
+      require 'mappy'
+      ::Mappy
+    end
+
+    def default_provider
+      require 'orcid/configuration/provider'
+      Provider.new
+    end
+
+    def default_authenticaton_model
+      require 'devise-multi_auth'
+      ::Devise::MultiAuth::Authentication
+    end
+  end
+end

--- a/lib/orcid/configuration/provider.rb
+++ b/lib/orcid/configuration/provider.rb
@@ -50,6 +50,13 @@ module Orcid
         end
       end
 
+      attr_writer :search_url
+      def search_url
+        @search_url ||= store.fetch('ORCID_SEARCH_URL') do
+          "https://sandbox.orcid.org/orcid-search/quick-search"
+        end
+      end
+
       attr_writer :authorize_url
       def authorize_url
         @authorize_url ||= store.fetch('ORCID_AUTHORIZE_URL') do

--- a/lib/orcid/configuration/provider.rb
+++ b/lib/orcid/configuration/provider.rb
@@ -1,0 +1,75 @@
+require 'orcid/exceptions'
+module Orcid
+  class Configuration
+    # Responsible for negotiating the retrieval of Orcid provider information.
+    # Especially important given that you have private auth keys.
+    # Also given that you may want to request against the sandbox versus the
+    # production Orcid service.
+    class Provider
+      attr_reader :store
+      def initialize(store = ::ENV)
+        @store = store
+      end
+
+      # See http://tools.ietf.org/html/draft-ietf-oauth-v2-10#section-3 for
+      # how to formulate scopes
+      attr_writer :authentication_scope
+      def authentication_scope
+        @authentication_scope ||=
+        store.fetch('ORCID_APP_AUTHENTICATION_SCOPE') do
+          '/read-limited /activities/update'
+        end
+      end
+
+      attr_writer :site_url
+      def site_url
+        @site_url ||= store.fetch('ORCID_SITE_URL') do
+          'http://api.sandbox.orcid.org'
+        end
+      end
+
+      attr_writer :token_url
+      def token_url
+        @token_url ||= store.fetch('ORCID_TOKEN_URL') do
+          'https://api.sandbox.orcid.org/oauth/token'
+        end
+      end
+
+      attr_writer :signin_via_json_url
+      def signin_via_json_url
+        @signin_via_json_url ||= store.fetch('ORCID_REMOTE_SIGNIN_URL') do
+          'https://sandbox.orcid.org/signin/auth.json'
+        end
+      end
+
+      attr_writer :host_url
+      def host_url
+        @host_url ||= store.fetch('ORCID_HOST_URL') do
+          uri = URI.parse(signin_via_json_url)
+          "#{uri.scheme}://#{uri.host}"
+        end
+      end
+
+      attr_writer :authorize_url
+      def authorize_url
+        @authorize_url ||= store.fetch('ORCID_AUTHORIZE_URL') do
+          'https://sandbox.orcid.org/oauth/authorize'
+        end
+      end
+
+      attr_writer :id
+      def id
+        @id ||= store.fetch('ORCID_APP_ID')
+      rescue KeyError
+        raise ConfigurationError, 'ORCID_APP_ID'
+      end
+
+      attr_writer :secret
+      def secret
+        @secret ||= store.fetch('ORCID_APP_SECRET')
+      rescue KeyError
+        raise ConfigurationError, 'ORCID_APP_SECRET'
+      end
+    end
+  end
+end

--- a/lib/orcid/engine.rb
+++ b/lib/orcid/engine.rb
@@ -1,0 +1,16 @@
+# The namespace for all things related to Orcid integration
+module Orcid
+
+  # While not an isolated namespace engine
+  # @See http://guides.rubyonrails.org/engines.html
+  class Engine < ::Rails::Engine
+    engine_name 'orcid'
+
+    initializer 'orcid.initializers' do |app|
+      app.config.paths.add 'app/services', eager_load: true
+      app.config.autoload_paths += %W(
+        #{config.root}/app/services
+      )
+    end
+  end
+end

--- a/lib/orcid/exceptions.rb
+++ b/lib/orcid/exceptions.rb
@@ -1,0 +1,82 @@
+module Orcid
+
+  # Intended to be the base for all exceptions raised by the Orcid gem.
+  class BaseError < RuntimeError
+  end
+
+  class ProfileRequestStateError < BaseError
+    def initialize(user)
+      super("Unexpected Orcid::ProfileRequest state for #{user.class} ID=#{user.to_param}.")
+    end
+  end
+
+  class ProfileRequestMethodExpectedError < BaseError
+    def initialize(request, method_name)
+      super("Expected #{request.inspect} to respond to :#{method_name}.")
+    end
+  end
+
+  class MissingUserForProfileRequest < BaseError
+    def initialize(request)
+      super("#{request.class} ID=#{request.to_param} is not associated with a :user.")
+    end
+  end
+
+  class ConfigurationError < BaseError
+    def initialize(key_name)
+      super("Unable to find #{key_name.inspect} in configuration storage.")
+    end
+  end
+
+  # Because in trouble shooting what all goes into this remote call,
+  # you may very well want all of this.
+  class RemoteServiceError < BaseError
+    def initialize(options)
+      text = []
+      text << "-- Client --"
+      append_client_options(options[:client], text)
+      append_token(options[:token], text)
+      append_request(options, text)
+      append_response(options, text)
+      super(text.join("\n"))
+    end
+
+    private
+
+    def append_client_options(client, text)
+      if client
+        text << "id:\n\t#{client.id.inspect}"
+        text << "site:\n\t#{client.site.inspect}"
+        text << "options:\n\t#{client.options.inspect}"
+        if defined?(Orcid.provider)
+          text << "scopes:\n\t#{Orcid.provider.authentication_scope}"
+        end
+      end
+      text
+    end
+
+    def append_token(token, text)
+      text << "\n-- Token --"
+      if token
+        text << "access_token:\n\t#{token.token.inspect}"
+        text << "refresh_token:\n\t#{token.refresh_token.inspect}"
+      end
+      text
+    end
+
+    def append_request(options, text)
+      text << "\n-- Request --"
+      text << "path:\n\t#{options[:request_path].inspect}" if options[:request_path]
+      text << "headers:\n\t#{options[:request_headers].inspect}" if options[:request_headers]
+      text << "body:\n\t#{options[:request_body]}" if options[:request_body]
+      text
+    end
+
+    def append_response(options, text)
+      text << "\n-- Response --"
+      text << "status:\n\t#{options[:response_status].inspect}" if options[:response_status]
+      text << "body:\n\t#{options[:response_body]}" if options[:response_body]
+      text
+    end
+  end
+end

--- a/lib/orcid/named_callbacks.rb
+++ b/lib/orcid/named_callbacks.rb
@@ -1,0 +1,21 @@
+module Orcid
+  # Inspired by Jim Weirich's NamedCallbacks
+  # https://github.com/jimweirich/wyriki/blob/master/spec/runners/named_callbacks_spec.rb#L1-L28
+  class NamedCallbacks
+    def initialize
+      @callbacks = {}
+    end
+
+    # Note this very specific implementation of #method_missing will raise
+    # errors on non-zero method arity.
+    def method_missing(callback_name, &block)
+      @callbacks[callback_name] = block
+    end
+
+    def call(callback_name, *args)
+      name = callback_name.to_sym
+      cb = @callbacks[name]
+      cb ? cb.call(*args) : true
+    end
+  end
+end

--- a/lib/orcid/spec_support.rb
+++ b/lib/orcid/spec_support.rb
@@ -1,0 +1,131 @@
+require 'rest_client'
+
+# This follows the instructions from:
+# http://support.orcid.org/knowledgebase/articles/179969-methods-to-generate-an-access-token-for-testing#curl
+class RequestSandboxAuthorizationCode
+
+  def self.call(options = {})
+    new(options).call
+  end
+
+  attr_reader :cookies, :access_scope, :authorize_url, :login_url
+  attr_reader :oauth_redirect_uri, :orcid_client_id, :authorization_code, :orcid_client_secret
+  attr_reader :orcid_profile_id, :password
+
+  def initialize(options = {})
+    @orcid_client_id = options.fetch(:orcid_client_id) { Orcid.provider.id }
+    @orcid_client_secret = options.fetch(:orcid_client_secret) { Orcid.provider.secret }
+    @login_url = options.fetch(:login_url) { Orcid.provider.signin_via_json_url }
+    @authorize_url = options.fetch(:authorize_url) { Orcid.provider.authorize_url }
+    @oauth_redirect_uri = options.fetch(:oauth_redirect_uri) { 'https://developers.google.com/oauthplayground' }
+    @access_scope = options.fetch(:scope) { Orcid.provider.authentication_scope }
+    @orcid_profile_id = options.fetch(:orcid_profile_id) { ENV['ORCID_CLAIMED_PROFILE_ID'] }
+    @password = options.fetch(:password) { ENV['ORCID_CLAIMED_PROFILE_PASSWORD'] }
+  end
+
+  def call
+    puts "Attempting to login to orcid { PROFILE_ID: '#{orcid_profile_id}', PASSWORD: '#{password}' }"
+    login_to_orcid
+    request_authorization
+    request_authorization_code
+  end
+
+  attr_writer :cookies
+  private :cookies
+
+  private
+
+  def custom_authorization_url
+    authorize_url.sub('oauth/authorize', 'oauth/custom/authorize.json')
+  end
+
+  def resource_options
+    { ssl_version: :SSLv23 }.tap {|options|
+      options[:headers] = { cookies: cookies } if cookies
+    }
+  end
+
+  def login_to_orcid
+    resource = RestClient::Resource.new(login_url, resource_options)
+    response = resource.post({ userId: orcid_profile_id, password: password })
+    if JSON.parse(response)['success']
+      self.cookies = response.cookies
+    else
+      fail "Response not successful: \n#{response}"
+    end
+  end
+
+  def request_authorization
+    parameters = {
+      client_id: orcid_client_id,
+      response_type: 'code',
+      scope: access_scope,
+      redirect_uri: oauth_redirect_uri
+    }
+    resource = RestClient::Resource.new("#{authorize_url}?#{parameters.to_query}", resource_options)
+    response = resource.get
+    response
+  end
+
+  def request_authorization_code
+    options = resource_options
+    options[:headers] ||= {}
+    options[:headers][:content_type] = :json
+    options[:headers][:accept] = :json
+    resource = RestClient::Resource.new(custom_authorization_url, options)
+    response = resource.post(authorization_code_payload.to_json)
+    json = JSON.parse(response)
+    redirected_to = json.fetch('redirectUri').fetch('value')
+    uri = URI.parse(redirected_to)
+    CGI.parse(uri.query).fetch('code').first
+  rescue RestClient::Exception => e
+    File.open("/Users/jfriesen/Desktop/orcid.html", 'w+') {|f| f.puts e.response.body.force_encoding('UTF-8') }
+    $stderr.puts "Response Code: #{e.response.code}\n\tCookies: #{cookies.inspect}\n\tAuthorizeURL: #{authorize_url.inspect}"
+    raise e
+  end
+
+  def authorization_code_payload
+    {
+      "errors" => [],
+      "userName" => {
+        "errors" => [],
+        "value" => "",
+        "required" => true,
+        "getRequiredMessage" => nil
+      },
+      "password" => {
+        "errors" => [],
+        "value" => "",
+        "required" => true,
+        "getRequiredMessage" => nil
+      },
+      "clientId" => {
+        "errors" => [],
+        "value" => "#{orcid_client_id}",
+        "required" => true,
+        "getRequiredMessage" => nil
+      },
+      "redirectUri" => {
+        "errors" => [],
+        "value" => "=#{URI.escape(oauth_redirect_uri)}",
+        "required" => true,
+        "getRequiredMessage" => nil
+      },
+      "scope" => {
+        "errors" => [],
+        "value" => "#{access_scope}",
+        "required" => true,
+        "getRequiredMessage" => nil
+      },
+      "responseType" => {
+        "errors" => [],
+        "value" => "code",
+        "required" => true,
+        "getRequiredMessage" => nil
+      },
+      "approved" => true,
+      "persistentTokenEnabled" => false
+    }
+  end
+
+end

--- a/lib/orcid/version.rb
+++ b/lib/orcid/version.rb
@@ -1,0 +1,3 @@
+module Orcid
+  VERSION = '0.9.1'
+end


### PR DESCRIPTION
These changes should prepare us for ORCID's API update from v1.2 to v2.0. Summary of changes:
- Pulled the orcid gem controllers/views/services into curate and removed the dependency on the gem
- The v2 search has changed drastically and will require a bit more work than we expected. We've also decided to drop the input form, in favor of the button that gets the user's orcid from the API. The two methods were confusing, and with the create/connect method the user at least has to authenticate with ORCID as some form of proof that it is their id. Given these two factors, we also dropped the search functionality for now.
- Moved the logic for requesting the users id and auth token using an auth code out of the CreateProfileController into the orcid module.

Also made a few additional bug fixes/improvements:
- Changed the create method in CreateProfileController controller to handle cases when something goes wrong with either the request for the auth token or if the user has denied access to the application, and give feedback to the user via a flash
- Changed the create/connect link to open within current window, since this will redirect back to this page when done

Related tickets: DLTP-1041, DLTP-1090, DLTP-1091