### PR TITLE
DLTP-1261: Paginate associated files

### DIFF
--- a/app/repository_models/curation_concern/with_generic_files.rb
+++ b/app/repository_models/curation_concern/with_generic_files.rb
@@ -11,6 +11,21 @@ module CurationConcern
       generic_files.each(&:destroy)
     end
 
+    # An alternative to #generic_files, allows querying for associated files a page at a time.
+    # Returns a tuple where the first item is a SolrResponse that can be used for pagination,
+    # and the second is an array of GenericFiles
+    def generic_files_page(page, per_page)
+      escaped_uri = ActiveFedora::SolrService.escape_uri_for_query(internal_uri)
+      q = "is_part_of_ssim:#{escaped_uri}"
+      per_page = per_page > 0 ? per_page : 10
+      start = page > 0 ? (page - 1) * per_page : 0
+      request_params = { start: start, rows: per_page }
+      solr_response = ActiveFedora::SolrService.query(q, raw: true, **request_params)
+      page = Blacklight::SolrResponse.new(solr_response, request_params)
+      generic_file_streams = ActiveFedora::SolrService.reify_solr_results(solr_response['response']['docs'])
+      return [page, generic_file_streams]
+    end
+
     def with_empty_contents?
       generic_files.any? {|gf| gf.with_empty_content?}
     end

--- a/app/views/curation_concern/base/_related_files.html.erb
+++ b/app/views/curation_concern/base/_related_files.html.erb
@@ -6,8 +6,8 @@
   <% if curation_concern.generic_files.present? %>
     <h2>Files</h2>
 
-    <% (@response, files) = curation_concern.generic_files_page(params[:files_page].to_i, params[:files_per_page].to_i) %>
-    
+    <% (files_solr_response, files) = curation_concern.generic_files_page(params[:files_page].to_i, params[:files_per_page].to_i) %>
+
     <% if files.any? %>
       <article class="file-delay-notice alert alert-info">
         <%= t('curate.notification_messages.file_retrieval').html_safe %>
@@ -117,7 +117,7 @@
     </article>
     <% end %>
     <div class="pager">
-      <%= paginate_rsolr_response @response, :outer_window => 2, :theme => 'blacklight', param_name: :files_page %>
+      <%= paginate_rsolr_response files_solr_response, :outer_window => 2, :theme => 'blacklight', param_name: :files_page, solr_response: files_solr_response %>
     </div>
   <% elsif editor %>
     <h2>Files</h2>

--- a/app/views/curation_concern/base/_related_files.html.erb
+++ b/app/views/curation_concern/base/_related_files.html.erb
@@ -6,8 +6,8 @@
   <% if curation_concern.generic_files.present? %>
     <h2>Files</h2>
 
-    <% files = curation_concern.generic_files %>
-
+    <% (@response, files) = curation_concern.generic_files_page(params[:files_page].to_i, params[:files_per_page].to_i) %>
+    
     <% if files.any? %>
       <article class="file-delay-notice alert alert-info">
         <%= t('curate.notification_messages.file_retrieval').html_safe %>
@@ -17,7 +17,6 @@
     <% if curation_concern.with_empty_contents? %>
       <div class="alert"><strong>Hey!</strong> It looks like there is a problem with one of these files.</div>
     <% end %>
-
     <% files.each_with_index do |generic_file, index| %>
       <%
         content = generic_file.datastreams.fetch('content')
@@ -117,7 +116,9 @@
         </div>
     </article>
     <% end %>
-
+    <div class="pager">
+      <%= paginate_rsolr_response @response, :outer_window => 2, :theme => 'blacklight', param_name: :files_page %>
+    </div>
   <% elsif editor %>
     <h2>Files</h2>
     <p><em>This <%= curation_concern.human_readable_type.downcase %> has no files associated with it.

