### PR TITLE
Removing confusing language around files

### DIFF
--- a/app/views/curation_concern/base/_form_files_and_links.html.erb
+++ b/app/views/curation_concern/base/_form_files_and_links.html.erb
@@ -6,10 +6,7 @@
   </div>
 </div>
 <% if curation_concern.persisted? %>
-<p><em>Files are managed from the <%= link_to(
-  "#{curation_concern.human_readable_type.downcase} record view",
-  common_object_path(curation_concern)
-  )%>.
+<p><em>Attachments cannot be deleted, please make them private or <a href="/faqs">contact us</a> to have them removed.
   <% unless curation_concern.generic_files.present? %>
     <br />You must attach at least one file to choose a thumbnail for this <%= curation_concern.human_readable_type.downcase %>.
   <% end %>

--- a/app/views/curation_concern/datasets/_form_files_and_links.html.erb
+++ b/app/views/curation_concern/datasets/_form_files_and_links.html.erb
@@ -13,10 +13,7 @@
   </div>
 </div>
 <% if curation_concern.persisted? %>
-<p><em>Files are managed from the <%= link_to(
-  "#{curation_concern.human_readable_type.downcase} record view",
-    common_object_path(curation_concern)
-  )%>.
+<p><em>Attachments cannot be deleted, please make them private or <a href="/faqs">contact us</a> to have them removed.
   <% unless curation_concern.generic_files.present? %>
     <br />You must attach at least one file to choose a thumbnail for this <%= curation_concern.human_readable_type.downcase %>.
   <% end %>

--- a/app/views/curation_concern/etds/_form_files_and_links.html.erb
+++ b/app/views/curation_concern/etds/_form_files_and_links.html.erb
@@ -6,10 +6,7 @@
   </div>
 </div>
 <% if curation_concern.persisted? %>
-<p><em>Files are managed from the <%= link_to(
-  "#{curation_concern.human_readable_type.downcase} record view",
-  common_object_path(curation_concern)
-  )%>.
+<p><em>Attachments cannot be deleted, please make them private or <a href="/faqs">contact us</a> to have them removed.
   <% unless curation_concern.generic_files.present? %>
     <br />You must attach at least one file to choose a thumbnail for this <%= curation_concern.human_readable_type.downcase %>.
   <% end %>

--- a/app/views/curation_concern/images/_form_files_and_links.html.erb
+++ b/app/views/curation_concern/images/_form_files_and_links.html.erb
@@ -6,10 +6,7 @@
   </div>
 </div>
 <% if curation_concern.persisted? %>
-<p><em>Files are managed from the <%= link_to(
-  "#{curation_concern.human_readable_type.downcase} record view",
-  common_object_path(curation_concern)
-  )%>.
+<p><em>Attachments cannot be deleted, please make them private or <a href="/faqs">contact us</a> to have them removed.
   <% unless curation_concern.generic_files.present? %>
     <br />You must attach at least one file to choose a thumbnail for this <%= curation_concern.human_readable_type.downcase %>.
   <% end %>


### PR DESCRIPTION
Replacing language that talks about managing attachments somewhere else
in the site.

Related to:

* DLTP-1492
* DLTP-1468