### PR TITLE
Deleting group redirects to groups#index DLTP-1481

### DIFF
--- a/app/controllers/hydramata/groups_controller.rb
+++ b/app/controllers/hydramata/groups_controller.rb
@@ -82,7 +82,7 @@ class Hydramata::GroupsController < ApplicationController
   def after_destroy_response(title)
     flash[:notice] = "Deleted #{title}"
     respond_with { |wants|
-      wants.html { redirect_to catalog_index_path }
+      wants.html { redirect_to hydramata_groups_path }
     }
   end
 


### PR DESCRIPTION
Prior to this commit, when deleting a group, the action would redirect
the user to the catalog controller's index. This was confusing and
something unexpected in the Rails default behavior.

With this commit, whenever a group is deleted, the user is redirected
to the groups#index action.

DLTP-1481