### PR TITLE
Removing delete options for repository objects

### DIFF
--- a/app/controllers/curation_concern/generic_files_controller.rb
+++ b/app/controllers/curation_concern/generic_files_controller.rb
@@ -84,13 +84,6 @@ class CurationConcern::GenericFilesController < CurationConcern::BaseController
     end
   end
 
-  def destroy
-    parent = curation_concern.batch
-    flash[:notice] = "Deleted #{curation_concern}"
-    curation_concern.destroy
-    respond_with([:curation_concern, parent])
-  end
-
   register :actor do
     CurationConcern::Utility.actor(curation_concern, current_user, attributes_for_actor)
   end

--- a/app/controllers/curation_concern/generic_works_controller.rb
+++ b/app/controllers/curation_concern/generic_works_controller.rb
@@ -100,20 +100,6 @@ class CurationConcern::GenericWorksController < CurationConcern::BaseController
   end
   protected :after_update_response
 
-  def destroy
-    title = curation_concern.to_s
-    curation_concern.destroy
-    after_destroy_response(title)
-  end
-
-  def after_destroy_response(title)
-    flash[:notice] = "Deleted #{title}"
-    respond_with { |wants|
-      wants.html { redirect_to catalog_index_path }
-    }
-  end
-  protected :after_destroy_response
-
   register :actor do
     CurationConcern::Utility.actor(curation_concern, current_user, attributes_for_actor)
   end

--- a/app/views/catalog/_index_partials/_identifier_and_action.html.erb
+++ b/app/views/catalog/_index_partials/_identifier_and_action.html.erb
@@ -26,18 +26,6 @@
           class: 'itemicon itemedit btn',
           title: "Edit Metadata"
         )%>
-        <% unless document.is_a?(Collection) %>
-          <%= link_to(
-            raw('<i class="icon-trash icon-large"></i>'),
-              [:curation_concern, document],
-              class: 'itemicon itemtrash btn',
-              data: {
-                confirm: "Delete this #{document.human_readable_type}?"
-              },
-              method: :delete,
-              title: "Delete #{document.human_readable_type}"
-            )%>
-        <% end %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/catalog/_thumbnail_result_tile.html.erb
+++ b/app/views/catalog/_thumbnail_result_tile.html.erb
@@ -32,20 +32,6 @@
           class: 'itemicon itemedit btn',
           title: "Edit #{document.human_readable_type}"
         )%>
-
-        <% unless document.is_a?(Collection) %>
-          <% available_actions += 1 %>
-          <%= link_to(
-            raw('<i class="icon-trash icon-large"></i>'),
-            [:curation_concern, document],
-            class: 'itemicon itemtrash btn',
-            data: {
-              confirm: "Delete this #{document.human_readable_type}?"
-            },
-            method: :delete,
-            title: "Delete #{document.human_readable_type}"
-          )%>
-        <% end %>
       <% end %>
     </div>
 

--- a/app/views/common_objects/show.html.erb
+++ b/app/views/common_objects/show.html.erb
@@ -17,9 +17,6 @@
     <%= link_to edit_polymorphic_path([:curation_concern, curation_concern]), class: 'btn btn-default' do %>
       <i class="icon icon-pencil"></i> Edit
     <% end %>
-    <%= link_to [:curation_concern, curation_concern], class: 'btn', data: { confirm: "Delete this #{curation_concern.human_readable_type}?" }, method: :delete do %>
-      <i class="icon icon-trash"></i> Delete
-    <% end %>
   <% end %>
   <% if RepoManager.with_active_privileges?(current_user) %>
     <%= link_to 'Reindex this Item', admin_reindex_pid_path(curation_concern.id) , class: 'btn btn-primary' %>

--- a/app/views/curate/collections/_collection.html.erb
+++ b/app/views/curate/collections/_collection.html.erb
@@ -10,22 +10,6 @@
   </td>
   <td>
     <% if can? :edit, collection %>
-
-      <% unless the_collection_is_my_profile %>
-        <%= button_to(
-          "Delete",
-          {
-            action: :destroy,
-            controller: :collections,
-            id: collection.id
-          },
-          data: {confirm: 'Are you sure you want to delete this collection?'},
-          class: 'btn',
-          form_class: 'button-to pull-right',
-          method: :delete
-        )%>
-      <% end %>
-
       <%= link_to "Edit", edit_collection_path(collection), class: 'btn pull-right' %>
     <% end %>
   </td>

--- a/app/views/curation_concern/base/_related_resources.html.erb
+++ b/app/views/curation_concern/base/_related_resources.html.erb
@@ -26,15 +26,6 @@
               <i class="icon icon-pencil"></i> Edit
               <% end %>
             <% end %>
