### PR TITLE
Change Sort Dropdown Order

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -592,12 +592,13 @@ class CatalogController < ApplicationController
     # except in the relevancy case).
     # label is key, solr field is value
     config.add_sort_field "score desc, #{uploaded_field} desc", label: "Sort by relevance"
+    config.add_sort_field "#{created_field} desc", label: "Sort by newest date created"
+    config.add_sort_field "#{created_field} asc", label: "Sort by oldest date created"
     config.add_sort_field "#{uploaded_field} desc", label: "Sort by newest upload"
     config.add_sort_field "#{uploaded_field} asc", label: "Sort by oldest upload"
     config.add_sort_field "#{modified_field} desc", label: "Sort by newest modification"
     config.add_sort_field "#{modified_field} asc", label: "Sort by oldest modification"
-    config.add_sort_field "#{created_field} desc", label: "Sort by newest date created"
-    config.add_sort_field "#{created_field} asc", label: "Sort by oldest date created"
+
 
 
     # If there are more than this many search results, no spelling ("did you


### PR DESCRIPTION
On DLTP-1396, per request from Don, "newest and oldest date created" sort options were moved to be after "relevance" sort option