### PR TITLE
Fixity report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ spec/*.zip
 spec/jetty_generator
 .tag
 .tags
+.byebug_history

--- a/app/assets/stylesheets/modules/admin.css.scss
+++ b/app/assets/stylesheets/modules/admin.css.scss
@@ -39,3 +39,62 @@
   overflow-x: auto;
   width: 100%;
 }
+.table-sortable > thead > tr > th {
+  cursor: pointer;
+  position: relative;
+}
+
+.table-sortable > thead > tr > th:after,
+.table-sortable > thead > tr > th:after,
+.table-sortable > thead > tr > th:after {
+  content: ' ';
+	position: absolute;
+  height: 0;
+  width: 0;
+  right: 10px; /* (right padding / 2) - arrow width */
+  top: 16px; /* ((padding * 2) + line height) - arrow height */
+  /** As pointed out by Dave Everitt in
+   * https://css-tricks.com/snippets/css/css-triangle/
+   * The arrow is not an equilateral triangle.
+   * the height is 86.6% of the width.
+   * Notice the above code does not subract the border
+   * width exactly. It is subtracting
+   * (rounded) border width * 86.6%
+   **/
+}
+
+/* Default sortable indicator */
+.table-sortable > thead > tr > th:after {
+  border-left: 5px solid transparent;
+	border-right: 5px solid transparent;
+	border-top: 5px solid #ccc;
+  border-bottom: 0px solid transparent;
+}
+/* !Default */
+
+/* Default sortable indicator:hover */
+.table-sortable > thead > tr > th:hover:after {
+	border-top: 5px solid #888;
+}
+/* !Default:hover */
+
+/* Ascending sortable indicator */
+.table-sortable > thead > tr > th.asc:after {
+  border-left: 5px solid transparent;
+	border-right: 5px solid transparent;
+  border-top: 0px solid transparent;
+	border-bottom: 5px solid #333;
+}
+.table-sortable > thead > tr > th.asc:hover:after {
+	border-bottom: 5px solid #888;
+}
+/* !Ascending */
+
+/* Descending sortable indicator */
+.table-sortable > thead > tr > th.desc:after {
+  border-left: 5px solid transparent;
+	border-right: 5px solid transparent;
+  border-top: 5px solid #333;
+	border-bottom: 5px solid transparent;
+}
+/* !Descending */

--- a/app/controllers/admin/fixity_controller.rb
+++ b/app/controllers/admin/fixity_controller.rb
@@ -1,0 +1,58 @@
+class Admin::FixityController < ApplicationController
+  with_themed_layout('1_column')
+
+  def index
+    pp params
+    @fixity_results = JSON.parse('[
+      {
+          "Id": "20481",
+          "Item": "id01931x",
+          "Scheduled_time": "2017-09-01T00:23:32Z",
+          "Status": "ok",
+          "Notes": ""
+      },
+      {
+          "Id": "20482",
+          "Item": "id05534x",
+          "Scheduled_time": "2017-09-01T00:23:32Z",
+          "Status": "error",
+          "Notes": ""
+      },
+      {
+          "Id": "20483",
+          "Item": "id08847x",
+          "Scheduled_time": "2017-09-01T03:23:32Z",
+          "Status": "ok",
+          "Notes": ""
+      },
+      {
+          "Id": "20484",
+          "Item": "id04756x",
+          "Scheduled_time": "2017-09-01T05:24:19Z",
+          "Status": "scheduled",
+          "Notes": ""
+      },
+      {
+          "Id": "20485",
+          "Item": "id06635x",
+          "Scheduled_time": "2017-09-01T05:24:44Z",
+          "Status": "scheduled",
+          "Notes": ""
+      },
+      {
+          "Id": "20486",
+          "Item": "id09884x",
+          "Scheduled_time": "2017-09-01T05:24:44Z",
+          "Status": "mismatched",
+          "Notes": ""
+      },
+      {
+          "Id": "20487",
+          "Item": "id06916x",
+          "Scheduled_time": "2017-09-01T05:24:44Z",
+          "Status": "ok",
+          "Notes": ""
+      }
+    ]')
+  end
+end

