### PR TITLE
Adding "Calculating…" to file size

### DIFF
--- a/app/controllers/curation_concern/generic_files_controller.rb
+++ b/app/controllers/curation_concern/generic_files_controller.rb
@@ -43,6 +43,7 @@ class CurationConcern::GenericFilesController < CurationConcern::BaseController
     curation_concern.batch = parent
     if actor.create
       curation_concern.update_parent_representative_if_empty(parent)
+      flash[:notice] = "You have uploaded a new file. We are processing it now."
       respond_with([:curation_concern, parent])
     else
       respond_with([:curation_concern, curation_concern]) { |wants|

--- a/app/views/curation_concern/base/_related_files_rows.html.erb
+++ b/app/views/curation_concern/base/_related_files_rows.html.erb
@@ -26,7 +26,8 @@
   </td>
   <td class="attribute attribute-filename"><%= generic_file.filename %></td>
   <td class="attribute attribute-description"><%= generic_file.description %></td>
-  <td class="attribute attribute-size"><%= number_to_human_size(generic_file.characterization_terms[:file_size].first.to_i) %></td>
+  <% file_size = generic_file.characterization_terms[:file_size].first.to_i %>
+  <td class="attribute attribute-size"><%= file_size > 0 ? number_to_human_size(file_size) : raw("Calculating&hellip;") %></td>
   <td class="attribute attribute-type"><%= generic_file.characterization_terms[:mime_type] %></td>
   <td class="attribute attribute-access">
     <%= render(


### PR DESCRIPTION
We determine the file size as part of the characterization process.
The characterization process runs asynchronous to the request cycle.
As such, it is likely that the file size has not yet been determined
when the application redirects the user after a successful file upload.

This adjustment corrects that behavior.

Closes DLTP-1524