### PR TITLE
Change to allow specifying users by net id when managing groups

### DIFF
--- a/app/assets/javascripts/curate/link_users.js.coffee
+++ b/app/assets/javascripts/curate/link_users.js.coffee
@@ -108,14 +108,18 @@
               name = val['fullname']
               label = val['uid'] + " (" + name + ")"
               matches.push {label: label, value: val['id'], name: name}
+            if(matches.length == 0)
+              matches.push { label: "No matches found.", value: 'not_found' }
             response( matches )
         minLength: 2
         focus: ( event, ui ) ->
-          $targetElement.val(ui.item.label)
+          if(ui.item.value != 'not_found')
+            $targetElement.val(ui.item.label)
           event.preventDefault()
         select: ( event, ui ) ->
-          _internals.addExistingUser($targetElement.closest('li'), ui.item.value, ui.item.label, ui.item.name)
-          $targetElement.val('')
+          if(ui.item.value != 'not_found')
+            _internals.addExistingUser($targetElement.closest('li'), ui.item.value, ui.item.label, ui.item.name)
+            $targetElement.val('')
           event.preventDefault()
 
 

--- a/app/assets/javascripts/curate/link_users.js.coffee
+++ b/app/assets/javascripts/curate/link_users.js.coffee
@@ -85,7 +85,7 @@
       template = Handlebars.compile(source)
       template({index: index})
 
-    addExistingUser: ($listItem, value, label) ->
+    addExistingUser: ($listItem, value, label, name) ->
       ## We have multiple places in a view where we need these autocomplete fields
       ## (Work edit view for example), so we don't want to use the first #existing-user-template.
       ## Using .closest isn't working, but this seems to for now.
@@ -93,7 +93,7 @@
       template = Handlebars.compile(source)
       $list = $listItem.closest('ul')
       $('input[required]', $list).removeAttr('required')
-      $listItem.replaceWith template({index: $('li', $list).index($listItem), value: value, label: label})
+      $listItem.replaceWith template({index: $('li', $list).index($listItem), value: value, label: label, name: name})
       _internals.newRow($list)
 
     autocompleteUsers: (el) ->
@@ -105,15 +105,16 @@
           $.getJSON (api), { q: request.term }, ( data, status, xhr) ->
             matches = []
             $.each data.data, (idx, val) ->
-              label = val['uid']+" ("+val['fullname']+")"
-              matches.push {label: label, value: val['id']}
+              name = val['fullname']
+              label = val['uid'] + " (" + name + ")"
+              matches.push {label: label, value: val['id'], name: name}
             response( matches )
         minLength: 2
         focus: ( event, ui ) ->
           $targetElement.val(ui.item.label)
           event.preventDefault()
         select: ( event, ui ) ->
-          _internals.addExistingUser($targetElement.closest('li'), ui.item.value, ui.item.label)
+          _internals.addExistingUser($targetElement.closest('li'), ui.item.value, ui.item.label, ui.item.name)
           $targetElement.val('')
           event.preventDefault()
 

--- a/app/repository_models/hydramata/group_membership_form.rb
+++ b/app/repository_models/hydramata/group_membership_form.rb
@@ -73,7 +73,9 @@ class Hydramata::GroupMembershipForm
     self.members.each do |member|
       group.reload
       if member[:action] == 'create'
-        add_member( person( member[:person_id] ), member[:role] )
+        person_id = member[:person_id]
+        person_id = FindOrCreateUser.call(member[:person_name]).person.id unless person_id.present?
+        add_member( person( person_id ), member[:role] )
       elsif member[:action] == 'destroy'
         group.remove_member( person( member[:person_id] ) )
       elsif member[:action] == 'none'

--- a/app/repository_models/hydramata/group_membership_form.rb
+++ b/app/repository_models/hydramata/group_membership_form.rb
@@ -73,9 +73,9 @@ class Hydramata::GroupMembershipForm
     self.members.each do |member|
       group.reload
       if member[:action] == 'create'
-        person_id = member[:person_id]
-        person_id = FindOrCreateUser.call(member[:person_name]).person.id unless person_id.present?
-        add_member( person( person_id ), member[:role] )
+        # In the case of create, the person_id refers to a netid from LDAP, not a fedora Person
+        user = FindOrCreateUser.call(member[:person_id], member[:person_name])
+        add_member( user.person, member[:role] )
       elsif member[:action] == 'destroy'
         group.remove_member( person( member[:person_id] ) )
       elsif member[:action] == 'none'

--- a/app/services/find_or_create_user.rb
+++ b/app/services/find_or_create_user.rb
@@ -1,0 +1,18 @@
+class FindOrCreateUser
+  def self.call(name)
+    user = User.find_or_create_by(username: name) do |u|
+      u.name = name
+      u.username = name
+    end
+
+    # There are a large number of things that expect a user to always have an associated
+    # Person and Profile object. Make sure this user has one
+    unless user.person && user.person.profile.present?
+      account = Account.to_adapter.get!(user.id)
+      update_status = account.update_with_password({ "name" => user.username })
+      user.reload
+    end
+
+    user
+  end
+end

