### PR TITLE
Use construct_page_title consistently

### DIFF
--- a/app/views/citation/show.html.erb
+++ b/app/views/citation/show.html.erb
@@ -1,5 +1,5 @@
 <%
- content_for :page_title, construct_page_title("#{curation_concern.title} // Citation")
+ content_for :page_title, construct_page_title(curation_concern.title, "Citation")
  content_for :page_header, content_tag('h1', "Cite &ldquo;#{curation_concern.title}&rdquo;".html_safe)
 %>
 

--- a/app/views/static_pages/policies-authoritative-source.erb
+++ b/app/views/static_pages/policies-authoritative-source.erb
@@ -1,5 +1,5 @@
 <% content_for :main_column_class, 'span8 offset2' %>
-<% content_for :page_title, construct_page_title('Authoritative Source // Policies // CurateND') %>
+<% content_for :page_title, construct_page_title('Authoritative Source', 'Policies') %>
 <% content_for :page_header do %>
 <div class="policy-header">
   <h1 class="center">CurateND Authoritative Source Location Policy</h1>

--- a/app/views/static_pages/policies-backup-location.erb
+++ b/app/views/static_pages/policies-backup-location.erb
@@ -1,5 +1,5 @@
 <% content_for :main_column_class, 'span8 offset2' %>
-<% content_for :page_title, construct_page_title('Backup Location // Policies // CurateND') %>
+<% content_for :page_title, construct_page_title('Backup Location', 'Policies') %>
 <% content_for :page_header do %>
 <div class="policy-header">
   <h1 class="center">Preservation Backup and</h1>

--- a/app/views/static_pages/policies-content-withdrawal.erb
+++ b/app/views/static_pages/policies-content-withdrawal.erb
@@ -1,5 +1,5 @@
 <% content_for :main_column_class, 'span8 offset2' %>
-<% content_for :page_title, construct_page_title('Content Withdrawal // Policies // CurateND') %>
+<% content_for :page_title, construct_page_title('Content Withdrawal', 'Policies') %>
 <% content_for :page_header do %>
 <div class="policy-header">
   <h1 class="center">CurateND Content Withdrawal Policy</h1>

--- a/app/views/static_pages/policies-content.html.erb
+++ b/app/views/static_pages/policies-content.html.erb
@@ -1,5 +1,5 @@
 <% content_for :main_column_class, 'span8 offset2' %>
-<% content_for :page_title, construct_page_title('Content in Scope // Policies // CurateND') %>
+<% content_for :page_title, construct_page_title('Content in Scope', 'Policies') %>
 <% content_for :page_header do %>
 <div class="policy-header">
   <h1 class="center">CurateND Content in Scope Policy</h1>

--- a/app/views/static_pages/policies-designated-communities.html.erb
+++ b/app/views/static_pages/policies-designated-communities.html.erb
@@ -1,5 +1,5 @@
 <% content_for :main_column_class, 'span8 offset2' %>
-<% content_for :page_title, construct_page_title('Designated Communities // Policies // CurateND') %>
+<% content_for :page_title, construct_page_title('Designated Communities', 'Policies') %>
 <% content_for :page_header do %>
 <div class="policy-header">
   <h1 class="center">Designated Communities of CurateND Policy</h1>

--- a/app/views/static_pages/policies-disaster-recovery.erb
+++ b/app/views/static_pages/policies-disaster-recovery.erb
@@ -1,5 +1,5 @@
 <% content_for :main_column_class, 'span8 offset2' %>
-<% content_for :page_title, construct_page_title('Disaster Recovery // Policies // CurateND') %>
+<% content_for :page_title, construct_page_title('Disaster Recovery', 'Policies') %>
 <% content_for :page_header do %>
 <div class="policy-header">
   <h1 class="center">CurateND Disaster Recovery Policy</h1>

--- a/app/views/static_pages/policies-export-replication.erb
+++ b/app/views/static_pages/policies-export-replication.erb
@@ -1,5 +1,5 @@
 <% content_for :main_column_class, 'span8 offset2' %>
