### PR TITLE
Fix README testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,32 @@ Installing the clamav gem on OS X is a trying process. It can be safely excluded
 from your development environment
 
 ```console
-$ bundle install --without headless
+bundle install --without headless
 ```
 
 ## Testing
 
-You can run `bundle exec rake` to execute the test suite.
+### 1. Start dependencies
+#### With Docker
+```console
+docker-compose -f docker-compose-test.yml up -d
+```
 
-You can also boot up jetty (e.g. `bundle exec rake curatend:jetty:start`) and run individual specs via `bundle exec rspec spec/path/to/file_spec.rb`
+#### Without Docker
+```console
+bundle exec rake curatend:jetty:start
+```
+
+### 2. Run specs
+To execute the full test suite, run
+```console
+bundle exec rake
+```
+To run individual specs, run
+
+```console
+bundle exec rspec spec/path/to/file_spec.rb
+```
 
 ### Testing of Specific Curation Concern Types
 
@@ -40,7 +58,7 @@ Before you start the web-server you'll need to make sure Fedora and SOLR are run
 You can run MySQL, Fedora and Solr via Docker:
 
 ```console
-$ docker-compose up -d
+docker-compose up -d
 ```
 
 #### Without Docker
@@ -48,13 +66,13 @@ $ docker-compose up -d
 Start Fedora and SOLR via jetty:
 
 ```console
-$ bundle exec rake curatend:jetty:start
+bundle exec rake curatend:jetty:start
 ```
 
 Start MySQL:
 
 ```console
-$ mysql.server start
+mysql.server start
 ```
 
 ### 2. Initialize the database
@@ -75,13 +93,13 @@ bundle exec db:seed:dev
 In most cases, you will need SSL, so use this command:
 
 ```console
-$ bundle exec thin start -p 3000 --ssl --ssl-key-file dev_server_keys/server.key --ssl-cert-file dev_server_keys/server.crt
+bundle exec thin start -p 3000 --ssl --ssl-key-file dev_server_keys/server.key --ssl-cert-file dev_server_keys/server.crt
 ```
 
 If you don't need SSL, use the following command:
 
 ```console
-$ bundle exec rails server
+bundle exec rails server
 ```
 
 ## Rebuilding curate-jetty Docker image

--- a/Rakefile
+++ b/Rakefile
@@ -23,7 +23,7 @@ end
 
 Rake::Task['default'].clear rescue true
 task :default do
-  Rake::Task['curatend:travis'].invoke
+  Rake::Task['curatend:ci'].invoke
 end
 
 task :stats => :test_setup


### PR DESCRIPTION
## Fix README testing instructions

e5055942d415481ef59783daa957dea6e816d42d

- Default rake task broke when we removed the travis task: https://github.com/ndlib/curate_nd/pull/714/files#diff-9b9d0be7c5a27195e74231a529524064L57
- Changed rake to run ci instead, which expects dependencies to be started separately
- Added additional instructions to testing. Now describes how to start the test dependencies both with and without docker, similar to other sections
- Removed the prompt $ in the console examples. Was just getting in the way of copy/paste.