### PR TITLE
Removing #html_safe for query parameters

### DIFF
--- a/app/views/catalog/_constraints_element.html.erb
+++ b/app/views/catalog/_constraints_element.html.erb
@@ -16,7 +16,7 @@
   <% end %>
   <% unless value.blank? %>
     <% decorated_value = Catalog::ConstraintPresenter.call(value: value, options: options) %>
-    <span class="filter-value"><%= options[:escape_value] ? h(decorated_value) : decorated_value.html_safe %></span>
+    <span class="filter-value"><%= options[:escape_value] ? h(decorated_value) : decorated_value %></span>
   <% end %>
   </span><a class="btn" href="<%= options[:remove] %>"><span class="accessible-hidden">remove </span>×</a>
 </span>

--- a/app/views/catalog/_search_term_splash.html.erb
+++ b/app/views/catalog/_search_term_splash.html.erb
@@ -4,7 +4,7 @@
     <div class="span9 offset3">
       <div class="search-term-splash">
         <h1>
-          <%= splash.title.html_safe %>
+          <%= splash.title %>
         </h1>
       </div>
     </div>


### PR DESCRIPTION
Not certain why these are here, but they expose a vulnerability that
needs to be removed. This could create some unforeseen upstream
consequences in the form of odd rendering of search results (if we are
expecting to render HTML from content), but we'll address those as
they surface.

Closes DLTP-1145