-            <% if can?(:destroy, link) %>
-              <%= link_to(
-                polymorphic_path([:curation_concern, link]),
-                class: 'btn', method: :delete, title: "Delete #{link.to_s.inspect}",
-                data: {confirm: "Deleting #{link.to_s.inspect} from #{t('sufia.product_name')} is permanent. Click OK to delete this from #{t('sufia.product_name')}, or Cancel to cancel this operation"}
-              ) do %>
-              <i class="icon icon-trash"></i> Delete
-              <% end %>
-            <% end %>
           <% end %>
           </li>
         <% end %>

--- a/app/views/curation_concern/base/show.html.erb
+++ b/app/views/curation_concern/base/show.html.erb
@@ -13,9 +13,6 @@
     <%= link_to edit_polymorphic_path([:curation_concern, curation_concern]), class: 'btn' do %>
       <i class="icon icon-pencil"></i> Edit
     <% end %>
-    <%= link_to [:curation_concern, curation_concern], class: 'btn', data: { confirm: "Delete this #{curation_concern.human_readable_type}?" }, method: :delete do %>
-      <i class="icon icon-trash"></i> Delete
-    <% end %>
   <% end %>
   <% if RepoManager.with_active_privileges?(current_user) %>
     <%= link_to 'Reindex this Item', admin_reindex_pid_path(curation_concern.id) , class: 'btn btn-primary' %>

--- a/app/views/curation_concern/patents/show.html.erb
+++ b/app/views/curation_concern/patents/show.html.erb
@@ -13,9 +13,6 @@
     <%= link_to edit_polymorphic_path([:curation_concern, curation_concern]), class: 'btn' do %>
       <i class="icon icon-pencil"></i> Edit
     <% end %>
-    <%= link_to [:curation_concern, curation_concern], class: 'btn', data: { confirm: "Delete this #{curation_concern.human_readable_type}?" }, method: :delete do %>
-      <i class="icon icon-trash"></i> Delete
-    <% end %>
   <% end %>
   <% if RepoManager.with_active_privileges?(current_user) %>
     <%= link_to 'Reindex this Item', admin_reindex_pid_path(curation_concern.id) , class: 'btn btn-primary' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ CurateNd::Application.routes.draw do
     }
   end
   scope module: 'curate' do
-    resources 'collections', 'profiles', 'profile_sections', controller: 'collections' do
+    resources 'collections', 'profiles', 'profile_sections', controller: 'collections', except: [:destroy] do
       collection do
         get :add_member_form
         put :add_member
@@ -47,7 +47,7 @@ CurateNd::Application.routes.draw do
 
   namespace :curation_concern, path: :concern do
     Curate.configuration.registered_curation_concern_types.map(&:tableize).each do |container|
-      resources container, except: [:index]
+      resources container, except: [:index, :destroy]
     end
     resources( :permissions, only:[]) do
       member do
@@ -58,7 +58,7 @@ CurateNd::Application.routes.draw do
     resources( :linked_resources, only: [:new, :create], path: 'container/:parent_id/linked_resources')
     resources( :linked_resources, only: [:show, :edit, :update, :destroy])
     resources( :generic_files, only: [:new, :create], path: 'container/:parent_id/generic_files')
-    resources( :generic_files, only: [:show, :edit, :update, :destroy]) do
+    resources( :generic_files, only: [:show, :edit, :update]) do
       member do
         get :versions
         put :rollback

--- a/spec/routing/generic_files_routing_spec.rb
+++ b/spec/routing/generic_files_routing_spec.rb
@@ -63,17 +63,4 @@ describe 'generic files routing' do
       )
     )
   end
-
-  it "routes DELETE /concern/container/:parent_id/related_files" do
-    expect(
-      delete: "/concern/generic_files/#{child_id}"
-    ).to(
-      route_to(
-        controller: "curation_concern/generic_files",
-        action: "destroy",
-        id: child_id
-      )
-    )
-  end
-
 end

--- a/spec/support/shared/shared_examples_is_a_curation_concern_controller.rb
+++ b/spec/support/shared/shared_examples_is_a_curation_concern_controller.rb
@@ -145,15 +145,4 @@ shared_examples 'is_a_curation_concern_controller' do |curation_concern_class, o
       end
     end
   end
-
-  if optionally_include_specs(actions, :destroy)
-    describe "#destroy" do
-      let(:work_to_be_deleted) { FactoryGirl.create(default_work_factory_name, user: user) }
-      it "should delete the work" do
-        delete :destroy, id: work_to_be_deleted
-        expect { GenericWork.find(work_to_be_deleted.pid) }.to raise_error
-      end
-    end
-  end
-
 end


### PR DESCRIPTION
## Removing links to delete objects from CurateND

2a82e131be3548f442a7477829ad6c5746a83d70

Per DLTP-1468, we do not want to expose, via the UI, a means of
deleting objects. Object deletion runs contrary to the spirit of
a repository.

## Removing destroy actions and routes

18ca1512c49aeb379396961de721f3c5c2178dfc

As part of DLTP-1468 we no longer want to expose a means of
deleting objects. This runs contrary to the spirit of a digital
repository.
