### PR TITLE
Fix for DLTP-1229

### DIFF
--- a/app/views/catalog/_thumbnail_result_tile.html.erb
+++ b/app/views/catalog/_thumbnail_result_tile.html.erb
@@ -6,7 +6,7 @@
 
   if document.respond_to?(:user)
     edit_path = ''
-  elsif document.is_a?(Collection)
+  elsif document.is_a?(Collection) || document.is_a?(LibraryCollection)
     edit_path = edit_collection_path(document)
   else
     edit_path ||= edit_polymorphic_path([:curation_concern, document])


### PR DESCRIPTION
- Problem was in building the edit path for LibraryCollection objects. Was falling to the else case when it should be handled by the same edit collection path.