--- a/app/services/find_or_create_user.rb
+++ b/app/services/find_or_create_user.rb
@@ -1,15 +1,15 @@
 class FindOrCreateUser
-  def self.call(name)
-    user = User.find_or_create_by(username: name) do |u|
+  def self.call(username, name)
+    user = User.find_or_create_by(username: username) do |u|
       u.name = name
-      u.username = name
+      u.username = username
     end
 
     # There are a large number of things that expect a user to always have an associated
     # Person and Profile object. Make sure this user has one
     unless user.person && user.person.profile.present?
       account = Account.to_adapter.get!(user.id)
-      update_status = account.update_with_password({ "name" => user.username })
+      update_status = account.update_with_password({ "username" => user.username, "name" => user.name })
       user.reload
     end
 

--- a/app/services/hydramata/group_membership_action_parser.rb
+++ b/app/services/hydramata/group_membership_action_parser.rb
@@ -19,19 +19,14 @@ module Hydramata::GroupMembershipActionParser
     action=[]
     #validate prescence of required params
     if !params["hydramata_group"]["title"].nil? and !params["hydramata_group"]["description"].nil? and !params["hydramata_group"]["members_attributes"].nil?
-
       params["hydramata_group"]["members_attributes"].each do |key, value|
-        if !value["id"].nil? and !value["_destroy"].nil? and value["_destroy"] == ""
-          #do nothing with membership
-          action << "none"
-        elsif !value["id"].nil? and value["id"] != "" and value["_destroy"].nil?
-          #add member
-          action << "create"
-        elsif !value["id"].nil? and value["id"] != "" and !value["_destroy"].nil?
+        if value["_destroy"].present? && value["id"].present?
           #remove member
           action << "destroy"
-        elsif !value["id"].nil? and value["id"] == "" and value["_destroy"].nil?
-          #empty member field, do nothing with membership
+        elsif value["name"].present? || value["id"].present?
+          #add member
+          action << "create"
+        else
           action << "none"
         end
       end
@@ -39,7 +34,6 @@ module Hydramata::GroupMembershipActionParser
     else
       raise Exception, "Exception placeholder"
     end
-
     action
 
   end
@@ -53,11 +47,10 @@ module Hydramata::GroupMembershipActionParser
     end
     action.each_with_index do |member_action, index|
       person_id = params["hydramata_group"]["members_attributes"][index.to_s]["id"]
-      if person_id.present?
-        role = params["group_member"]["edit_users_ids"].include?(person_id) ? "manager" : "member"
-        new_params_hash = Hash[person_id: person_id, action: member_action, role: role]
-        new_params_aggregate << new_params_hash
-      end
+      person_name = params["hydramata_group"]["members_attributes"][index.to_s]["name"]
+      role = person_id.present? && params["group_member"]["edit_users_ids"].include?(person_id) ? "manager" : "member"
+      new_params_hash = Hash[person_id: person_id, person_name: person_name, action: member_action, role: role]
+      new_params_aggregate << new_params_hash
     end
     { group_id: params[:id], current_user: current_user, title: params["hydramata_group"]["title"], description: params["hydramata_group"]["description"], members: new_params_aggregate, no_record_editors: false }
   end

--- a/app/services/hydramata/group_membership_action_parser.rb
+++ b/app/services/hydramata/group_membership_action_parser.rb
@@ -23,7 +23,7 @@ module Hydramata::GroupMembershipActionParser
         if value["_destroy"].present? && value["id"].present?
           #remove member
           action << "destroy"
-        elsif value["name"].present? || value["id"].present?
+        elsif value["_new"].present? && value["id"].present?
           #add member
           action << "create"
         else

--- a/app/views/hydramata/groups/_linked_members.html.erb
+++ b/app/views/hydramata/groups/_linked_members.html.erb
@@ -43,6 +43,8 @@
               <p target="_new">{{label}}</p>
             </span>
             <input type="hidden" name="<%=prefix %>[members_attributes][{{index}}][id]" value="{{value}}">
+            <input type="hidden" name="<%=prefix %>[members_attributes][{{index}}][_new]" value="{{value}}">
+            <input type="hidden" name="<%=prefix %>[members_attributes][{{index}}][name]" value="{{name}}">
             <span class="field-controls">
               <button class="btn btn-danger remove">
                 <i class="icon-white icon-minus"></i>

--- a/app/views/hydramata/groups/_linked_members.html.erb
+++ b/app/views/hydramata/groups/_linked_members.html.erb
@@ -80,10 +80,11 @@
             </div>
             <div class="span3">
               <% if memberField.object.persisted? %>
