### PR TITLE
DLTP-1258: Sort missing to bottom

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,11 @@ RUN wget https://github.com/ndlib/hydra-jetty/archive/xacml-updates-for-curate-w
 RUN unzip -d . -qo xacml-updates-for-curate-with-solr-updates.zip
 
 RUN rm xacml-updates-for-curate-with-solr-updates.zip
+
+# Copy all application specific configs
 COPY config/jetty.yml /hydra-jetty-xacml-updates-for-curate-with-solr-updates
+COPY solr_conf/conf/ /hydra-jetty-xacml-updates-for-curate-with-solr-updates/solr/development-core/conf/
+COPY solr_conf/conf/ /hydra-jetty-xacml-updates-for-curate-with-solr-updates/solr/test-core/conf/
 
 ENV JETTY_HOME /hydra-jetty-xacml-updates-for-curate-with-solr-updates
 WORKDIR /hydra-jetty-xacml-updates-for-curate-with-solr-updates

--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ $ docker run -p 8983:8983 -d --name curate-jetty -t ndlib/curate-jetty
 
 And to stop Fedora/Solr if using Docker:
 ```console
-docker stop curate-jetty
-docker rm curate-jetty
+docker stop curate-jetty && docker rm curate-jetty
 ```
 
 You may also need to make sure that mySQL is running as well:

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -237,7 +237,7 @@ class CatalogController < ApplicationController
   end
 
   def self.created_field
-    solr_name('date_created_derived', :stored_searchable , type: :date)
+    solr_name('date_created_derived', :stored_sortable, type: :date)
   end
 
   def self.search_config
@@ -596,8 +596,8 @@ class CatalogController < ApplicationController
     config.add_sort_field "#{uploaded_field} asc", label: "Sort by oldest upload"
     config.add_sort_field "#{modified_field} desc", label: "Sort by newest modification"
     config.add_sort_field "#{modified_field} asc", label: "Sort by oldest modification"
-    config.add_sort_field "ord(#{created_field}) desc", label: "Sort by newest date created"
-    config.add_sort_field "ord(#{created_field}) asc", label: "Sort by oldest date created"
+    config.add_sort_field "#{created_field} desc", label: "Sort by newest date created"
+    config.add_sort_field "#{created_field} asc", label: "Sort by oldest date created"
 
 
     # If there are more than this many search results, no spelling ("did you

--- a/app/repository_models/curation_concern/model.rb
+++ b/app/repository_models/curation_concern/model.rb
@@ -60,6 +60,8 @@ protected
         parse_date(publication_date)
       when self.respond_to?(:date_issued)
         parse_date(date_issued)
+      when self.respond_to?(:date)
+        parse_date(date)
       when self.respond_to?(:date_created)
         parse_date(date_created)
       end

--- a/app/repository_models/curation_concern/model.rb
+++ b/app/repository_models/curation_concern/model.rb
@@ -55,22 +55,19 @@ protected
       # so I'm putting this here. If this changes, then it may make sense to move
       # this logic into the individual model's to_solr methods.
       # See ticket DLTP-1258
-      derived_dates = case true
+      derived_date = case true
       when self.respond_to?(:publication_date)
-        parse_dates(publication_date)
+        parse_date(publication_date)
       when self.respond_to?(:date_issued)
-        parse_dates(date_issued)
+        parse_date(date_issued)
       when self.respond_to?(:date_created)
-        parse_dates(date_created)
+        parse_date(date_created)
       end
-      self.class.create_and_insert_terms('date_created_derived', derived_dates, [:dateable], solr_doc)
+      self.class.create_and_insert_terms('date_created_derived', derived_date, [:stored_sortable], solr_doc)
     end
 
-    def parse_dates(source_dates)
-      Array.wrap(source_dates).each_with_object([]) do |date, mem|
-        mem << Curate::DateFormatter.parse(date.to_s).to_s unless date.blank?
-        mem
-      end
+    def parse_date(source_date)
+      Curate::DateFormatter.parse(source_date.to_s) unless source_date.blank?
     end
 
     def index_collection_pids(solr_doc)

--- a/solr_conf/conf/schema.xml
+++ b/solr_conf/conf/schema.xml
@@ -96,7 +96,7 @@
     <dynamicField name="*_dtim" type="date" stored="false" indexed="true" multiValued="true"/>
     <dynamicField name="*_dts" type="date" stored="true" indexed="false" multiValued="false"/>
     <dynamicField name="*_dtsm" type="date" stored="true" indexed="false" multiValued="true"/>
-    <dynamicField name="*_dtsi" type="date" stored="true" indexed="true" multiValued="false"/>
+    <dynamicField name="*_dtsi" type="date" stored="true" indexed="true" multiValued="false" sortMissingLast="true"/>
     <dynamicField name="*_dtsim" type="date" stored="true" indexed="true" multiValued="true"/>
 
     <!-- trie date (_dtt...) (for faster range queries) -->


### PR DESCRIPTION
## DLTP-1258: Sort missing to bottom

e3adbea324269c2a3898abbbca5a1cef802fd4e4

This can be done at query time using something like 'sort=if(ord(date_created_derived_dtsim),ord(date_created_derived_dtsim),999999) asc', but I decided to do it at the schema level. This required a number of changes:
- Change the schema for the _dtsi field to sortMissingLast
- Change the model to use a single value date field. Which meant changing the params passed to solrizer's create_and_insert_terms method to :stored_sortable, and passing a single date instead of an array of strings (otherwise it would not recognize it as a date field and wouldn't add the _dt suffix
- Changed the catalog controller to match, and no longer need to use ord function since we can sort on a single value date field naturally.
- This also meant fixing a problem with the Dockerfile. Was previously just using the downloaded schema/configs. Had to add a copy command to make sure that the schema used in dev/test were up to date with what's in the curate repo.