### PR TITLE
Bugfix for works with LinkedResources

### DIFF
--- a/app/repository_models/curation_concern/with_generic_files.rb
+++ b/app/repository_models/curation_concern/with_generic_files.rb
@@ -16,10 +16,12 @@ module CurationConcern
     # and the second is an array of GenericFiles
     def generic_files_page(page, per_page)
       escaped_uri = ActiveFedora::SolrService.escape_uri_for_query(internal_uri)
+      escaped_model = ActiveFedora::SolrService.escape_uri_for_query("info:fedora/afmodel:GenericFile")
       q = "is_part_of_ssim:#{escaped_uri}"
+      fq = "has_model_ssim:#{escaped_model}"
       per_page = per_page > 0 ? per_page : 10
       start = page > 0 ? (page - 1) * per_page : 0
-      request_params = { start: start, rows: per_page }
+      request_params = { fq: fq, start: start, rows: per_page }
       solr_response = ActiveFedora::SolrService.query(q, raw: true, **request_params)
       page = Blacklight::SolrResponse.new(solr_response, request_params)
       generic_file_streams = ActiveFedora::SolrService.reify_solr_results(solr_response['response']['docs'])


### PR DESCRIPTION
## DLTP-1344: Bugfix for works with LinkedResources

9def71688c4809c5b4da1612124f3a22e855580d

- The new paginated method for retrieving generic files was not filtering to just GenericFile type. Added additional filter to only query for GenericFiles