+                <% nameLabel = memberField.object.name.present? ? memberField.object.name : memberField.object.user.username %>
                 <% if ( @group.edit_users.include?(memberField.object.user_key) && @group.edit_users.size == 1 ) %>
-                  <span class="linked-user current-user"><%=memberField.object.name %></span>
+                  <span class="linked-user current-user"><%= nameLabel %></span>
                 <% else %>
-                  <span class="linked-user"><%=memberField.object.name %></span>
+                  <span class="linked-user"><%= nameLabel  %></span>
                 <% end %>
                 <% unless ( @group.edit_users.include?(memberField.object.user_key) && @group.edit_users.size == 1 ) %>
                   <span class="field-controls"></span>

--- a/app/views/hydramata/groups/show.html.erb
+++ b/app/views/hydramata/groups/show.html.erb
@@ -29,8 +29,8 @@
 <div class="group-members">
   <ul class="collection-listing">
     <% @group.members.each do |member| %>
-      <li class='collection-member'><%= link_to member.name, person_path(member) %></li>
+      <% nameLabel = member.name.present? ? member.name : member.user.username %>
+      <li class='collection-member'><%= link_to nameLabel, person_path(member) %></li>
     <% end %>
   </ul>
 </div>
-

--- a/spec/services/find_or_create_user_spec.rb
+++ b/spec/services/find_or_create_user_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 RSpec.describe FindOrCreateUser do
   context 'when the user exists' do
-    let!(:user) { FactoryGirl.create(:user, username: 'existing_user') }
-    let(:subject) { FindOrCreateUser.call('existing_user') }
+    let!(:user) { FactoryGirl.create(:user, username: 'existing_user', name: 'Existing User') }
+    let(:subject) { FindOrCreateUser.call('existing_user', 'Existing User') }
 
     it 'does not create a new user' do
       expect(User).not_to receive(:new)
@@ -15,51 +15,51 @@ RSpec.describe FindOrCreateUser do
     end
 
     context 'and it already has an associated person' do
-      let!(:user) { FactoryGirl.create(:user_with_person, username: 'existing_user') }
+      let!(:user) { FactoryGirl.create(:user_with_person, username: 'existing_user', name: 'Existing User') }
 
       it 'does not create a new person' do
         expect(Person).not_to receive(:new)
-        FindOrCreateUser.call('existing_user')
+        FindOrCreateUser.call('existing_user', 'Existing User')
       end
 
       it 'does not create a new profile' do
         expect(Profile).not_to receive(:new)
-        FindOrCreateUser.call('existing_user')
+        FindOrCreateUser.call('existing_user', 'Existing User')
       end
     end
 
     context 'but it does not have an associated person' do
-      let!(:user) { FactoryGirl.create(:user, username: 'existing_user') }
+      let!(:user) { FactoryGirl.create(:user, username: 'existing_user', name: 'Existing User') }
 
       it 'creates a new person if no person is given' do
         # I have no idea atm why this is getting called twice, but it is
         expect(Person).to receive(:new).at_least(:once).and_call_original
-        FindOrCreateUser.call('existing_user')
+        FindOrCreateUser.call('existing_user', 'Existing User')
       end
     end
   end
 
   context 'when the user does not exist' do
-    context 'and a Person object is not provided' do
-      let(:subject) { FindOrCreateUser.call('new_user') }
+    let(:subject) { FindOrCreateUser.call('new_user', 'New User') }
 
-      it 'creates a new user' do
-        expect(User.all.limit(2)).to eq([])
-        subject
-        expect(User.all.limit(2).map(&:name)).to eq(['new_user'])
-      end
+    it 'creates a new user with the given username and name' do
+      expect(User.all.limit(2)).to eq([])
+      subject
+      users = User.all.limit(2)
+      expect(users.map(&:username)).to eq(['new_user'])
+      expect(users.map(&:name)).to eq(['New User'])
+    end
 
-      it 'creates a new person' do
-        expect(Person.all).to eq([])
-        subject
-        expect(Person.all.map(&:name)).to eq(['new_user'])
-      end
+    it 'creates a new person with the given name' do
+      expect(Person.all).to eq([])
+      subject
+      expect(Person.all.map(&:name)).to eq(['New User'])
+    end
 
-      it 'creates a new profile' do
-        expect(Profile.all).to eq([])
-        user = subject
-        expect(Profile.all.map(&:title)).to eq(['new_user'])
-      end
+    it 'creates a new profile with the given name as the title' do
+      expect(Profile.all).to eq([])
+      user = subject
+      expect(Profile.all.map(&:title)).to eq(['New User'])
     end
   end
 end