--- a/app/controllers/admin/fixity_controller.rb
+++ b/app/controllers/admin/fixity_controller.rb
@@ -2,57 +2,23 @@ class Admin::FixityController < ApplicationController
   with_themed_layout('1_column')
 
   def index
-    pp params
-    @fixity_results = JSON.parse('[
-      {
-          "Id": "20481",
-          "Item": "id01931x",
-          "Scheduled_time": "2017-09-01T00:23:32Z",
-          "Status": "ok",
-          "Notes": ""
-      },
-      {
-          "Id": "20482",
-          "Item": "id05534x",
-          "Scheduled_time": "2017-09-01T00:23:32Z",
-          "Status": "error",
-          "Notes": ""
-      },
-      {
-          "Id": "20483",
-          "Item": "id08847x",
-          "Scheduled_time": "2017-09-01T03:23:32Z",
-          "Status": "ok",
-          "Notes": ""
-      },
-      {
-          "Id": "20484",
-          "Item": "id04756x",
-          "Scheduled_time": "2017-09-01T05:24:19Z",
-          "Status": "scheduled",
-          "Notes": ""
-      },
-      {
-          "Id": "20485",
-          "Item": "id06635x",
-          "Scheduled_time": "2017-09-01T05:24:44Z",
-          "Status": "scheduled",
-          "Notes": ""
-      },
-      {
-          "Id": "20486",
-          "Item": "id09884x",
-          "Scheduled_time": "2017-09-01T05:24:44Z",
-          "Status": "mismatched",
-          "Notes": ""
-      },
-      {
-          "Id": "20487",
-          "Item": "id06916x",
-          "Scheduled_time": "2017-09-01T05:24:44Z",
-          "Status": "ok",
-          "Notes": ""
-      }
-    ]')
+    params.delete_if { |k, v| v.nil? || v.empty? }
+    results = Bendo::Services::FixityChecks.call(params: params)
+
+    if results.status === 200
+      @fixity_results = results.body
+    else
+      @fixity_results = []
+    end
+
+    respond_to do |format|
+      format.html do
+        flash[:error] = "Something went wrong when retrieving records from Bendo." unless results.status === 200
+      end
+
+      format.json do
+        render json: @fixity_results, status: results.status
+      end
+    end
   end
 end

--- a/app/controllers/admin/fixity_controller.rb
+++ b/app/controllers/admin/fixity_controller.rb
@@ -2,8 +2,7 @@ class Admin::FixityController < ApplicationController
   with_themed_layout('1_column')
 
   def index
-    params.delete_if { |k, v| v.nil? || v.empty? }
-    results = Bendo::Services::FixityChecks.call(params: params)
+    results = Bendo::Services::FixityChecks.call(params: clean_params)
 
     if results.status === 200
       @fixity_results = results.body
@@ -20,5 +19,10 @@ class Admin::FixityController < ApplicationController
         render json: @fixity_results, status: results.status
       end
     end
+  end
+
+  def clean_params
+    params.permit(:item, :status, :scheduled_time_start, :scheduled_time_end )
+      .delete_if { |k, v| v.nil? || v.empty? }
   end
 end

--- a/app/controllers/admin/fixity_controller.rb
+++ b/app/controllers/admin/fixity_controller.rb
@@ -4,7 +4,7 @@ class Admin::FixityController < ApplicationController
   def index
     results = Bendo::Services::FixityChecks.call(params: clean_params)
 
-    if results.status === 200
+    if results.status == 200
       @fixity_results = results.body
     else
       @fixity_results = []
@@ -12,7 +12,7 @@ class Admin::FixityController < ApplicationController
 
     respond_to do |format|
       format.html do
-        flash[:error] = "Something went wrong when retrieving records from Bendo." unless results.status === 200
+        flash[:error] = "Something went wrong when retrieving records from Bendo." unless results.status == 200
       end
 
       format.json do

