### PR TITLE
Refining Doi::Datacite.normalize_identifier

### DIFF
--- a/app/services/doi/datacite.rb
+++ b/app/services/doi/datacite.rb
@@ -7,11 +7,8 @@ module Doi
 
     def self.normalize_identifier(value)
       value.to_s.strip.
-        sub(/\A#{resolver_url}\/*/, '').
-        sub(/\A\s*doi:\s+/, 'doi:').
-        sub(/\A(\d.*)/, 'doi:\1').
-        sub(/\Adoi\s*:\s*/, 'doi:').
-        sub(/\A(doi:\d*.\d*)\s*\/\s*(\w*)/, '\1/\2')
+        gsub(" ", '').
+        sub(/\A.*10\./, "doi:10.")
     end
 
     def self.remote_uri_for(identifier)

--- a/spec/services/doi/datacite_spec.rb
+++ b/spec/services/doi/datacite_spec.rb
@@ -1,3 +1,4 @@
+require 'spec_helper'
 
 module Doi
   RSpec.describe Datacite do
@@ -27,58 +28,17 @@ module Doi
     end
 
     describe '#normalize_identifier' do
-      it 'returns only the doi when given a url to the resolver instead of the doi' do
-        expect(subject.normalize_identifier("#{ENV.fetch('DOI_RESOLVER')}/doi:123")).to eq('doi:123')
-      end
-
-      it 'returns the doi with "doi:" prefix if only the numeric identifier is given' do
-        expect(subject.normalize_identifier("10.25626/abc123")).to eq('doi:10.25626/abc123')
-      end
-
-      context 'removes extra spaces in the identifier' do
-        it 'such as " doi:10.25626/abc123"' do
-          expect(subject.normalize_identifier(' doi:10.25626/abc123')).to eq('doi:10.25626/abc123')
+      [
+        ["#{ENV.fetch('DOI_RESOLVER')}/doi:10.123", 'doi:10.123'],
+        ["10.25626/abc123", 'doi:10.25626/abc123'],
+        [" doi:10.25626/abc123", 'doi:10.25626/abc123'],
+        ["doi:10.25626/abc123 ", 'doi:10.25626/abc123'],
+        ["doi: 10.25626/abc123", 'doi:10.25626/abc123'],
+        ["doi: 10.25626 / abc123", 'doi:10.25626/abc123']
+      ].each do |given, expected|
+        it "normalizes #{given.inspect} to #{expected.inspect}" do
+          expect(subject.normalize_identifier(given)).to eq(expected)
         end
-
-        it 'such as "doi:10.25626/abc123 "' do
-          expect(subject.normalize_identifier('doi:10.25626/abc123 ')).to eq('doi:10.25626/abc123')
-        end
-
-        it 'such as "doi: 10.25626/abc123"' do
-          expect(subject.normalize_identifier('doi: 10.25626/abc123')).to eq('doi:10.25626/abc123')
-        end
-
-        it 'such as "doi :10.25626/abc123"' do
-          expect(subject.normalize_identifier('doi :10.25626/abc123')).to eq('doi:10.25626/abc123')
-        end
-
-        it 'such as "doi : 10.25626/abc123"' do
-          expect(subject.normalize_identifier('doi : 10.25626/abc123')).to eq('doi:10.25626/abc123')
-        end
-
-        it 'such as "doi:10.25626 /abc123"' do
-          expect(subject.normalize_identifier('doi:10.25626 /abc123')).to eq('doi:10.25626/abc123')
-        end
-
-        it 'such as "doi:10.25626/ abc123"' do
-          expect(subject.normalize_identifier('doi:10.25626/ abc123')).to eq('doi:10.25626/abc123')
-        end
-
-        it 'such as "doi:10.25626 / abc123"' do
-          expect(subject.normalize_identifier('doi:10.25626 / abc123')).to eq('doi:10.25626/abc123')
-        end
-
-        it 'such as "doi:10.25626 / abc123 "' do
-          expect(subject.normalize_identifier('doi:10.25626 / abc123 ')).to eq('doi:10.25626/abc123')
-        end
-
-        it 'such as "doi : 10.25626 / abc123 "' do
-          expect(subject.normalize_identifier('doi : 10.25626 / abc123 ')).to eq('doi:10.25626/abc123')
-        end
-      end
-
-      it 'returns the doi without transformation if it is already correct' do
-        expect(subject.normalize_identifier('doi:10.25626/abc123')).to eq('doi:10.25626/abc123')
       end
     end
 

--- a/spec/services/doi/datacite_spec.rb
+++ b/spec/services/doi/datacite_spec.rb
@@ -34,7 +34,9 @@ module Doi
         [" doi:10.25626/abc123", 'doi:10.25626/abc123'],
         ["doi:10.25626/abc123 ", 'doi:10.25626/abc123'],
         ["doi: 10.25626/abc123", 'doi:10.25626/abc123'],
-        ["doi: 10.25626 / abc123", 'doi:10.25626/abc123']
+        ["doi: 10.25626 / abc123", 'doi:10.25626/abc123'],
+        ['https://doi:10.123/abc', 'doi:10.123/abc'],
+        ["https://doi.org/10.1002/ppsc.201700420", "doi:10.1002/ppsc.201700420"]
       ].each do |given, expected|
         it "normalizes #{given.inspect} to #{expected.inspect}" do
           expect(subject.normalize_identifier(given)).to eq(expected)


### PR DESCRIPTION
## Adding testing tables

2a3e70e495172e63711caa3253374cb85c2f5e14

Instead of the chatty individual rspec scenarios, compress those into a
test tables. This helps clarify at a glance what is being tested.

## Refining Doi::Datacite.normalize_identifier

64fb24fa753b262d90c96d5efbe2abfc11b42a5a

Based on the following comment in JIRA, the solution is to ensure that
past scenarios continue to work when we apply different implementations
of the normalize_identifier.

> We've seen this before: https://github.com/ndlib/curate_nd/issues/201
>
> As noted there, a DOI is not a URL. Also, there appears to be no
> standard for prefixing DOIs. I think the best normalization routine is
> to look for the initial "10." in the DOI, strip of everything before
> and prefix it with "doi:".
>
> DOIs in that format seem to resolve ok, since the dx.doi.org resolver
> can deal with a "doi:" prefix.

DLTP-1528
