### PR TITLE
Replacing Access Rights with Record Visibility

### DIFF
--- a/app/views/curate/collections/_form_permission.html.erb
+++ b/app/views/curate/collections/_form_permission.html.erb
@@ -2,7 +2,6 @@
   <fieldset>
     <legend>
       Record Visibility and Access
-      <small>Who should be able to view your collection?</small>
     </legend>
 
     <section class="help-block">

--- a/app/views/curate/collections/_form_permission.html.erb
+++ b/app/views/curate/collections/_form_permission.html.erb
@@ -26,5 +26,9 @@
       </label>
     </div>
 
+    <section class="help-block">
+      <p>Both the record and the attached file(s) will have the same visibility by default. The visibilities can be adjusted individually after uploading. <a href="/faqs">Contact us</a> for help or with questions.</p>
+    </section>
+
   </fieldset>
 </div>

--- a/app/views/curate/collections/_form_permission.html.erb
+++ b/app/views/curate/collections/_form_permission.html.erb
@@ -1,7 +1,7 @@
 <div id="set-access-controls">
   <fieldset>
     <legend>
-      Access Rights
+      Record Visibility
       <small>Who should be able to view your collection?</small>
     </legend>
 

--- a/app/views/curate/collections/_form_permission.html.erb
+++ b/app/views/curate/collections/_form_permission.html.erb
@@ -6,14 +6,9 @@
 
     <section class="help-block">
       <p>
-        <strong>Please note</strong>, making something visible to the world (i.e.
-        marking this as <span class="label label-success">Open Access</span>) may be
-        viewed as publishing which could impact your ability to:
+        <strong>Please note</strong>, making something visible to the world (i.e. marking this as <span class="label label-success">Open Access</span>)
+        may be viewed as publishing which could impact your ability to patent your work and publish your work in a journal. Check out <a href="http://www.sherpa.ac.uk/romeo/">SHERPA/RoMEO</a> for more information about publisher copyright policies.
       </p>
-      <ul>
-        <li>patent your work</li>
-        <li>publish your work in a journal</li>
-      </ul>
     </section>
 
     <div class="control-group">

--- a/app/views/curate/collections/_form_permission.html.erb
+++ b/app/views/curate/collections/_form_permission.html.erb
@@ -1,7 +1,7 @@
 <div id="set-access-controls">
   <fieldset>
     <legend>
-      Record Visibility
+      Record Visibility and Access
       <small>Who should be able to view your collection?</small>
     </legend>
 

--- a/app/views/curation_concern/articles/_attributes.html.erb
+++ b/app/views/curation_concern/articles/_attributes.html.erb
@@ -78,7 +78,7 @@
     <%= curation_concern_attribute_to_html(curation_concern, :spatial_coverage, "Spatial Coverage") %>
     <%= curation_concern_attribute_to_html(curation_concern, :temporal_coverage, "Temporal Coverage") %>
     <tr>
-      <th>Access Rights</th>
+      <th>Record Visibility</th>
       <td>
         <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern } %>
       </td>

--- a/app/views/curation_concern/articles/_attributes.html.erb
+++ b/app/views/curation_concern/articles/_attributes.html.erb
@@ -78,7 +78,7 @@
     <%= curation_concern_attribute_to_html(curation_concern, :spatial_coverage, "Spatial Coverage") %>
     <%= curation_concern_attribute_to_html(curation_concern, :temporal_coverage, "Temporal Coverage") %>
     <tr>
-      <th>Record Visibility</th>
+      <th>Record Visibility and Access</th>
       <td>
         <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern } %>
       </td>

--- a/app/views/curation_concern/audios/_attributes.html.erb
+++ b/app/views/curation_concern/audios/_attributes.html.erb
@@ -31,7 +31,7 @@
     <%= curation_concern_attribute_to_html(curation_concern, :alephIdentifier, "Aleph Record Number") %>
     <%= curation_concern_attribute_to_html(curation_concern, :library_collections, "Member of") %>
     <tr>
-      <th>Access Rights</th>
+      <th>Record Visibility</th>
       <td>
         <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern } %>
       </td>

--- a/app/views/curation_concern/audios/_attributes.html.erb
+++ b/app/views/curation_concern/audios/_attributes.html.erb
@@ -31,7 +31,7 @@
     <%= curation_concern_attribute_to_html(curation_concern, :alephIdentifier, "Aleph Record Number") %>
     <%= curation_concern_attribute_to_html(curation_concern, :library_collections, "Member of") %>
     <tr>
-      <th>Record Visibility</th>
+      <th>Record Visibility and Access</th>
       <td>
         <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern } %>
       </td>

--- a/app/views/curation_concern/base/_form_permission.html.erb
+++ b/app/views/curation_concern/base/_form_permission.html.erb
@@ -5,17 +5,9 @@
 
   <section class="help-block">
     <p>
