### PR TITLE
Replacing "Open Access" with "Public"

### DIFF
--- a/app/helpers/curate_helper.rb
+++ b/app/helpers/curate_helper.rb
@@ -303,10 +303,10 @@ module CurateHelper
       if hash[Hydra.config[:permissions][:read][:group]].include?('public')
         if hash[Hydra.config[:permissions][:embargo_release_date]].present?
           dom_label_class = 'label-warning'
-          link_title = 'Open Access with Embargo'
+          link_title = 'Embargo then Public'
         else
           dom_label_class = 'label-success'
-          link_title = 'Open Access'
+          link_title = 'Public'
         end
       elsif hash[Hydra.config[:permissions][:read][:group]].include?('registered')
         dom_label_class = 'label-info'

--- a/app/models/access_renderer.rb
+++ b/app/models/access_renderer.rb
@@ -76,7 +76,7 @@ class AccessRenderer
         qualifier = "until #{human_readable_embargo_release_date}"
       elsif publically_viewable?
         dom_label_class = 'label-success'
-        link_title = 'Open Access'
+        link_title = 'Public'
       elsif viewable_by_institution?
         dom_label_class = 'label-info'
         link_title = I18n.t('sufia.institution_name')

--- a/app/views/curate/collections/_form_permission.html.erb
+++ b/app/views/curate/collections/_form_permission.html.erb
@@ -6,7 +6,7 @@
 
     <section class="help-block">
       <p>
-        <strong>Please note</strong>, making something visible to the world (i.e. marking this as <span class="label label-success">Open Access</span>)
+        <strong>Please note</strong>, making something visible to the world (i.e. marking this as <span class="label label-success">Public</span>)
         may be viewed as publishing which could impact your ability to patent your work and publish your work in a journal. Check out <a href="http://www.sherpa.ac.uk/romeo/">SHERPA/RoMEO</a> for more information about publisher copyright policies.
       </p>
     </section>
@@ -14,7 +14,7 @@
     <div class="control-group">
       <label class="radio">
         <input type="radio" id="visibility_open" name="<%= f.object_name %>[visibility]" value="<%= Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC %>" <% if @collection.open_access? %> checked="true"<% end %>/>
-        <span class="label label-success">Open Access</span> Visible to the world.
+        <span class="label label-success">Public</span> Visible to the world.
       </label>
       <label class="radio">
         <input type="radio" id="visibility_ndu" name="<%= f.object_name %>[visibility]" value="<%= Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED %>" <% if @collection.authenticated_only_access? %> checked="true"<% end %> />

--- a/app/views/curation_concern/articles/edit.html.erb
+++ b/app/views/curation_concern/articles/edit.html.erb
@@ -6,7 +6,7 @@
     The more complete the description the easier it will be to find by yourself and others.
   </p>
   <p>
-    Please consider releasing your article as an Open Access work.
+    Please consider releasing your article as a Public work.
   </p>
 <% end %>
 

--- a/app/views/curation_concern/base/_form_permission.html.erb
+++ b/app/views/curation_concern/base/_form_permission.html.erb
@@ -5,7 +5,7 @@
 
   <section class="help-block">
     <p>
-      <strong>Please note</strong>, making something visible to the world (i.e. marking this as <span class="label label-success">Open Access</span>)
+      <strong>Please note</strong>, making something visible to the world (i.e. marking this as <span class="label label-success">Public</span>)
       may be viewed as publishing which could impact your ability to patent your work and publish your work in a journal.
       Check out <a href="http://www.sherpa.ac.uk/romeo/">SHERPA/RoMEO</a> for more information about publisher copyright policies.
     </p>
@@ -16,11 +16,11 @@
   <div class="control-group" onchange="embargoDateRequired(event.target.id, '<%= f.object_name %>');">
     <label class="radio">
       <input type="radio" id="visibility_open" name="<%= f.object_name %>[visibility]" value="<%= Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC %>" <% if !curation_concern.persisted? || (access_controls.viewable? && access_controls.publically_viewable?) %> checked="true"<% end %>/>
-      <span class="label label-success">Open Access</span> Visible to the world.
+      <span class="label label-success">Public</span> Visible to the world.
     </label>
     <label class="radio">
       <input type="radio" id="visibility_embargo" name="<%= f.object_name %>[visibility]" value="<%= Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO %>" <% if curation_concern.persisted? && access_controls.viewable? && access_controls.has_embargo? && access_controls.currently_under_embargo? %> checked="true"<% end %>/>
-      <span class="label label-warning">Open Access with Embargo</span> Treated as <span class="label label-important">Private</span> until <%= f.input :embargo_release_date, wrapper: :inline, input_html: { placeholder: Date.tomorrow, class: 'input-small datepicker' } %> then it is <span class="label label-success">Open Access</span>.
+      <span class="label label-warning">Embargo then Public</span> Treated as <span class="label label-important">Private</span> until <%= f.input :embargo_release_date, wrapper: :inline, input_html: { placeholder: Date.tomorrow, class: 'input-small datepicker' } %> then it is <span class="label label-success">Public</span>.
     </label>
     <label class="radio">
       <input type="radio" id="visibility_ndu" name="<%= f.object_name %>[visibility]" value="<%= Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED %>" <% if curation_concern.persisted? && access_controls.viewable? && access_controls.viewable_by_institution_today? %> checked="true"<% end %> />

