### PR TITLE
Fix "mysql Incorrect string value: '\xE2\x9C\x93"\x0As" error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: password
       MYSQL_DATABASE: curate_nd_development
+    volumes:
+      - ./docker/mysql-utf8.cnf:/etc/mysql/conf.d/mysql-utf8.cnf
   jetty:
     image: ndlib/curate-jetty-devseed
     ports:

--- a/docker/mysql-utf8.cnf
+++ b/docker/mysql-utf8.cnf
@@ -1,0 +1,4 @@
+[mysqld]
+character-set-server = utf8
+collation-server = utf8_unicode_ci
+skip-character-set-client-handshake


### PR DESCRIPTION
## Fix "mysql Incorrect string value: '\xE2\x9C\x93"\x0As" error

3de2ec2809f50d2aba51ce29afe3b7f0a22e999f

Problem was that the default character set in mariadb was not being set to utf8. Added a custom config to the docker compose that will set this every time mariadb starts