### PR TITLE
Use test cas instead of library cas

### DIFF
--- a/config/application.yml
+++ b/config/application.yml
@@ -35,7 +35,7 @@ OSF_SCHEME: 'https'
 
 
 development:
-  cas_base_url: "https://cas.library.nd.edu/cas"
+  cas_base_url: "https://login-test.cc.nd.edu/cas"
   cas_destination_url: "https://localhost:3000"
   cas_follow_url: "https://localhost:3000"
   # Commented out because these create the requirement to start the noids server


### PR DESCRIPTION
Changed config for development and tested running under ssl. 

Note: You must run under ssl for this to work:
`bundle exec thin start -p 3000 --ssl --ssl-key-file dev_server_keys/server.key --ssl-cert-file dev_server_keys/server.crt`