### PR TITLE
DLTP-1258: Handle two digit years

### DIFF
--- a/lib/curate/date_formatter.rb
+++ b/lib/curate/date_formatter.rb
@@ -8,7 +8,7 @@ module Curate
       if is_a_year?(date_string)
         Date.new(date_string.to_i)
       else
-        date = Chronic.parse(date_string)
+        date = Chronic.parse(date_string, ambiguous_year_future_bias: 100)
         date.to_date if date
       end
     end


### PR DESCRIPTION
## DLTP-1258: Handle two digit years

076e339a298c9a7b14c4ba7e3c341c18f2f1f55f

- Currently, 2 digit years are parsed as the current year. This is causing problems with sorting. There is an optional param 'ambiguous_year_future_bias ' that will allow us to handle the majority of use cases. Using 100 will cause all single/two digit years up to the current year to show as the current year, anything beyond that will show as 100 years ago. Ex: the current year is 2018, so 01-17 will parse as 20yy and 18-99 will parse as 19yy. This is a stop gap solution and 2 digit years will have to eventually be remediated.

Examples of how this ends up getting mapped:
```ruby

(1..10).each {|i| puts Chronic.parse("9/12/0#{i}", ambiguous_year_future_bias: 100) }
2001-09-12 12:00:00 -0500
2002-09-12 12:00:00 -0500
2003-09-12 12:00:00 -0500
2004-09-12 12:00:00 -0500
2005-09-12 12:00:00 -0500
2006-09-12 12:00:00 -0400
2007-09-12 12:00:00 -0400
2008-09-12 12:00:00 -0400
2009-09-12 12:00:00 -0400
2010-09-12 12:00:00 -0400

(1..99).each {|i| puts Chronic.parse("9/12/#{i}", ambiguous_year_future_bias: 100) }
2001-09-12 12:00:00 -0500
2002-09-12 12:00:00 -0500
2003-09-12 12:00:00 -0500
2004-09-12 12:00:00 -0500
2005-09-12 12:00:00 -0500
2006-09-12 12:00:00 -0400
2007-09-12 12:00:00 -0400
2008-09-12 12:00:00 -0400
2009-09-12 12:00:00 -0400
2010-09-12 12:00:00 -0400
2011-09-12 12:00:00 -0400
2012-09-12 12:00:00 -0400
2013-09-12 12:00:00 -0400
2014-09-12 12:00:00 -0400
2015-09-12 12:00:00 -0400
2016-09-12 12:00:00 -0400
2017-09-12 12:00:00 -0400
1918-09-12 12:00:00 -0500
1919-09-12 12:00:00 -0500
1920-09-12 12:00:00 -0600
1921-09-12 12:00:00 -0600
1922-09-12 12:00:00 -0600
1923-09-12 12:00:00 -0600
1924-09-12 12:00:00 -0600
1925-09-12 12:00:00 -0600
1926-09-12 12:00:00 -0600
1927-09-12 12:00:00 -0600
1928-09-12 12:00:00 -0600
1929-09-12 12:00:00 -0600
1930-09-12 12:00:00 -0600
1931-09-12 12:00:00 -0600
1932-09-12 12:00:00 -0600
1933-09-12 12:00:00 -0600
1934-09-12 12:00:00 -0600
1935-09-12 12:00:00 -0600
1936-09-12 12:00:00 -0600
1937-09-12 12:00:00 -0600
1938-09-12 12:00:00 -0600
1939-09-12 12:00:00 -0600
1940-09-12 12:00:00 -0600
1941-09-12 12:00:00 -0500
1942-09-12 12:00:00 -0500
1943-09-12 12:00:00 -0500
1944-09-12 12:00:00 -0500
1945-09-12 12:00:00 -0500
1946-09-12 12:00:00 -0500
1947-09-12 12:00:00 -0500
1948-09-12 12:00:00 -0500
1949-09-12 12:00:00 -0500
1950-09-12 12:00:00 -0500
1951-09-12 12:00:00 -0500
1952-09-12 12:00:00 -0500
1953-09-12 12:00:00 -0500
1954-09-12 12:00:00 -0500
1955-09-12 12:00:00 -0500
1956-09-12 12:00:00 -0500
1957-09-12 12:00:00 -0500
1958-09-12 12:00:00 -0500
1959-09-12 12:00:00 -0500
1960-09-12 12:00:00 -0500
1961-09-12 12:00:00 -0500
1962-09-12 12:00:00 -0500
1963-09-12 12:00:00 -0500
1964-09-12 12:00:00 -0500
1965-09-12 12:00:00 -0500
1966-09-12 12:00:00 -0500
1967-09-12 12:00:00 -0500
1968-09-12 12:00:00 -0500
1969-09-12 12:00:00 -0400
1970-09-12 12:00:00 -0400
1971-09-12 12:00:00 -0500
1972-09-12 12:00:00 -0500
1973-09-12 12:00:00 -0500
1974-09-12 12:00:00 -0500
1975-09-12 12:00:00 -0500
1976-09-12 12:00:00 -0500
1977-09-12 12:00:00 -0500
1978-09-12 12:00:00 -0500
1979-09-12 12:00:00 -0500
1980-09-12 12:00:00 -0500
1981-09-12 12:00:00 -0500
1982-09-12 12:00:00 -0500
1983-09-12 12:00:00 -0500
1984-09-12 12:00:00 -0500
1985-09-12 12:00:00 -0500
1986-09-12 12:00:00 -0500
1987-09-12 12:00:00 -0500
1988-09-12 12:00:00 -0500
1989-09-12 12:00:00 -0500
1990-09-12 12:00:00 -0500
1991-09-12 12:00:00 -0500
1992-09-12 12:00:00 -0500
1993-09-12 12:00:00 -0500
1994-09-12 12:00:00 -0500
1995-09-12 12:00:00 -0500
1996-09-12 12:00:00 -0500
1997-09-12 12:00:00 -0500
1998-09-12 12:00:00 -0500
1999-09-12 12:00:00 -0500

```