### PR TITLE
Remove word 'Show' from show page title

### DIFF
--- a/app/views/common_objects/show.html.erb
+++ b/app/views/common_objects/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, construct_page_title(curation_concern.title, 'Show') if curation_concern.title %>
+<% content_for :page_title, construct_page_title(curation_concern.title) if curation_concern.title %>
 
 <% content_for :page_header do %>
 <% if curation_concern.kind_of?(GenericFile) %>


### PR DESCRIPTION
"Show Page" is web dev jargon, and does not mean anything to our patrons.