### PR TITLE
Addressing load issue in Document

### DIFF
--- a/README_DOCKER.md
+++ b/README_DOCKER.md
@@ -25,6 +25,14 @@ docker-compose exec rails bundle exec rspec spec/path/to/file_spec.rb
 docker-compose exec rails bundle exec byebug --remote localhost:9876
 ```
 
+## Rebuilding rails Docker image
+
+Do this when you change Gemfile or Gemfile.lock or anything that Rails won't hotload.
+
+```console
+docker-compose build rails
+```
+
 ## Rebuilding curate-jetty Docker image
 
 To rebuild the Docker image for running jetty, use the following command:

--- a/app/repository_datastreams/document_datastream.rb
+++ b/app/repository_datastreams/document_datastream.rb
@@ -1,4 +1,5 @@
 require File.expand_path('../../../lib/rdf/qualified_dc', __FILE__)
+require File.expand_path('../../../lib/rdf/nd', __FILE__)
 
 class DocumentDatastream < ActiveFedora::NtriplesRDFDatastream
   map_predicates do |map|


### PR DESCRIPTION
Adding an explicit load for the RDF::ND module. In development,
I encountered the following error:

```console
NameError: uninitialized constant RDF::ND
```

In production this manifested in the Document class not having
the correct predicates in it's inspect. If Document were the first
of the repository models loaded, then the class would say something
like:

```console
Document.new.title
NoMethodError <#Document> does not respond to :title
```

If Document were loaded after other repository models (e.g Image), then
we wouldn't encounter the error, and the Document would have the
expected attributes.

For workers, since usually load one model at a time, they would always
encounter this error. But for web-application facing, they would not,
as Document is one amongst many objects that could be loaded.

DLTP-1520