### PR TITLE
Adding form validation for attachments

### DIFF
--- a/app/views/curation_concern/generic_files/_form.html.erb
+++ b/app/views/curation_concern/generic_files/_form.html.erb
@@ -17,7 +17,8 @@
           <%= f.input :file,
                       as: :file,
                       input_html: {multiple: multiple_allowed},
-                      label: 'Upload files'
+                      label: 'Upload files',
+                      required: true
           %>
       </fieldset>
     </div>


### PR DESCRIPTION
By adding the "required: true" attribute to the `f.input :file`,
when I go to click the Submit button for the form, if I have not
attached a file, then the the HTML 5 required attribute renders
a "! Please select one or more files" warning pointing to the
file input element.

DLTP-1530