### PR TITLE
Add additional derived create dates

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -237,7 +237,7 @@ class CatalogController < ApplicationController
   end
 
   def self.created_field
-    solr_name('date_created_derived_dtsim', :stored_sortable , type: :date)
+    solr_name('date_created_derived', :stored_searchable , type: :date)
   end
 
   def self.search_config
@@ -596,8 +596,8 @@ class CatalogController < ApplicationController
     config.add_sort_field "#{uploaded_field} asc", label: "Sort by oldest upload"
     config.add_sort_field "#{modified_field} desc", label: "Sort by newest modification"
     config.add_sort_field "#{modified_field} asc", label: "Sort by oldest modification"
-    config.add_sort_field "#{created_field} desc", label: "Sort by newest date created"
-    config.add_sort_field "#{created_field} asc", label: "Sort by oldest date created"
+    config.add_sort_field "ord(#{created_field}) desc", label: "Sort by newest date created"
+    config.add_sort_field "ord(#{created_field}) asc", label: "Sort by oldest date created"
 
 
     # If there are more than this many search results, no spelling ("did you

--- a/db/seeds/dev.rb
+++ b/db/seeds/dev.rb
@@ -49,9 +49,12 @@ user_with_profile = create_user('userwithprofile@example.com', 'userwithprofile'
 create_account(user_with_profile)
 user_without_profile = create_user('userwithoutprofile@example.com', 'userwithoutprofile', 'foobarbaz')
 seeds_file = MockFile.new(__FILE__, 'text/plain', false)
+date_created = 1.month.ago.strftime("%Y-%m-%d")
+publication_date = 1.year.ago.strftime("%Y-%m-%d")
+date_issued = 9.months.ago.strftime("%Y-%m-%d")
 
 puts "Things with no files"
-attributes = { creator: user_with_profile.username, abstract: 'Article abstract', title: 'Article with no files' }
+attributes = { creator: user_with_profile.username, abstract: 'Article abstract', title: 'Article with no files', date_created: date_created, publication_date: publication_date }
 puts "#{attributes[:title]}"
 find_or_create(Article, CurationConcern::ArticleActor, 'article_with_no_files', user_with_profile, attributes)
 
@@ -64,11 +67,11 @@ attributes = { creator: user_with_profile.username, title: 'Catholic Document wi
 puts "#{attributes[:title]}"
 find_or_create(CatholicDocument, CurationConcern::CatholicDocumentActor, 'catholicdoc_with_no_files', user_with_profile, attributes)
 
-attributes = { creator: user_with_profile.username, description: 'Dataset description', title: 'Dataset with no files' }
+attributes = { creator: user_with_profile.username, description: 'Dataset description', title: 'Dataset with no files', date_created: date_created }
 puts "#{attributes[:title]}"
 find_or_create(Dataset, CurationConcern::DatasetActor, 'dataset_with_no_files', user_with_profile, attributes)
 
-attributes = { creator: user_with_profile.username, title: 'Document with no files' }
+attributes = { creator: user_with_profile.username, title: 'Document with no files', date_created: date_created, publication_date: publication_date }
 puts "#{attributes[:title]}"
 find_or_create(Document, CurationConcern::DocumentActor, 'document_with_no_files', user_with_profile, attributes)
 
@@ -76,7 +79,7 @@ attributes = { creator: user_with_profile.username, title: 'Finding Aid with no 
 puts "#{attributes[:title]}"
 find_or_create(FindingAid, CurationConcern::FindingAidActor, 'findingaid_with_no_files', user_with_profile, attributes)
 
-attributes = { creator: user_with_profile.username, description: 'Image description', title: 'Image with no files' }
+attributes = { creator: user_with_profile.username, description: 'Image description', title: 'Image with no files', date_created: date_created }
 puts "#{attributes[:title]}"
 find_or_create(Image, CurationConcern::ImageActor, 'image_with_no_files', user_with_profile, attributes)
 
@@ -89,12 +92,12 @@ attributes = { creator: user_with_profile.username, description: 'Senior Thesis 
 puts "#{attributes[:title]}"
 find_or_create(SeniorThesis, CurationConcern::SeniorThesisActor, 'seniorthesis_with_no_files', user_with_profile, attributes)
 
-attributes = { creator: user_with_profile.username, description: 'Video description', title: 'Video with no files' }
+attributes = { creator: user_with_profile.username, description: 'Video description', title: 'Video with no files', date_created: date_created, publication_date: publication_date }
 puts "#{attributes[:title]}"
 find_or_create(Video, CurationConcern::VideoActor, 'video_with_no_files', user_with_profile, attributes)
 
 puts "Things with files"
-article_attributes = { creator: user_with_profile.username, abstract: 'Abstract', title: 'Article with many files' }
+article_attributes = { creator: user_with_profile.username, abstract: 'Abstract', title: 'Article with many files', publication_date: publication_date }
 puts "#{attributes[:title]}"
 article = find_or_create(Article, CurationConcern::ArticleActor, 'article_with_many_files', user_with_profile, article_attributes)
 15.times do |i|


### PR DESCRIPTION
## DLTP-1258: Add additional derived create dates

c6696f682c99810c1a86f5852e3c4929eba3a66c

- Expanded the derived created date on all models to also convert publication_date and date_issued when they are available, using the priority sequence of publication_date -> date_issued -> date_created.
- Added some additional attributes to the dev seed data in order to easily test this derived date.
- Fixed a problem in catalog_controller with the sort field name. Since we're using solr_name helper to determine the full field name, don't need to include the dtsim suffix. Also changed to stored_searchable to add the m to the suffix (to match the way the field is created in the model)
- Fixed a problem in catalog_controller with the sort function. It must use the ordinal function since it's multivalued. If this because inconsistent or problematic (ex: Solr recommends not using ord() because of high memory usage), then we'll need to modify the schema to be single valued and reindex everything.