### PR TITLE
Edit versions expects single file

### DIFF
--- a/app/services/curation_concern/generic_file_actor.rb
+++ b/app/services/curation_concern/generic_file_actor.rb
@@ -32,7 +32,7 @@ module CurationConcern
 
     protected
     def update_file
-      file = attributes.delete(:file)
+      file = Array.wrap(attributes.delete(:file)).first
       title = attributes[:title]
       title ||= file.original_filename if file
       curation_concern.label = title

--- a/app/views/curation_concern/generic_files/_form.html.erb
+++ b/app/views/curation_concern/generic_files/_form.html.erb
@@ -1,4 +1,10 @@
 <%= simple_form_for [:curation_concern, curation_concern], :html => { :onsubmit => "return validateCurationConcernForm(this);", "data-model-name" => curation_concern.class.model_name.singular } do |f| %>
+<% if request.filtered_parameters["action"] == "edit" %>
+  <% multiple_allowed = false %>
+<% else %>
+  <% multiple_allowed = true %>
+<% end %>
+
   <div class="row">
     <div class="span6">
       <fieldset class="required">
@@ -10,7 +16,7 @@
         </legend>
           <%= f.input :file,
                       as: :file,
-                      input_html: {multiple: true},
+                      input_html: {multiple: multiple_allowed},
                       label: 'Upload files'
           %>
       </fieldset>

--- a/db/seeds/dev.rb
+++ b/db/seeds/dev.rb
@@ -76,9 +76,9 @@ attributes = { title: "Test Library Collection", description: "A collection for 
 puts "#{attributes[:title]}"
 coll1 = find_or_create_library_collection('test_collection', user_with_profile, attributes)
 
-# make >10 subcollections
+# make subcollections
 puts "Creating subcollections with a member work"
-12.times do |i|
+2.times do |i|
   attributes = { title: "Test SubCollection #{i}", description: "#{i} subcollection for testing", depositor: user_with_profile.username, creator: user_with_profile.username, contributor: user_with_profile.username, date_created: date_created, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
   coll = find_or_create_library_collection("test_subcollection_#{i}", user_with_profile, attributes)
   coll1.library_collection_members << coll


### PR DESCRIPTION
Fixes DLTP-1517

Multiple uploads are allow when adding files, but when changing a file only one can be changed at a time. Since the actor expects to replace a single file, it now picks up the first file from the array. The form is also changed to not allow multiple files to be uploaded in this case.