--- a/spec/services/find_or_create_user_spec.rb
+++ b/spec/services/find_or_create_user_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+RSpec.describe FindOrCreateUser do
+  context 'when the user exists' do
+    let!(:user) { FactoryGirl.create(:user, username: 'existing_user') }
+    let(:subject) { FindOrCreateUser.call('existing_user') }
+
+    it 'does not create a new user' do
+      expect(User).not_to receive(:new)
+      subject
+    end
+
+    it 'returns the existing user' do
+      expect(subject).to eq(user)
+    end
+
+    context 'and it already has an associated person' do
+      let!(:user) { FactoryGirl.create(:user_with_person, username: 'existing_user') }
+
+      it 'does not create a new person' do
+        expect(Person).not_to receive(:new)
+        FindOrCreateUser.call('existing_user')
+      end
+
+      it 'does not create a new profile' do
+        expect(Profile).not_to receive(:new)
+        FindOrCreateUser.call('existing_user')
+      end
+    end
+
+    context 'but it does not have an associated person' do
+      let!(:user) { FactoryGirl.create(:user, username: 'existing_user') }
+
+      it 'creates a new person if no person is given' do
+        # I have no idea atm why this is getting called twice, but it is
+        expect(Person).to receive(:new).at_least(:once).and_call_original
+        FindOrCreateUser.call('existing_user')
+      end
+    end
+  end
+
+  context 'when the user does not exist' do
+    context 'and a Person object is not provided' do
+      let(:subject) { FindOrCreateUser.call('new_user') }
+
+      it 'creates a new user' do
+        expect(User.all.limit(2)).to eq([])
+        subject
+        expect(User.all.limit(2).map(&:name)).to eq(['new_user'])
+      end
+
+      it 'creates a new person' do
+        expect(Person.all).to eq([])
+        subject
+        expect(Person.all.map(&:name)).to eq(['new_user'])
+      end
+
+      it 'creates a new profile' do
+        expect(Profile.all).to eq([])
+        user = subject
+        expect(Profile.all.map(&:title)).to eq(['new_user'])
+      end
+    end
+  end
+end

--- a/spec/services/find_or_create_user_spec.rb
+++ b/spec/services/find_or_create_user_spec.rb
@@ -14,6 +14,11 @@ RSpec.describe FindOrCreateUser do
       expect(subject).to eq(user)
     end
 
+    it 'does not change the name' do
+      subject = FindOrCreateUser.call('existing_user', 'New Name')
+      expect(subject.name).to eq('Existing User')
+    end
+
     context 'and it already has an associated person' do
       let!(:user) { FactoryGirl.create(:user_with_person, username: 'existing_user', name: 'Existing User') }
 
@@ -22,9 +27,19 @@ RSpec.describe FindOrCreateUser do
         FindOrCreateUser.call('existing_user', 'Existing User')
       end
 
+      it 'does not change the person name' do
+        subject = FindOrCreateUser.call('existing_user', 'New Name')
+        expect(subject.person.name).to eq('Existing User')
+      end
+
       it 'does not create a new profile' do
         expect(Profile).not_to receive(:new)
         FindOrCreateUser.call('existing_user', 'Existing User')
+      end
+
+      it 'does not change the profile title' do
+        subject = FindOrCreateUser.call('existing_user', 'New Name')
+        expect(subject.person.profile.title).to eq('Existing User')
       end
     end
 


### PR DESCRIPTION
## Change back-end to allow specifying users by net id

7184add1fb41e4703f88e713b5864bd4c8e0995a

- Changed group_membership_action_parser to implicitly convert a user with a name but no id to a create action. This is to ensure this is passed on to the group_membership_form to create a user before adding to the group 
- Added a new service class that will assist with all of the things involved in creating a new user, including creating a person and profile. Will go back and refactor other things to use this. 
- Changed group_membership_form to create a person and profile if one does not exist for that user name.

## DLTP-1459 Frontend changes

b9c9fabe0ede6f39e312d5d998d3dcbe6088d2e5

Changed front-end settings to allow for ldap search of netid

## Merge pull request #717 from ndlib/DLTP-1459

e31a231a05213439fbf54f4eef5883ffb3218d15

DLTP-1459 Frontend changes

## DLTP-1387: Integrating front end and back end changes

750d8186659cc6970638350e6a507ddfd557a33e

- Changed the _linked_members.html to be a bit more explicit about the action for each user id. For new users it will now have a _new attribute similar to the _destroy. This removes the ambiguity on the back end inside of the group_membership_action_parser
- Changed the _linked_members.html form and the link_users.js to additionally pass the full name of the person
- With these changes, in the case of a 'create' action, the person_id will allways be a netid when it makes it to the group_membership_form. Simplified this code to always call FindOrCreateUser with the given id and name
- Updated the specs to match these changes and added tests to ensure that the user's full name is mapped appropriately to the user/person/profile fields.