-      <strong>Please note</strong>, making something visible to the world (i.e.
-      marking this as <span class="label label-success">Open Access</span>) may be
-      viewed as publishing which could impact your ability to:
-    </p>
-    <ul>
-      <li>Patent your work</li>
-      <li>Publish your work in a journal</li>
-    </ul>
-    <p>
-      Check out <a href="http://www.sherpa.ac.uk/romeo/">SHERPA/RoMEO</a> for more
-      information about publisher copyright policies.
+      <strong>Please note</strong>, making something visible to the world (i.e. marking this as <span class="label label-success">Open Access</span>)
+      may be viewed as publishing which could impact your ability to patent your work and publish your work in a journal.
+      Check out <a href="http://www.sherpa.ac.uk/romeo/">SHERPA/RoMEO</a> for more information about publisher copyright policies.
     </p>
   </section>
 

--- a/app/views/curation_concern/base/_form_permission.html.erb
+++ b/app/views/curation_concern/base/_form_permission.html.erb
@@ -1,6 +1,6 @@
 <fieldset id="set-access-controls">
   <legend>
-    Record Visibility
+    Record Visibility and Access
     <small>Who should be able to view or download this content?</small>
   </legend>
 

--- a/app/views/curation_concern/base/_form_permission.html.erb
+++ b/app/views/curation_concern/base/_form_permission.html.erb
@@ -1,7 +1,6 @@
 <fieldset id="set-access-controls">
   <legend>
     Record Visibility and Access
-    <small>Who should be able to view or download this content?</small>
   </legend>
 
   <section class="help-block">

--- a/app/views/curation_concern/base/_form_permission.html.erb
+++ b/app/views/curation_concern/base/_form_permission.html.erb
@@ -32,4 +32,8 @@
     </label>
   </div>
 
+  <section class="help-block">
+    <p>Both the record and the attached file(s) will have the same visibility by default. The visibilities can be adjusted individually after uploading. <a href="/faqs">Contact us</a> for help or with questions.</p>
+  </section>
+
 </fieldset>

--- a/app/views/curation_concern/base/_form_permission.html.erb
+++ b/app/views/curation_concern/base/_form_permission.html.erb
@@ -1,6 +1,6 @@
 <fieldset id="set-access-controls">
   <legend>
-    Access Rights
+    Record Visibility
     <small>Who should be able to view or download this content?</small>
   </legend>
 

--- a/app/views/curation_concern/catholic_documents/_attributes.html.erb
+++ b/app/views/curation_concern/catholic_documents/_attributes.html.erb
@@ -28,7 +28,7 @@
   <%= curation_concern_attribute_to_html(curation_concern, :alephIdentifier,            'Catalog Record') %>
 
   <tr>
-    <th>Record Visibility</th>
+    <th>Record Visibility and Access</th>
     <td>
       <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern } %>
     </td>

--- a/app/views/curation_concern/catholic_documents/_attributes.html.erb
+++ b/app/views/curation_concern/catholic_documents/_attributes.html.erb
@@ -28,7 +28,7 @@
   <%= curation_concern_attribute_to_html(curation_concern, :alephIdentifier,            'Catalog Record') %>
 
   <tr>
-    <th>Access Rights</th>
+    <th>Record Visibility</th>
     <td>
       <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern } %>
     </td>

--- a/app/views/curation_concern/datasets/_attributes.html.erb
+++ b/app/views/curation_concern/datasets/_attributes.html.erb
@@ -26,7 +26,7 @@
     <%= curation_concern_attribute_to_html(curation_concern, :spatial_coverage, "Spatial Coverage") %>
     <%= curation_concern_attribute_to_html(curation_concern, :temporal_coverage, "Temporal Coverage") %>
     <tr>
-      <th>Access Rights</th>
+      <th>Record Visibility</th>
       <td>
         <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern } %>
       </td>

--- a/app/views/curation_concern/datasets/_attributes.html.erb
+++ b/app/views/curation_concern/datasets/_attributes.html.erb
@@ -26,7 +26,7 @@
     <%= curation_concern_attribute_to_html(curation_concern, :spatial_coverage, "Spatial Coverage") %>
     <%= curation_concern_attribute_to_html(curation_concern, :temporal_coverage, "Temporal Coverage") %>
     <tr>
-      <th>Record Visibility</th>
+      <th>Record Visibility and Access</th>
       <td>
         <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern } %>
       </td>

--- a/app/views/curation_concern/documents/_attributes.html.erb
+++ b/app/views/curation_concern/documents/_attributes.html.erb
@@ -55,7 +55,7 @@
   <%= curation_concern_attribute_to_html(curation_concern, :local_identifier,           'Local Identifier') %>
 
   <tr>
-    <th>Record Visibility</th>
+    <th>Record Visibility and Access</th>
     <td>
       <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern } %>
     </td>

--- a/app/views/curation_concern/etds/_attributes.html.erb
+++ b/app/views/curation_concern/etds/_attributes.html.erb
@@ -56,7 +56,7 @@
   <%= curation_concern_attribute_to_html(curation_concern, :coverage_temporal, "Coverage Temporal") %>
   <%= curation_concern_attribute_to_html(curation_concern, :coverage_spatial, "Coverage Spatial") %>
   <tr>
-    <th>Record Visibility</th>
+    <th>Record Visibility and Access</th>
     <td>
       <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern } %>
     </td>

