### PR TITLE
Add monsido tracking

### DIFF
--- a/app/views/layouts/boilerplate.html.erb
+++ b/app/views/layouts/boilerplate.html.erb
@@ -20,6 +20,8 @@
     <%= render :partial => '/ga', :formats => [:html] -%>
   </head>
   <body>
+    <script type="text/javascript">var _monsido = _monsido || [];             _monsido.push(['_setDomainToken', 'PHxwIeNkUqLdDIH8iu9lVA']);             _monsido.push(['_withStatistics', 'true']);</script>
+    <script src="//cdn.monsido.com/tool/javascripts/monsido.js"></script>
     <% unless Rails.env.production? %>
       <p class="environment-notice"><strong>WARNING: </strong> This site is running in <%= Rails.env %>. Production data will not be changed.</p>
     <% end %>


### PR DESCRIPTION
## DLTP-1313: Add monsido tracking

7258dfdcb490020214de880095b5b9cdb957c405

- Added this to the boilerplate layout. As far as I can tell this is what is used to render the base layout with head/body tags. There is another 503 page that is used when CurateND is down for maintenance, but not sure if we want it there.