### PR TITLE
Adding failsafe for byebug server

### DIFF
--- a/config/initializers/byebug.rb
+++ b/config/initializers/byebug.rb
@@ -2,6 +2,10 @@ if Rails.env.development?
   require 'byebug/core'
   #Byebug.wait_connection = true
   port = ENV.fetch("BYEBUG_SERVER_PORT", 9876).to_i
-  print "Starting byebug server for remote debugging on port #{port}\n"
-  Byebug.start_server 'localhost', port
+  begin
+    print "Starting byebug server for remote debugging on port #{port}\n"
+    Byebug.start_server 'localhost', port
+  rescue Errno::EADDRNOTAVAIL
+    puts "Port #{port} already in use. It could be byebug"
+  end
 end


### PR DESCRIPTION
Prior to this change when using `docker-sync-stack start` then running
`docker-compose exec rails bundle exec rake routes` (or any other
`bundle exec` command in the docker context), the command would fail
with the following message:

```console
Starting byebug server for remote debugging on port 9876
rake aborted!
Errno::EADDRNOTAVAIL: Cannot assign requested address -
    bind(2) for "localhost" port 9877
```

After this change when using `docker-sync-stack start` then running
`bundle exec` command in the docker context the command would succeed
and in the console output I got the following:

```console
Starting byebug server for remote debugging on port 9876
Port 9876 already in use. It could be byebug
```