--- a/app/views/curation_concern/generic_works/edit.html.erb
+++ b/app/views/curation_concern/generic_works/edit.html.erb
@@ -6,7 +6,7 @@
     The more complete the description the easier it will be to find by yourself and others.
   </p>
   <p>
-    Please consider releasing your <%=curation_concern.human_readable_type.downcase %> as an Open Access work.
+    Please consider releasing your <%= curation_concern.human_readable_type.downcase %> as a <span class="label label-success">Public</span> work.
   </p>
 <% end %>
 

--- a/app/views/curation_concern/generic_works/new.html.erb
+++ b/app/views/curation_concern/generic_works/new.html.erb
@@ -6,7 +6,7 @@
   All starred fields are required. Additional fields can be filled in as appropriate. More descriptive information will help others find your work.
 </p>
 <p>
-  Please consider releasing your <%= curation_concern.human_readable_type.downcase %> as an <span class="label label-success">Open Access</span> work.
+  Please consider releasing your <%= curation_concern.human_readable_type.downcase %> as a <span class="label label-success">Public</span> work.
 </p>
 
 <% end %>

--- a/app/views/curation_concern/senior_theses/edit.html.erb
+++ b/app/views/curation_concern/senior_theses/edit.html.erb
@@ -6,7 +6,7 @@
     The more complete the description the easier it will be to find by yourself and others.
   </p>
   <p>
-    Please consider releasing your thesis as an Open Access work.
+    Please consider releasing your <%= curation_concern.human_readable_type.downcase %> as a <span class="label label-success">Public</span> work.
   </p>
 <% end %>
 

--- a/app/views/curation_concern/senior_theses/new.html.erb
+++ b/app/views/curation_concern/senior_theses/new.html.erb
@@ -6,7 +6,7 @@
   All starred fields are required. Additional fields can be filled in as appropriate. More descriptive information will help others find your work.
 </p>
 <p>
-  Please consider releasing your <%= curation_concern.human_readable_type.downcase %> as an <span class="label label-success">Open Access</span> work.
+  Please consider releasing your <%= curation_concern.human_readable_type.downcase %> as a <span class="label label-success">Public</span> work.
 </p>
 
 <% end %>

--- a/app/views/static_pages/policies-designated-communities.html.erb
+++ b/app/views/static_pages/policies-designated-communities.html.erb
@@ -30,8 +30,8 @@
   </p>
 
   <ul>
-    <li><strong>Open Access</strong> This content is accessible to the world.</li>
-    <li><strong>Open Access with Embargo</strong> This content is accessible to the world after a date set by an editor.</li>
+    <li><strong>Public</strong> This content is accessible to the world.</li>
+    <li><strong>Embargo then Public</strong> This content is accessible to the world after a date set by an editor.</li>
     <li><strong>University of Notre Dame</strong> This content is only accessible to patrons with an active Notre Dame netid.  In certain cases, non-ND collaborators will also have access as noted above.<a href="#no-longer-affiliated">*</a></li>
     <li><strong>Private</strong> This content is only accessible to the editors, including any non-ND collaborators.<a href="#no-longer-affiliated">*</a></li>
   </ul>

--- a/spec/helpers/curate_helper_spec.rb
+++ b/spec/helpers/curate_helper_spec.rb
@@ -231,9 +231,9 @@ RSpec.describe CurateHelper do
     describe 'with a "public" access group' do
       let(:access_policy) { 'public' }
       describe 'without embargo release date' do
-        let(:expected_label) { "Open Access" }
+        let(:expected_label) { "Public" }
         let(:visibility) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC}
-        it 'renders an "Open Access" label' do
+        it 'renders an "Public" label' do
           rendered = helper.link_to_edit_permissions(curation_concern, solr_document)
           expect(rendered).to(
             have_tag("a#permission_#{curation_concern.to_param}") {
@@ -244,10 +244,10 @@ RSpec.describe CurateHelper do
       end
 
       describe 'with an embargo release date' do
-        let(:expected_label) { "Open Access with Embargo" }
+        let(:expected_label) { "Embargo then Public" }
         let(:embargo_release_date) { Date.today.to_s }
         let(:visibility) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC}
-        it 'renders an "Open Access with Embargo" label' do
+        it 'renders an "Embargo then Public" label' do
           rendered = helper.link_to_edit_permissions(curation_concern, solr_document)
           expect(rendered).to(
             have_tag("a#permission_#{curation_concern.to_param}") {
@@ -262,9 +262,9 @@ RSpec.describe CurateHelper do
       # This test is purely speculative to the appropriate labeling behavior and
       # does not account for whether the document is truly accessable; I suppose
       # I'm persisting hash drive development via a Solr document
-      let(:expected_label) { "Open Access" }
+      let(:expected_label) { "Public" }
       let(:access_policy) { 'public registered' }
-      it 'renders an "Open Access" label' do
+      it 'renders an "Public" label' do
         rendered = helper.link_to_edit_permissions(curation_concern, solr_document)
         expect(rendered).to(
           have_tag("a#permission_#{curation_concern.to_param}") {


### PR DESCRIPTION
> Change every instance of the "Open Access" access rights badge to read
> "Public". Also change the "Open Access with Embargo" to
> "Embargo then Public". This will span show pages and edit pages.

In addition, I found a form inconsistency in which some forms rendered
"Public" with a badge/label and others did not. For these cases, I opted
to normalize rendering "Public" with a badge/label.

DLTP-1540

Related to https://github.com/ndlib/sipity/pull/1183