### PR TITLE
Removing "My Collections" button

### DIFF
--- a/app/views/shared/_my_actions.html.erb
+++ b/app/views/shared/_my_actions.html.erb
@@ -5,7 +5,6 @@
   </a>
   <ul class="dropdown-menu">
     <li><%= link_to 'My Works',       catalog_index_path(:'f[generic_type_sim][]' => 'Work', works: 'mine'), class: 'my-works',       role: 'menuitem' %></li>
-    <li><%= link_to 'My Collections', collections_path,                                                      class: 'my-collections', role: 'menuitem' %></li>
     <li><%= link_to 'Group Administration',      hydramata_groups_path,                                                 class: 'my-groups',      role: 'menuitem' %></li>
     <li><%= link_to 'My Account',     user_profile_path,                                                     class: 'my-account',     role: 'menuitem' %></li>
     <% if CurateND::AdminConstraint.is_admin?(current_user) %>


### PR DESCRIPTION
Per DLTP-1537:

> the 'Manage > My Collection' button is creating confusion amongst
> users that they can create their own collections.
>
> Per Don Brower, the user collection functionality was removed two
> years ago, and so this button should be removed.