### PR TITLE
Locabulary changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ group :default do
   # Need rubyracer to run integration tests.....really?!?
   # See https://github.com/sstephenson/execjs#readme for more supported runtimes
   gem 'libv8', '~> 3.16.14.3'
-  gem 'locabulary', '0.7.2', github: 'ndlib/locabulary'
+  gem 'locabulary', '0.7.3', github: 'ndlib/locabulary'
   gem 'lograge'
   gem 'logstash-event'
   gem 'logstash-logger'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,9 +35,9 @@ GIT
 
 GIT
   remote: git://github.com/ndlib/locabulary.git
-  revision: 4781a516d1108dd3b6c3c888859246066cc15fcf
+  revision: 3f9ba337510087ef7abf8088b8d55fc3db9247d2
   specs:
-    locabulary (0.7.2)
+    locabulary (0.7.3)
       activesupport (>= 4.0, < 6.0)
       dry-configurable (~> 0.1.7)
       json (~> 1.8)
@@ -722,7 +722,7 @@ DEPENDENCIES
   json-ld
   kaminari!
   libv8 (~> 3.16.14.3)
-  locabulary (= 0.7.2)!
+  locabulary (= 0.7.3)!
   lograge
   logstash-event
   logstash-logger


### PR DESCRIPTION
## DLTP-1323: Bumping version of locabulary to get a few more small changes to the ND Research heading in Departments and Units.

5aa28f4b76f492d4306e4f4236a66661466ec286