### PR TITLE
Dockerize curate-jetty

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+tmp
+# Don't need gems for now, since we're only doing jetty.
+# Will probably need to remove this if we create a rails image
+vendor/bundle

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+# Builds a docker image to run hydra jetty (Fedora 3.6.2 and Solr 4.0.0) for Curate
+FROM java:8-jre
+
+RUN wget https://github.com/ndlib/hydra-jetty/archive/xacml-updates-for-curate-with-solr-updates.zip
+RUN unzip -d . -qo xacml-updates-for-curate-with-solr-updates.zip
+
+RUN rm xacml-updates-for-curate-with-solr-updates.zip
+COPY config/jetty.yml /hydra-jetty-xacml-updates-for-curate-with-solr-updates
+
+ENV JETTY_HOME /hydra-jetty-xacml-updates-for-curate-with-solr-updates
+WORKDIR /hydra-jetty-xacml-updates-for-curate-with-solr-updates
+ENTRYPOINT java -Djetty.port=8983 -Dsolr.solr.home=/hydra-jetty-xacml-updates-for-curate-with-solr-updates/solr -XX:+CMSPermGenSweepingEnabled -XX:+CMSClassUnloadingEnabled -XX:PermSize=64M -XX:MaxPermSize=128M -jar /hydra-jetty-xacml-updates-for-curate-with-solr-updates/start.jar

--- a/README.md
+++ b/README.md
@@ -40,7 +40,13 @@ $ bundle exec rake curatend:jetty:start
 
 You can also run Fedora and Solr via Docker:
 ```console
-$ docker run -p 8983:8983 -t ndlib/curate-jetty
+$ docker run -p 8983:8983 -d --name curate-jetty -t ndlib/curate-jetty
+```
+
+And to stop Fedora/Solr if using Docker:
+```console
+docker stop curate-jetty
+docker rm curate-jetty
 ```
 
 You may also need to make sure that mySQL is running as well:
@@ -51,16 +57,24 @@ $ mysql.server start
 
 ### Getting Your Rails Application Running
 
-In most cases, you won't need SSL, so use the following command:
+In most cases, you will need SSL, so use this command:
+
+```console
+$ bundle exec thin start -p 3000 --ssl --ssl-key-file dev_server_keys/server.key --ssl-cert-file dev_server_keys/server.crt
+```
+
+If you don't need SSL, use the following command:
 
 ```console
 $ bundle exec rails server
 ```
 
-If you do need SSL, use this command:
+
+
+To seed database with test data:
 
 ```console
-$ bundle exec thin start -p 3000 --ssl --ssl-key-file dev_server_keys/server.key --ssl-cert-file dev_server_keys/server.crt
+bundle exec rake db:schema:load db:seed:dev
 ```
 
 ### Rebuilding curate-jetty Docker image

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ Before you start the web-server you'll need to make sure Fedora and SOLR are run
 $ bundle exec rake curatend:jetty:start
 ```
 
+You can also run Fedora and Solr via Docker:
+```console
+$ docker run -p 8983:8983 -t ndlib/curate-jetty
+```
+
 You may also need to make sure that mySQL is running as well:
 
 ```console
@@ -56,6 +61,21 @@ If you do need SSL, use this command:
 
 ```console
 $ bundle exec thin start -p 3000 --ssl --ssl-key-file dev_server_keys/server.key --ssl-cert-file dev_server_keys/server.crt
+```
+
+### Rebuilding curate-jetty Docker image
+
+To rebuild the Docker image for running jetty, use the following command:
+
+```console
+docker build . -t ndlib/curate-jetty
+```
+
+To push your image to Dockerhub:
+
+```console
+docker login
+docker push ndlib/curate-jetty
 ```
 
 ## Release Documentation


### PR DESCRIPTION
## Dockerize curate-jetty. This will replace the rake task to run curatend:jetty:start.

6defd8397f3bfb18f5ea57d399a0c7ec19cf10ed

- Added a Dockerfile to reconstruct the necessary version of java, jetty, solr configs, etc
- Updated the Readme with alternate instructions for running jetty via docker and rebuilding the image
- .dockerignore will ignore locally installed gems (if you used bundle install --path vendor/bundle). This is to keep the build relatively fast. This will likely need to change if we also use Docker for the rails app

## Add additional Docker commands and other Readme improvements

b98bb639a4ebf2a38f63c119dc12876dccc34810

- Changed the docker run to use a container name and run as a daemon
- Added commands to stop the docker container
- Changed the default rails command to use SSL
- Bonus! Added command for seeding database