--- a/app/views/curation_concern/finding_aids/_attributes.html.erb
+++ b/app/views/curation_concern/finding_aids/_attributes.html.erb
@@ -17,7 +17,7 @@
           "Catalog Record"
       ) %>
   <tr>
-    <th>Record Visibility</th>
+    <th>Record Visibility and Access</th>
     <td>
       <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern } %>
     </td>

--- a/app/views/curation_concern/generic_files/_attributes.html.erb
+++ b/app/views/curation_concern/generic_files/_attributes.html.erb
@@ -42,7 +42,7 @@
       </tr>
     <% end %>
     <tr>
-      <th>Record Visibility</th>
+      <th>Record Visibility and Access</th>
       <td>
         <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern, show_date: true } %>
       </td>

--- a/app/views/curation_concern/generic_files/_attributes.html.erb
+++ b/app/views/curation_concern/generic_files/_attributes.html.erb
@@ -42,7 +42,7 @@
       </tr>
     <% end %>
     <tr>
-      <th>Access Rights</th>
+      <th>Record Visibility</th>
       <td>
         <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern, show_date: true } %>
       </td>

--- a/app/views/curation_concern/generic_works/_attributes.html.erb
+++ b/app/views/curation_concern/generic_works/_attributes.html.erb
@@ -19,7 +19,7 @@
           "Catalog Record"
       ) %>
   <tr>
-    <th>Record Visibility</th>
+    <th>Record Visibility and Access</th>
     <td>
       <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern } %>
     </td>

--- a/app/views/curation_concern/images/_attributes.html.erb
+++ b/app/views/curation_concern/images/_attributes.html.erb
@@ -76,7 +76,7 @@
     <%= curation_concern_attribute_to_html(curation_concern, :spatial_coverage, "Spatial Coverage") %>
     <%= curation_concern_attribute_to_html(curation_concern, :temporal_coverage, "Temporal Coverage") %>
     <tr>
-      <th>Record Visibility</th>
+      <th>Record Visibility and Access</th>
       <td>
         <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern } %>
       </td>

--- a/app/views/curation_concern/osf_archives/_attributes.html.erb
+++ b/app/views/curation_concern/osf_archives/_attributes.html.erb
@@ -20,7 +20,7 @@
             "Catalog Record"
         ) %>
     <tr>
-      <th>Record Visibility</th>
+      <th>Record Visibility and Access</th>
       <td>
         <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern } %>
       </td>

--- a/app/views/curation_concern/osf_archives/_attributes.html.erb
+++ b/app/views/curation_concern/osf_archives/_attributes.html.erb
@@ -20,7 +20,7 @@
             "Catalog Record"
         ) %>
     <tr>
-      <th>Access Rights</th>
+      <th>Record Visibility</th>
       <td>
         <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern } %>
       </td>

--- a/app/views/curation_concern/patents/_attributes.html.erb
+++ b/app/views/curation_concern/patents/_attributes.html.erb
@@ -31,7 +31,7 @@
       ) %>
 
   <tr>
-    <th>Record Visibility</th>
+    <th>Record Visibility and Access</th>
     <td>
       <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern } %>
     </td>

--- a/app/views/curation_concern/senior_theses/_attributes.html.erb
+++ b/app/views/curation_concern/senior_theses/_attributes.html.erb
@@ -21,7 +21,7 @@
       ) %>
   <%= curation_concern_attribute_to_html(curation_concern, :publisher, "Publisher") %>
   <tr>
-    <th>Record Visibility</th>
+    <th>Record Visibility and Access</th>
     <td>
       <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern } %>
     </td>

--- a/app/views/curation_concern/videos/_attributes.html.erb
+++ b/app/views/curation_concern/videos/_attributes.html.erb
@@ -30,7 +30,7 @@
     <%= curation_concern_attribute_to_html(curation_concern, :alephIdentifier, "Aleph Record Number") %>
     <%= curation_concern_attribute_to_html(curation_concern, :library_collections, "Member of") %>
     <tr>
-      <th>Record Visibility</th>
+      <th>Record Visibility and Access</th>
       <td>
         <%= render partial: 'permission_badge', locals: { curation_concern: curation_concern } %>
       </td>


### PR DESCRIPTION
## Replacing Access Rights with Record Visibility

7da1961406e18a4cb33f836c87a8cd2f56d26b07

Updating the other references from "Access Rights" to "Record
Visibility", and thus better clarify its intented usage.

See https://github.com/ndlib/curate_nd/pull/689

DLTP-1464

## Replacing Record Visibility language

d6b09d43e8a79e183639c322819fb8f029ad1f3b

Based on further refinements and discussion on DLTP-1464, adding further
language to clarify that visibility is also about access.

## Removing grey help text

d734a172622f900e8d4ba90c16281eec336b3b91

Per conversations in DLTP-1464

## Updating guidance on record visibility

bd93cfcd66cf822e9859b16356415cd9f5a79eeb

Per conversations in DLTP-1464, we want to clarify the language.

## Adding additional help text

6c41c628fa1c591412b91935f6fe55f4e4bf393f

Clarifying the relationship in visibility and access between the
record and associated files. Also providing yet another touch-base
point for asking for help.

Related to DLTP-1464