--- a/app/views/kaminari/blacklight/_paginator.html.erb
+++ b/app/views/kaminari/blacklight/_paginator.html.erb
@@ -1,3 +1,9 @@
+<!--
+  Setting an instance variable of @response here because the blacklight/kaminari helpers
+  expect this to be set to the solr response. Passing in a local for the response param
+  doesn't seem to work entirely with blacklight 4.5.0
+-->
+<% @response ||= solr_response %>
 <%- pagination_info_cache = render_pagination_info @response %>
 <div class="page_links">
   <% if total_pages > 1 -%>

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -72,7 +72,7 @@ end
 namespace :db do
   desc "Run the seed rake task."
   task :seed, :roles => :app do
-    run "cd #{current_path}; #{rake} RAILS_ENV=#{rails_env} db:seed"
+    run "cd #{release_path}; #{rake} RAILS_ENV=#{rails_env} db:seed"
   end
 end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,7 +9,60 @@
 ###############################################################################
 ###############################################################################
 
+class MockFile < Rack::Test::UploadedFile
+  attr_accessor :fake_file_name
+  # Override this method so that we can provide a fake file name.
+  # Several views depend on the datastream label, which is just the
+  # the original_filename of the file. This allows you to effectively
+  # change what label is displayed in those views. Otherwise, you will
+  # see the same label for every file.
+  def original_filename
+    fake_file_name || super
+  end
+end
+
+# Creates a new user without duplicating usernames
+def create_user(email, name, pw)
+  user = User.find_or_create_by(username: name) do |u|
+    u.email = email
+    u.username = name
+    u.password = pw
+    u.password_confirmation = pw
+  end
+  user
+end
+
+# Creates or finds an object by id. If an actor is given, will use the actor to create
+# the object. Otherwise, will just use the new method on the model given
+def find_or_create(model, actor, id, user, params)
+  curation_concern = model.where(desc_metadata__identifier_tesim: id).first
+  if curation_concern.nil?
+    curation_concern = model.new(identifier: id)
+    if actor.present?
+      actor.new(curation_concern, user, params).create
+    else
+      curation_concern.attributes = params
+      curation_concern.apply_depositor_metadata(user.user_key)
+      curation_concern.save!
+    end
+  end
+  curation_concern
+end
+
+# Shared variables
+foo_user = create_user('foo@example.com', 'foo', 'foobarbaz')
+seeds_file = MockFile.new(__FILE__, 'text/plain', false)
+
 RepositoryAdministrator.usernames.each do |username|
   next if RepoManager.find_by(username: username)
   RepoManager.find_or_create_by!(username: username, active: true)
+end
+
+# Create an article with many files to test things like pagination
+article_attributes = { creator: foo_user.username, abstract: 'Abstract', title: 'Article with many files' }
+article = find_or_create(Article, CurationConcern::ArticleActor, 'article_with_many_files', foo_user, article_attributes)
+15.times do |i|
+  seeds_file.fake_file_name = "article_with_many_files.generic_files_#{i}"
+  file_attributes = { batch: article, file: seeds_file }
+  file = find_or_create(GenericFile, CurationConcern::GenericFileActor, "article_with_many_files.generic_file_#{i}", foo_user, file_attributes)
 end


### PR DESCRIPTION
## DLTP-1261: Paginate associated files

9b7c783558c08cf55676e02e0858ad51250a3062

- Added seed data for an article with many files. This meant expanding the seeds a bit to create classes and methods that would allow us to generate seed data more easily.
- Added a new method CurationConcern::WithGenericFiles#generic_files_page. This method will get a paginated result set of generic files from solr, and return both the solr response and the datastreams for the files from fedora. There didn't seem to be a natural way to do this via the built associations, so had to recreate a lot of the query/object massaging that happens in other places to get it to work with our Kaminari paginator.
- Added pagination render to the related_files partial and changed the call from generic_files (which is added via ActiveFedora has_many association) to the new paginated method
- Incidentally found a problem with how deploy runs seeds. Was looking at current path instead of release path, which means it would not use new seeds if the seeds.rb had been updated as part of this deploy.