-<% content_for :page_title, construct_page_title('Preservation Backup // Policies // CurateND') %>
+<% content_for :page_title, construct_page_title('Preservation Backup', 'Policies') %>
 <% content_for :page_header do %>
 <div class="policy-header">
   <h1 class="center">Preservation Backup and </h1>

--- a/app/views/static_pages/policies-fees.erb
+++ b/app/views/static_pages/policies-fees.erb
@@ -1,5 +1,5 @@
 <% content_for :main_column_class, 'span8 offset2' %>
-<% content_for :page_title, construct_page_title('Content Withdrawal // Policies // CurateND') %>
+<% content_for :page_title, construct_page_title('Content Withdrawal', 'Policies') %>
 <% content_for :page_header do %>
 <div class="policy-header">
   <h1 class="center">Policy on Deposit and Access Fees</h1>

--- a/app/views/static_pages/policies-mission.html.erb
+++ b/app/views/static_pages/policies-mission.html.erb
@@ -1,5 +1,5 @@
 <% content_for :main_column_class, 'span8 offset2' %>
-<% content_for :page_title, construct_page_title('Mission // Policies // CurateND') %>
+<% content_for :page_title, construct_page_title('Mission', 'Policies') %>
 <% content_for :page_header do %>
 <div class="policy-header">
   <h1 class="center">CurateND Mission</h1>

--- a/app/views/static_pages/policies-persistent-identifier.html.erb
+++ b/app/views/static_pages/policies-persistent-identifier.html.erb
@@ -1,5 +1,5 @@
 <% content_for :main_column_class, 'span8 offset2' %>
-<% content_for :page_title, construct_page_title('Persistent Identifier Policy // Policies // CurateND') %>
+<% content_for :page_title, construct_page_title('Persistent Identifier Policy', 'Policies') %>
 <% content_for :page_header do %>
 <div class="policy-header">
   <h1 class="center">CurateND Persistent Identifier Policy</h1>

--- a/app/views/static_pages/policies-preservation-migration.html.erb
+++ b/app/views/static_pages/policies-preservation-migration.html.erb
@@ -1,5 +1,5 @@
 <% content_for :main_column_class, 'span8 offset2' %>
-<% content_for :page_title, construct_page_title('Preservation and Migration // Policies // CurateND') %>
+<% content_for :page_title, construct_page_title('Preservation and Migration', 'Policies') %>
 <% content_for :page_header do %>
 <div class="policy-header">
   <h1 class="center">CurateND Content Format Preservation</h1>

--- a/app/views/static_pages/policies-retention-review.html.erb
+++ b/app/views/static_pages/policies-retention-review.html.erb
@@ -1,5 +1,5 @@
 <% content_for :main_column_class, 'span8 offset2' %>
-<% content_for :page_title, construct_page_title('Retention and Review // Policies // CurateND') %>
+<% content_for :page_title, construct_page_title('Retention and Review', 'Policies') %>
 <% content_for :page_header do %>
 <div class="policy-header">
   <h1 class="center">Retention and Review of CurateND Policy</h1>

--- a/app/views/static_pages/policies-succession-plan.erb
+++ b/app/views/static_pages/policies-succession-plan.erb
@@ -1,5 +1,5 @@
 <% content_for :main_column_class, 'span8 offset2' %>
-<% content_for :page_title, construct_page_title('Succession Plan // Policies // CurateND') %>
+<% content_for :page_title, construct_page_title('Succession Plan', 'Policies') %>
 <% content_for :page_header do %>
 <div class="policy-header">
   <h1 class="center">CurateND Succession Planning Policy</h1>

--- a/app/views/static_pages/policies-support.html.erb
+++ b/app/views/static_pages/policies-support.html.erb
@@ -1,5 +1,5 @@
 <% content_for :main_column_class, 'span8 offset2' %>
-<% content_for :page_title, construct_page_title('Depositor Support // Policies // CurateND') %>
+<% content_for :page_title, construct_page_title('Depositor Support', 'Policies') %>
 <% content_for :page_header do %>
 <div class="policy-header">
   <h1 class="center">General Support Policy for Depositors</h1>


### PR DESCRIPTION
Some templates were putting the '//' into page titles. Change to use the
helper method (which already does that).