### PR TITLE
Remove people from "Type of Work" facet filter, take 2!

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -14,7 +14,13 @@ module BlacklightFacetExtras
       def self.included(some_class)
         some_class.solr_search_params_logic << :add_inclusive_facets_to_solr unless some_class.solr_search_params_logic.include? :add_inclusive_facets_to_solr
         some_class.solr_search_params_logic << :add_multiple_facets_to_solr unless some_class.solr_search_params_logic.include? :add_multiple_facets_to_solr
+        some_class.solr_search_params_logic << :add_exclude_person_to_solr
         some_class.helper BlacklightFacetExtras::Multiple::ViewHelperExtension
+      end
+
+      def add_exclude_person_to_solr(solr_parameters, user_params)
+        solr_parameters[:fq] ||= []
+        solr_parameters[:fq] << "-active_fedora_model_ssi:Person"
       end
 
       ##
@@ -124,18 +130,8 @@ module BlacklightFacetExtras
         options[:locals][:solr_field] ||= display_facet.name
         options[:locals][:solr_fname] ||= display_facet.name # DEPRECATED
         options[:locals][:facet_field] ||= facet_configuration_for_field(display_facet.name)
-        if display_facet.name == "human_readable_type_sim"
-          options[:locals][:display_facet] ||= exclude_facet_items(display_facet, ["Person"])
-        else
-          options[:locals][:display_facet] ||= display_facet
-        end
+        options[:locals][:display_facet] ||= display_facet
         render(options)
-      end
-
-      # Creates a copy of a facet and excludes items with values that are in the exclude_list
-      def exclude_facet_items(facet_field, exclude_list)
-        filtered_items = facet_field.items.select {|i| !exclude_list.include?(i.value) }
-        Blacklight::SolrResponse::Facets::FacetField.new(facet_field.name, filtered_items)
       end
     end
   end
@@ -183,31 +179,6 @@ class CatalogController < ApplicationController
       format.json { render json: render_search_results_as_json }
       format.jsonld { render text: CatalogIndexJsonldPresenter.new(@response, request.url, request.query_parameters).to_jsonld, layout: false }
     end
-  end
-
-  # This is a direct copy of get_facet_pagination in gems/blacklight-4.5.0/lib/blacklight/solr_helper.rb,
-  # with an added bit for filtering out Person values from the facet values for "Type of Work", since
-  # there does not seem to be a supported way of doing this in blacklight 4.5.0
-  def get_facet_pagination(facet_field, user_params=params || {}, extra_controller_params={})
-
-    solr_params = solr_facet_params(facet_field, user_params, extra_controller_params)
-
-    # Make the solr call
-    response =find(blacklight_config.qt, solr_params)
-
-    limit = solr_params[:"f.#{facet_field}.facet.limit"] -1
-    items = response.facets.first.items
-    items = items.select {|i| i.value != "Person" } if facet_field == "human_readable_type_sim"
-
-    # Actually create the paginator!
-    # NOTE: The sniffing of the proper sort from the solr response is not
-    # currently tested for, tricky to figure out how to test, since the
-    # default setup we test against doesn't use this feature.
-    return     Blacklight::Solr::FacetPaginator.new(items,
-      :offset => solr_params[:"f.#{facet_field}.facet.offset"],
-      :limit => limit,
-      :sort => response["responseHeader"]["params"][:"f.#{facet_field}.facet.sort"] || response["responseHeader"]["params"]["facet.sort"]
-    )
   end
 
   def hierarchy_facet

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -51,6 +51,7 @@ end
 
 # Shared variables
 foo_user = create_user('foo@example.com', 'foo', 'foobarbaz')
+foo_person = Person.new({ name: foo_user.username }).save!
 seeds_file = MockFile.new(__FILE__, 'text/plain', false)
 
 RepositoryAdministrator.usernames.each do |username|
@@ -58,8 +59,52 @@ RepositoryAdministrator.usernames.each do |username|
   RepoManager.find_or_create_by!(username: username, active: true)
 end
 
-# Create an article with many files to test things like pagination
+pp "Things with no files"
+attributes = { creator: foo_user.username, abstract: 'Article abstract', title: 'Article with no files' }
+pp attributes[:title]
+find_or_create(Article, CurationConcern::ArticleActor, 'article_with_no_files', foo_user, attributes)
+
+# TODO: This is currently duplicating. Need to figure out what field to use for find in find_or_create
+attributes = { creator: foo_user.username, description: 'Audio description', title: 'Audio with no files' }
+pp attributes[:title]
+find_or_create(Audio, CurationConcern::AudioActor, 'audio_with_no_files', foo_user, attributes)
+
+attributes = { creator: foo_user.username, title: 'Catholic Document with no files' }
+pp attributes[:title]
+find_or_create(CatholicDocument, CurationConcern::CatholicDocumentActor, 'catholicdoc_with_no_files', foo_user, attributes)
+
+attributes = { creator: foo_user.username, description: 'Dataset description', title: 'Dataset with no files' }
+pp attributes[:title]
+find_or_create(Dataset, CurationConcern::DatasetActor, 'dataset_with_no_files', foo_user, attributes)
+
+attributes = { creator: foo_user.username, title: 'Document with no files' }
+pp attributes[:title]
+find_or_create(Document, CurationConcern::DocumentActor, 'document_with_no_files', foo_user, attributes)
+
+attributes = { creator: foo_user.username, title: 'Finding Aid with no files' }
+pp attributes[:title]
+find_or_create(FindingAid, CurationConcern::FindingAidActor, 'findingaid_with_no_files', foo_user, attributes)
+
+attributes = { creator: foo_user.username, description: 'Image description', title: 'Image with no files' }
+pp attributes[:title]
+find_or_create(Image, CurationConcern::ImageActor, 'image_with_no_files', foo_user, attributes)
+
+# TODO: There is no :identifier field on patents. Can't use current implementation of find_or_create
+#attributes = { creator: foo_user.username, description: 'Patent description', title: 'Patent with no files' }
+#pp attributes[:title]
+#find_or_create(Patent, CurationConcern::PatentActor, 'patent_with_no_files', foo_user, attributes)
+
+attributes = { creator: foo_user.username, description: 'Senior Thesis description', title: 'Senior Thesis with no files' }
+pp attributes[:title]
+find_or_create(SeniorThesis, CurationConcern::SeniorThesisActor, 'seniorthesis_with_no_files', foo_user, attributes)
+
+attributes = { creator: foo_user.username, description: 'Video description', title: 'Video with no files' }
+pp attributes[:title]
+find_or_create(Video, CurationConcern::VideoActor, 'video_with_no_files', foo_user, attributes)
+
+pp "Things with files"
 article_attributes = { creator: foo_user.username, abstract: 'Abstract', title: 'Article with many files' }
+pp attributes[:title]
 article = find_or_create(Article, CurationConcern::ArticleActor, 'article_with_many_files', foo_user, article_attributes)
 15.times do |i|
   seeds_file.fake_file_name = "article_with_many_files.generic_files_#{i}"


### PR DESCRIPTION
## DLTP-1259: Remove people from "Type of Work" facet filter:

984fdc48a784c543507189106bce709735b94b21

- The previous way (#667) fixed this at render time. After some discussion, it appears we don't need the Person types to show up in the query results. Removed the previous fix and replaced with an exclusion at query time.
- Added additional seed data to create several different types of works, including a Person