### PR TITLE
Fix for DLTP-1247 XSS bug

### DIFF
--- a/app/views/catalog/_search_term_splash.html.erb
+++ b/app/views/catalog/_search_term_splash.html.erb
@@ -15,7 +15,7 @@
   <div class="row">
     <div class="span9 offset3">
       <div class="search-term-splash">
-        <%= render partial: 'shared/site_search', locals: { placeholder: "Search #{splash.title}".html_safe } %>
+        <%= render partial: 'shared/site_search', locals: { placeholder: "Search #{splash.title}" } %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Fix for DLTP-1247 XSS bug

a1c1e1557f04e9e36ee64c4ee01a0cfd11517494

- The placeholder text for the search bar was allowing injection of unsafe code. The splash title is assigned by Catalog::SearchSplashPresenter#call, which is driven by url params. Marking it as html_safe in the view without sanitizing it within the presenter is causing the bug. As far as I can tell there is no reason to mark it safe, and I was unable to trace why this was added, so I'm just going to remove and let rails sanitize it. If this causes a problem we can evaluate how to more safely allow this to be driven by params.