### PR TITLE
Departments and Units Locabulary update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ group :default do
   # Need rubyracer to run integration tests.....really?!?
   # See https://github.com/sstephenson/execjs#readme for more supported runtimes
   gem 'libv8', '~> 3.16.14.3'
-  gem 'locabulary', github: 'ndlib/locabulary', branch: 'master'
+  gem 'locabulary', '0.7.2', github: 'ndlib/locabulary'
   gem 'lograge'
   gem 'logstash-event'
   gem 'logstash-logger'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,11 +35,10 @@ GIT
 
 GIT
   remote: git://github.com/ndlib/locabulary.git
-  revision: 638728ce45c16b1072bfc3ec79f31ecdda767765
-  branch: master
+  revision: 4781a516d1108dd3b6c3c888859246066cc15fcf
   specs:
-    locabulary (0.7.1)
-      activesupport (~> 4.0)
+    locabulary (0.7.2)
+      activesupport (>= 4.0, < 6.0)
       dry-configurable (~> 0.1.7)
       json (~> 1.8)
 
@@ -310,7 +309,7 @@ GEM
     hydra-remote_identifier (0.6.7)
       activesupport (>= 3.2.13, < 5.0)
       rest-client (~> 1.6.7)
-    i18n (0.9.4)
+    i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     jettywrapper (2.0.4)
@@ -723,7 +722,7 @@ DEPENDENCIES
   json-ld
   kaminari!
   libv8 (~> 3.16.14.3)
-  locabulary!
+  locabulary (= 0.7.2)!
   lograge
   logstash-event
   logstash-logger


### PR DESCRIPTION
## DLTP-1323: Bumping version of locabulary

- Bumping version of locabulary to get the new ND Research heading in Departments and Units.
- Moved to an explicit version of locabulary so that we can better track associated changes to Curate

b9941157dd9df61828cbb1e2c0e82a542f5a31d4