--- a/app/services/bendo/services/fixity_checks.rb
+++ b/app/services/bendo/services/fixity_checks.rb
@@ -1,0 +1,33 @@
+module Bendo
+  module Services
+    class FixityChecks
+      Response = Struct.new(:status, :body)
+
+      def self.call(params: params)
+        new.get(params: params)
+      end
+
+      def get(params: params)
+        query_params = transform_params(params: params).compact.join("&")
+        url = Bendo.fixity_url() + "?#{query_params}"
+        conn = Faraday.new url: url, headers: { 'X-Api-Key' => Bendo.api_key() }
+        result = conn.get
+        # A Bendo response body is only valid json if success
+        body = result.status === 200 ? JSON.parse(result.body) : result.body
+        Response.new(result.status, body)
+      end
+
+      # Transforms from params Curate understands to params that Bendo understands. Inherently whitelists params as well
+      def transform_params(params: params)
+        params.map do |k,v|
+          new_key = param_map[k]
+          new_key.present? ? "#{new_key}=#{v}" : nil
+        end
+      end
+
+      def param_map
+        @param_map ||= { "item" => "item", "status" => "status", "scheduled_time_start" => "start", "scheduled_time_end" => "end" }.freeze
+      end
+    end
+  end
+end

--- a/app/services/bendo/services/fixity_checks.rb
+++ b/app/services/bendo/services/fixity_checks.rb
@@ -1,3 +1,5 @@
+require 'faraday'
+
 module Bendo
   module Services
     class FixityChecks

--- a/app/services/bendo/services/fixity_checks.rb
+++ b/app/services/bendo/services/fixity_checks.rb
@@ -15,7 +15,7 @@ module Bendo
         conn = Faraday.new url: url, headers: { 'X-Api-Key' => Bendo.api_key() }
         result = conn.get
         # A Bendo response body is only valid json if success
-        body = result.status === 200 ? JSON.parse(result.body) : result.body
+        body = result.status == 200 ? JSON.parse(result.body) : result.body
         Response.new(result.status, body)
       end
 

--- a/app/views/admin/base/index.html.erb
+++ b/app/views/admin/base/index.html.erb
@@ -16,3 +16,4 @@
 <p class="lead"><%= link_to 'Application Exceptions', "https://errbit.library.nd.edu" %></p>
 <p class="lead"><%= link_to 'Resque Queue', admin_resque_server_path %></p>
 <p class="lead"><%= link_to 'Batch Ingest Jobs', admin_batch_ingest_index_path %></p>
+<p class="lead"><%= link_to 'Bendo Fixity Checks', admin_fixity_index_path %></p>

--- a/app/views/admin/fixity/index.html.erb
+++ b/app/views/admin/fixity/index.html.erb
@@ -4,13 +4,12 @@
     <div class="span5">
       <div class="control-group string">
         <span class="control-label">Item:</span>
-        <input name="item" class="controls string input-xlarge" v-model="filters.Item" placeholder="id00000x">
+        <input name="item" class="controls string input-xlarge" v-model="filters.item" placeholder="id00000x">
       </div>
       <div class="control-group string">
         <span class="control-label">Status:</span>
-        <select name="status" v-model="filters.Status.selected">
-          <option disabled value="">Please select one</option>
-          <option v-for="option in filters.Status.options" v-bind:value="option.value">
+        <select name="status" v-model="filters.status.selected">
+          <option v-for="option in filters.status.options" v-bind:value="option.value">
             {{ option.text }}
           </option>
         </select>
@@ -19,11 +18,11 @@
     <div class="span5">
       <div class="control-group string">
         <span class="control-label">Start Date:</span>
-        <input name="scheduled_time_start" class="controls string input-xlarge" v-model="filters.Scheduled_time_start">
+        <input name="scheduled_time_start" class="controls string input-xlarge" v-model="filters.scheduled_time_start">
       </div>
       <div class="control-group string">
         <span class="control-label">End Date:</span>
-        <input name="scheduled_time_end" class="controls string input-xlarge" v-model="filters.Scheduled_time_end">
+        <input name="scheduled_time_end" class="controls string input-xlarge" v-model="filters.scheduled_time_end">
       </div>
     </div>
     <div class="span10">
@@ -31,6 +30,17 @@
     </div>
   </form>
   <legend>Fixity Checks</legend>
