### PR TITLE
Display Editor on Books and Book Chapters

### DIFF
--- a/app/views/curation_concern/documents/_document.html.erb
+++ b/app/views/curation_concern/documents/_document.html.erb
@@ -18,6 +18,10 @@
             <dt>Author(s):</dt>
             <dd><%= render_index_field_value(document: solr_doc, field: 'desc_metadata__author_tesim') %></dd>
           <% end %>
+          <% if solr_doc.has?('desc_metadata__editor_tesim') %>
+            <dt>Editor(s):</dt>
+            <dd><%= render_index_field_value(document: solr_doc, field: 'desc_metadata__editor_tesim') %></dd>
+          <% end %>
         <% else %>
           <% if solr_doc.has?('desc_metadata__creator_tesim') %>
             <dt>Author(s):</dt>


### PR DESCRIPTION
DLTP-1395 : Some books do not have Authors, only Editors. This will allow Editors to be seen for Books and Book Chapters in the search.