+  <div class="control-group string">
+    <span class="control-label">Limit to:</span>
+    <select name="limit" v-model="limits.selected">
+      <option v-for="option in limits.options" v-bind:value="option.value">
+        {{ option.text }}
+      </option>
+    </select>
+  </div>
+  <div class="control-group string">
+    <span v-if="limitedEntries.length < sortedEntries.length">{{ sortedEntries.length - limitedEntries.length }} results are not being displayed.</span>
+  </div>
   <table class="table table-striped table-sortable">
     <thead>
       <tr>
@@ -42,7 +52,7 @@
       </tr>
     </thead>
     <tbody>
-      <tr v-for="entry in sortedEntries">
+      <tr v-for="entry in limitedEntries">
         <td>{{ entry.Id }}</td>
         <td>{{ entry.Item }}</td>
         <td>{{ entry.Scheduled_time }}</td>
@@ -55,7 +65,7 @@
 
 <%= javascript_include_tag "https://unpkg.com/vue" %>
 <%= javascript_include_tag "https://unpkg.com/vue-router" %>
-<%= javascript_tag defer: 'defer' do -%>
+<%= javascript_tag do -%>
   var router = new VueRouter({
       mode: 'history',
       routes: []
@@ -67,19 +77,29 @@
     data() {
       return {
         entries: JSON.parse('<%= raw(@fixity_results.to_json) %>'),
+        limits: {
+          selected: 10,
+          options: [
+            { text: '10', value: 10 },
+            { text: '50', value: 50 },
+            { text: '100', value: 100 },
+            { text: '1000', value: 1000 }
+          ]
+        },
         sortField: 'Id',
         sortDirection: -1,
         filters: {
-          Item: this.$route.query.item || null,
-          Scheduled_time_start: this.$route.query.scheduled_time_start || this.timeToday(0,0,0,0),
-          Scheduled_time_end: this.$route.query.scheduled_time_start || this.timeToday(23,59,59,999),
-          Status: {
+          item: this.$route.query.item || null,
+          scheduled_time_start: this.$route.query.scheduled_time_start || this.timeToday(0,0,0,0),
+          scheduled_time_end: this.$route.query.scheduled_time_end || this.timeToday(23,59,59,999),
+          status: {
             selected: this.$route.query.status || '',
             options: [
+              { text: 'Any', value: '' },
               { text: 'Ok', value: 'ok' },
               { text: 'Error', value: 'error' },
               { text: 'Scheduled', value: 'scheduled' },
-              { text: 'Mismatched', value: 'mismatched' }
+              { text: 'Mismatch', value: 'mismatch' }
             ]
           },
         }
@@ -89,6 +109,9 @@
       sortedEntries: function () {
         // For now this just sorts as a string. May need to do dates at some point
         return this.entries.sort((a, b) => this.sortDirection * a[this.sortField].localeCompare(b[this.sortField]))
+      },
+      limitedEntries: function() {
+        return this.sortedEntries.slice(0, this.limits.selected)
       }
     },
     methods: {

--- a/app/views/admin/fixity/index.html.erb
+++ b/app/views/admin/fixity/index.html.erb
@@ -1,0 +1,102 @@
+<div id="fixity_body">
+  <form action="/admin/fixity" method="get">
+    <div class="control-group string">
+      <span class="control-label">Item:</span>
+      <input name="item" class="controls string input-xlarge" v-model="filters.Item" placeholder="id00000x">
+    </div>
+    <div class="control-group string">
+      <span class="control-label">Start Date:</span>
+      <input name="scheduled_time_start" class="controls string input-xlarge" v-model="filters.Scheduled_time_start">
+    </div>
+    <div class="control-group string">
+      <span class="control-label">End Date:</span>
+      <input name="scheduled_time_end" class="controls string input-xlarge" v-model="filters.Scheduled_time_end">
+    </div>
+    <div class="control-group string">
+      <span class="control-label">Status:</span>
+      <select name="status" v-model="filters.Status.selected">
+        <option disabled value="">Please select one</option>
+        <option v-for="option in filters.Status.options" v-bind:value="option.value">
+          {{ option.text }}
+        </option>
+      </select>
+    </div>
+    <div class="control-group">
+      <button type="submit" class="btn btn-primary">Update</button>
+    </div>
+  </form>
+  <table class="table table-striped table-sortable">
+    <thead>
+      <tr>
+        <th v-bind:class="sortClass('Id')" v-on:click="changeSort('Id')">Id</th>
+        <th v-bind:class="sortClass('Item')" v-on:click="changeSort('Item')">Item</th>
+        <th v-bind:class="sortClass('Scheduled_time')" v-on:click="changeSort('Scheduled_time')">Scheduled Time</th>
+        <th v-bind:class="sortClass('Status')" v-on:click="changeSort('Status')">Status</th>
+        <th v-bind:class="sortClass('Notes')" v-on:click="changeSort('Notes')">Notes</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr v-for="entry in sortedEntries">
+        <td>{{ entry.Id }}</td>
+        <td>{{ entry.Item }}</td>
+        <td>{{ entry.Scheduled_time }}</td>
+        <td>{{ entry.Status }}</td>
+        <td>{{ entry.Notes }}</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<%= javascript_include_tag "https://unpkg.com/vue" %>
+<%= javascript_tag defer: 'defer' do -%>
+  var vueApp = new Vue({
+    el: '#fixity_body',
+    data() {
+      return {
+        entries: JSON.parse('<%= raw(@fixity_results.to_json) %>'),
+        sortField: 'Id',
+        sortDirection: -1,
+        filters: {
+          Item: null,
+          Scheduled_time_start: this.timeToday(0,0,0,0),
+          Scheduled_time_end: this.timeToday(23,59,59,999),
+          Status: {
+            selected: '',
+            options: [
+              { text: 'Ok', value: 'ok' },
+              { text: 'Error', value: 'error' },
+              { text: 'Scheduled', value: 'scheduled' },
+              { text: 'Mismatched', value: 'mismatched' }
+            ]
+          },
+        }
+      }
+    },
+    computed: {
+      sortedEntries: function () {
+        // For now this just sorts as a string. May need to do dates at some point
+        return this.entries.sort((a, b) => this.sortDirection * a[this.sortField].localeCompare(b[this.sortField]))
+      }
+    },
+    methods: {
+      changeSort: function (field) {
+        if(this.sortField === field)
+          this.sortDirection *= -1
+        else {
+          this.sortDirection = 1
+          this.sortField = field
+        }
+      },
+      sortClass: function (field) {
+        if(this.sortField === field)
+          return this.sortDirection === 1 ? 'asc' : 'desc'
+        return ''
+      },
+      timeToday: function (h, m, s, ms) {
+        var date = new Date()
+        date.setHours(h, m, s, ms)
+        return date.toISOString()
+      }
+    }
+  })
+<% end -%>

--- a/app/views/admin/fixity/index.html.erb
+++ b/app/views/admin/fixity/index.html.erb
@@ -1,30 +1,36 @@
 <div id="fixity_body">
-  <form action="/admin/fixity" method="get">
-    <div class="control-group string">
-      <span class="control-label">Item:</span>
-      <input name="item" class="controls string input-xlarge" v-model="filters.Item" placeholder="id00000x">
+  <form action="/admin/fixity" method="get" class="control-group">
+    <legend>Filters</legend>
+    <div class="span5">
+      <div class="control-group string">
+        <span class="control-label">Item:</span>
+        <input name="item" class="controls string input-xlarge" v-model="filters.Item" placeholder="id00000x">
+      </div>
+      <div class="control-group string">
+        <span class="control-label">Status:</span>
+        <select name="status" v-model="filters.Status.selected">
+          <option disabled value="">Please select one</option>
+          <option v-for="option in filters.Status.options" v-bind:value="option.value">
+            {{ option.text }}
+          </option>
+        </select>
+      </div>
     </div>
-    <div class="control-group string">
-      <span class="control-label">Start Date:</span>
-      <input name="scheduled_time_start" class="controls string input-xlarge" v-model="filters.Scheduled_time_start">
+    <div class="span5">
+      <div class="control-group string">
+        <span class="control-label">Start Date:</span>
+        <input name="scheduled_time_start" class="controls string input-xlarge" v-model="filters.Scheduled_time_start">
+      </div>
+      <div class="control-group string">
+        <span class="control-label">End Date:</span>
+        <input name="scheduled_time_end" class="controls string input-xlarge" v-model="filters.Scheduled_time_end">
+      </div>
     </div>
-    <div class="control-group string">
-      <span class="control-label">End Date:</span>
-      <input name="scheduled_time_end" class="controls string input-xlarge" v-model="filters.Scheduled_time_end">
-    </div>
-    <div class="control-group string">
-      <span class="control-label">Status:</span>
-      <select name="status" v-model="filters.Status.selected">
-        <option disabled value="">Please select one</option>
-        <option v-for="option in filters.Status.options" v-bind:value="option.value">
-          {{ option.text }}
-        </option>
-      </select>
-    </div>
-    <div class="control-group">
-      <button type="submit" class="btn btn-primary">Update</button>
+    <div class="span10">
+      <button type="submit" class="control-group btn btn-primary">Update</button>
     </div>
   </form>
+  <legend>Fixity Checks</legend>
   <table class="table table-striped table-sortable">
     <thead>
       <tr>
@@ -48,8 +54,15 @@
 </div>
 
 <%= javascript_include_tag "https://unpkg.com/vue" %>
+<%= javascript_include_tag "https://unpkg.com/vue-router" %>
 <%= javascript_tag defer: 'defer' do -%>
+  var router = new VueRouter({
+      mode: 'history',
+      routes: []
+  })
+
   var vueApp = new Vue({
+    router,
     el: '#fixity_body',
     data() {
       return {
@@ -57,11 +70,11 @@
         sortField: 'Id',
         sortDirection: -1,
         filters: {
-          Item: null,
-          Scheduled_time_start: this.timeToday(0,0,0,0),
-          Scheduled_time_end: this.timeToday(23,59,59,999),
+          Item: this.$route.query.item || null,
+          Scheduled_time_start: this.$route.query.scheduled_time_start || this.timeToday(0,0,0,0),
+          Scheduled_time_end: this.$route.query.scheduled_time_start || this.timeToday(23,59,59,999),
           Status: {
-            selected: '',
+            selected: this.$route.query.status || '',
             options: [
               { text: 'Ok', value: 'ok' },
               { text: 'Error', value: 'error' },

--- a/config/application.yml
+++ b/config/application.yml
@@ -50,3 +50,4 @@ development:
   ORCID_HOST_URL: "https://sandbox.orcid.org"
   ORCID_AUTHORIZE_URL: "https://sandbox.orcid.org/oauth/authorize"
   ORCID_SEARCH_URL: "https://sandbox.orcid.org/orcid-search/quick-search"
+  bendo_api_key: ''

--- a/config/bendo.yml
+++ b/config/bendo.yml
@@ -1,5 +1,6 @@
 development:
   url: 'http://localhost:14000'
+  api_key: ''
 test:
   url: 'http://localhost:14000'
 ci:

--- a/config/bendo.yml
+++ b/config/bendo.yml
@@ -1,6 +1,5 @@
 development:
   url: 'http://localhost:14000'
-  api_key: ''
 test:
   url: 'http://localhost:14000'
 ci:

--- a/config/initializers/bendo.rb
+++ b/config/initializers/bendo.rb
@@ -4,8 +4,12 @@ require 'psych'
 module Bendo
   module_function
 
+  def config
+    @@config ||= Psych.load(ERB.new(IO.read(Rails.root.join('config/bendo.yml'))).result).fetch(Rails.env)
+  end
+
   def url
-    @@url ||= Psych.load(ERB.new(IO.read(Rails.root.join('config/bendo.yml'))).result).fetch(Rails.env).fetch('url')
+    @@url ||= config.fetch('url')
   end
 
   def item_path(slug)
@@ -18,5 +22,13 @@ module Bendo
 
   def item_url(slug)
     File.join(url, item_path(slug))
+  end
+
+  def fixity_url()
+    File.join(url, '/fixity')
+  end
+
+  def api_key()
+    @@api_key ||= config.fetch('api_key')
   end
 end

--- a/config/initializers/bendo.rb
+++ b/config/initializers/bendo.rb
@@ -29,6 +29,6 @@ module Bendo
   end
 
   def api_key()
-    @@api_key ||= config.fetch('api_key')
+    @@api_key ||= ENV.fetch('bendo_api_key')
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -105,6 +105,7 @@ CurateNd::Application.routes.draw do
       resource :repo_manager, only: [:edit, :update], path: :privledges
       resources :ingest_osf_archives, only: [:new, :create]
       resources :batch_ingest, only: [:index]
+      resources :fixity, only: [:index]
     end
 
     constraints CurateND::AdminAPIConstraint do

--- a/spec/controllers/admin/fixity_controller_spec.rb
+++ b/spec/controllers/admin/fixity_controller_spec.rb
@@ -1,0 +1,113 @@
+require 'spec_helper'
+
+describe Admin::FixityController, type: :controller do
+  describe "#index" do
+    let(:subject) { get :index }
+    let(:bendo_success) { instance_double(Bendo::Services::FixityChecks::Response, { status: 200, body: 'body' }) }
+    let(:bendo_error) { instance_double(Bendo::Services::FixityChecks::Response, { status: 400, body: 'body' }) }
+
+    before(:each) do
+      allow(Bendo::Services::FixityChecks).to receive(:call)
+    end
+
+    it "removes any empty string parameters before calling bendo" do
+      expect(Bendo::Services::FixityChecks).to receive(:call).with(params: { "item" => "thing" })
+      get :index, { item: "thing", status: "" }
+    end
+
+    it "removes any nil parameters before calling bendo" do
+      expect(Bendo::Services::FixityChecks).to receive(:call).with(params: { "item" => "thing" })
+      get :index, { item: "thing", scheduled_time_start: nil }
+    end
+
+    context 'when requesting html' do
+      let(:subject) { get :index }
+
+      context 'and bendo returns success' do
+        before(:each) do
+          allow(Bendo::Services::FixityChecks).to receive(:call).and_return(bendo_success)
+        end
+
+        it "assigns fixity_results" do
+          subject
+          expect(assigns(:fixity_results)).to eq('body')
+        end
+
+        it "does not flash an error" do
+          subject
+          expect(flash[:error]).not_to be_present
+        end
+
+        it "renders the index view" do
+          expect(subject).to render_template(:index)
+        end
+      end
+
+      context 'and bendo returns error' do
+        before(:each) do
+          allow(Bendo::Services::FixityChecks).to receive(:call).and_return(bendo_error)
+        end
+
+        it "assigns fixity_results as an empty array" do
+          subject
+          expect(assigns(:fixity_results)).to eq([])
+        end
+
+        it "flashes an error" do
+          subject
+          expect(flash[:error]).to be_present
+        end
+
+        it "renders the index view" do
+          expect(subject).to render_template(:index)
+        end
+      end
+    end
+
+    context 'when requesting json' do
+      let(:subject) { get :index, format: :json }
+
+      context 'and bendo returns success' do
+        before(:each) do
+          allow(Bendo::Services::FixityChecks).to receive(:call).and_return(bendo_success)
+        end
+
+        it "renders the json data from bendo" do
+          subject
+          expect(response.body).to eq('body')
+        end
+
+        it "returns 200" do
+          subject
+          expect(response.status).to eq(200)
+        end
+
+        it "renders the fixity_results as json" do
+          subject
+          expect(response.content_type).to eq "application/json"
+        end
+      end
+
+      context 'and bendo returns error' do
+        before(:each) do
+          allow(Bendo::Services::FixityChecks).to receive(:call).and_return(bendo_error)
+        end
+
+        it "renders an empty array" do
+          subject
+          expect(response.body).to eq("[]")
+        end
+
+        it "returns status given by bendo" do
+          subject
+          expect(response.status).to eq(bendo_error.status)
+        end
+
+        it "renders the fixity_results as json" do
+          subject
+          expect(response.content_type).to eq "application/json"
+        end
+      end
+    end
+  end
+end

--- a/spec/fast_spec_helper.rb
+++ b/spec/fast_spec_helper.rb
@@ -1,3 +1,6 @@
+require 'active_support'
+require 'active_support/core_ext'
+
 unless defined?(Rails) # If we are in a Rails context this is overkill.
   Dir[File.expand_path('../../app/*', __FILE__)].each do |dir|
     $LOAD_PATH << dir

--- a/spec/services/bendo/services/fixity_checks_spec.rb
+++ b/spec/services/bendo/services/fixity_checks_spec.rb
@@ -1,0 +1,105 @@
+require 'fast_spec_helper'
+require 'bendo/services/fixity_checks'
+require 'webmock/rspec'
+
+module Bendo
+  module Services
+    RSpec.describe FixityChecks do
+      let(:api_key) { "api_key" }
+      let(:fixity_url) { "http://localhost/fixity_url" }
+      let(:fake_response_hash) { [ { "a" => "a", "b" => "b" } ] }
+      let(:fake_response) { fake_response_hash.to_json }
+
+      before(:each) do
+        allow(Bendo).to receive(:api_key).and_return(api_key)
+        allow(Bendo).to receive(:fixity_url).and_return(fixity_url)
+      end
+
+      describe '.call' do
+        context 'for all requests to bendo' do
+          subject { described_class.call(params: {}) }
+
+          before(:each) do
+            stub_request(:any, fixity_url).to_return(status: 200, body: fake_response)
+          end
+
+          it 'performs a GET to the API at the url from the Bendo module' do
+            allow(Bendo).to receive(:fixity_url).and_return('http://some.where.com')
+            stub_request(:any, 'http://some.where.com').to_return(status: 200, body: fake_response)
+            subject
+            expect(WebMock).to have_requested(:get, 'http://some.where.com')
+          end
+
+          it 'calls bendo with the api key' do
+            subject
+            expect(WebMock).to have_requested(:get, fixity_url).with(headers: { 'X-Api-Key' => api_key })
+          end
+        end
+
+        context 'when a 200 is returned from bendo' do
+          subject { described_class.call(params: {}) }
+
+          before(:each) do
+            stub_request(:any, fixity_url).to_return(status: 200, body: fake_response)
+          end
+
+          it 'returns 200' do
+            expect(subject.status).to eq(200)
+          end
+
+          it 'returns the results from bendo as a hash' do
+            expect(subject.body).to eq(fake_response_hash)
+          end
+        end
+
+        context 'when a 200 is not returned from bendo' do
+          subject { described_class.call(params: {}) }
+
+          before(:each) do
+            stub_request(:any, fixity_url).to_return(status: 400, body: fake_response)
+          end
+
+          it 'passes the bendo status through to the response' do
+            expect(subject.status).to eq(400)
+          end
+
+          it 'returns the results from bendo as is' do
+            expect(subject.body).to eq(fake_response)
+          end
+        end
+
+        context 'with no parameters' do
+          subject { described_class.call(params: {}) }
+
+          before(:each) do
+            stub_request(:any, fixity_url).to_return(status: 200, body: fake_response)
+          end
+
+          it 'calls bendo with no params' do
+            subject
+            expect(WebMock).to have_requested(:get, fixity_url).with(query: '')
+          end
+        end
+
+        context 'with parameters' do
+          let(:params) do
+            { "item" => "item", "status" => "status", "scheduled_time_start" => "start", "scheduled_time_end" => "end" }
+          end
+          let(:remapped_params) do
+            { "item" => "item", "status" => "status", "start" => "start", "end" => "end" }
+          end
+          subject { described_class.call(params: params) }
+
+          before(:each) do
+            stub_request(:any, fixity_url).with(query: remapped_params).to_return(status: 200, body: fake_response)
+          end
+
+          it 'calls bendo with remapped params' do
+            subject
+            expect(WebMock).to have_requested(:get, fixity_url).with(query: remapped_params)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a basic report interface that can be used to show the Bendo fixity checks. Summary of changes:
- Created a view using Vue for data bindings, sort behaviors, etc. The resulting json from bendo will be rendered as a stringified json into the view, the client will handle rendering all of this as html. 
- Created route/controller path to render the new view. Started adding a json response as well and will likely change the view to primarily fetch data from the controller like an api, but stopping this for the moment just to get this in as it is functional/good enough.
- Created a service class to handle api calls to bendo's fixity resource.
- The service requires a bendo_api_key either in the env or in the config. Added this as a placeholder to the dev section in application.yml, but this means I'll also need to create a corresponding change to the secrets before we can deploy.
- Added active support to the fast spec helper for usage of .present?
- Added css for rendering sort arrows in a table

Associated tickets: DLTP-1046, DLTP-1095, DLTP-1096