### PR TITLE
Ensuring expanded ToS allows acceptance

### DIFF
--- a/app/controllers/terms_of_service_agreements_controller.rb
+++ b/app/controllers/terms_of_service_agreements_controller.rb
@@ -11,6 +11,7 @@ class TermsOfServiceAgreementsController < ApplicationController
   def create
     if user_just_agreed_to_tos?
       current_user.agree_to_terms_of_service!
+      flash[:notice] = "You've agreed to the Terms of Service."
       redirect_to new_classify_concern_path
     else
       flash.now[:notice] = "To proceed, you must agree to the Terms of Service."

--- a/app/controllers/terms_of_service_agreements_controller.rb
+++ b/app/controllers/terms_of_service_agreements_controller.rb
@@ -11,8 +11,10 @@ class TermsOfServiceAgreementsController < ApplicationController
   def create
     if user_just_agreed_to_tos?
       current_user.agree_to_terms_of_service!
-      flash[:notice] = "You've agreed to the Terms of Service."
-      redirect_to new_classify_concern_path
+      # The standard use case for users accepting ToS is that they are entering
+      # the system for the first time. As such, the next likely step is filling out their
+      # registration information.
+      redirect_to edit_user_registration_path, notice: "You've agreed to the Terms of Service. Please fill out your account details."
     else
       flash.now[:notice] = "To proceed, you must agree to the Terms of Service."
       render 'new'

--- a/app/views/terms_of_service_agreements/new.html.erb
+++ b/app/views/terms_of_service_agreements/new.html.erb
@@ -15,145 +15,145 @@
     <%= submit_tag controller.i_agree_text, id: 'tos-agree', class: 'btn btn-large btn-primary tos-agree' %>
     <%= submit_tag controller.i_do_not_agree_text, id: 'tos-disagree', class: 'btn btn-large btn-link tos-disagree'  %>
   </div>
+<% end %>
 
+<div id="full-terms-of-service" class="full-terms-of-service modal hide fade" tabindex="-1" role="dialog" aria-labelledby="terms-of-service" aria-hidden="true">
+  <div class="modal-header">
+    <button type="button" class="close" data-dismiss="modal" aria-hidden="true"><i class="icon icon-remove"></i></button>
+    <h3 id="terms-of-service"><%= I18n.t('sufia.product_name')%> Terms of Service</h3>
+    <a href="javascript:window.print()" class="btn print"><i class="icon icon-print"></i> Print</a>
+  </div>
+  <div class="modal-body">
 
-  <div id="full-terms-of-service" class="full-terms-of-service modal hide fade" tabindex="-1" role="dialog" aria-labelledby="terms-of-service" aria-hidden="true">
-    <div class="modal-header">
-      <button type="button" class="close" data-dismiss="modal" aria-hidden="true"><i class="icon icon-remove"></i></button>
-      <h3 id="terms-of-service"><%= I18n.t('sufia.product_name')%> Terms of Service</h3>
-      <a href="javascript:window.print()" class="btn print"><i class="icon icon-print"></i> Print</a>
+    <article class="terms-of-service">
+      <ol>
+        <li>
+          <p>
+            General: <%= I18n.t('sufia.product_name') %> is maintained by the <%= I18n.t('sufia.institution_name') %> Libraries in support of our mission to disseminate information and research to scholars, educators and the public.
+            As used in these Terms of Use, the terms &ldquo;University,&rdquo; &ldquo;we, &ldquo;us,&rdquo; and &ldquo;our&rdquo; refer to the <%= I18n.t('sufia.institution_name') %>.
+            Use of <%= I18n.t('sufia.product_name') %> (the Site and its contents) is subject to the following terms and conditions and all applicable laws.
+            By using the Site or any of its content, you accept and agree to be bound by these Terms of Use and all applicable laws.
+            If any of these Terms of Use are unacceptable to you, do not use the Site.
+          </p>
+        </li>
+
+        <li>
+          <p>
+            Changes to Terms of Use Are Binding: We may change these Terms of Use from time-to-time without advance notice.
+            Your use of the Site or any of its content after any changes have been made will constitute your agreement on a prospective basis to the modified Terms of Use and all of the changes.
+            Accordingly, you should read these Terms of Use from time-to-time for any changes.
+          </p>
+        </li>
+
+        <li>
+          <p>
+            Copyright and Use of <%= I18n.t('sufia.product_name') %> Content: <%= I18n.t('sufia.product_name') %> includes text, images, graphics, information, articles, multi-media objects, scholarly projects and other works protected by copyright, trademark and other laws (&ldquo;Content&rdquo;).
+            Some of the Content on this site may include materials from older published works that have passed into the &ldquo;public domain&rdquo; under U.S. copyright law.
+            Where such information is known, it is included specifically in the metadata associated with each item of Content.
+            However, the Site itself and most of the materials held as Content on the Site are protected by copyright and other laws.
+            These materials have been deposited to enable teaching, research, and other non-profit educational activities.
+            Unless otherwise specified in the metadata attached to an item of Content, you may use the Site and the Content only for non-commercial, research, educational, or related academic purposes.
+            Further, you have the responsibility to make your own assessment of the copyright or other legal concerns that might affect your use of <%= I18n.t('sufia.product_name') %> content and to assume personal responsibility for your uses of Content.
+          </p>
+        </li>
+
+        <li>
+          <p>
+            Special Permissions: <%= I18n.t('sufia.product_name') %> does not have the authority to grant or deny special permissions to use images or other Content found on the site beyond those uses that are specifically described in these Terms of Use or as noted specifically on individual items of Content.
+            <%= I18n.t('sufia.product_name') %> staff are not able to undertake copyright investigations on behalf of Site users.
+          </p>
+        </li>
+
+        <li>
+          <p>
+            <%= I18n.t('sufia.product_name') %> Access Levels: <%= I18n.t('sufia.product_name') %> often makes its Content available to the general public.
+            However, some of the Content on this Site may have been been made available only to University community users or other user subgroups by the depositor.
+            Such Content cannot be used, downloaded, or distributed outside the University community (or subgroup identified) without the specific permission of the depositor.
+          </p>
+        </li>
+
+        <li>
+          <p>
+            Use of <%= I18n.t('sufia.product_name') %> Site and Content: Unless otherwise specified in the metadata attached to an item, Content that has been made accessible to the general public may be used for non-commercial, research, educational, or related academic purposes only.
+            Such uses include personal study, distribution to students, research and scholarship (including computational research uses such as data and text-mining, citation-extraction, or cross-referencing) as long as you do not sell the Content or sell advertising on any page on which the Content is displayed.
+            If you make an item of Content available to others, you shall do so in accordance with the terms of the rights granted pursuant to the particular item of Content, or at a minimum, you will retain with the Content its title, the name of the author(s), a reference to these Terms of Use, any copyright notice included on the original, and any metadata associated with the original.
+            You may not use a facsimile of the published version of an article that may be posted in <%= I18n.t('sufia.product_name') %> under these open access terms, unless the publisher so permits.
+            You will not make any translation, adaptation or other derivative work of an item of Content except as authorized under U.S. law.
+            You may not sublicense or otherwise transfer your rights in an item of Content, unless specifically authorized by the copyright license granted to the item of Content and will only make Content  available to others for use by them under these Terms of Use.
+            Links on the Site to third-party web sites are provided solely as a convenience to you.
+            We do not approve or endorse the content of linked third-party sites, and you agree that we will have no responsibility or liability in connection with your use of any linked third-party sites.
+            Nothing in these Terms of Use or on the Site will be construed as granting you any right or license to use any trademarks, service marks or logos displayed on the Site.
+            You agree not to use or register any name, logo or insignia of the <%= I18n.t('sufia.institution_name') %> or any of its subdivisions for any purpose except with our prior written approval and in accordance with any restrictions required by us.
+          </p>
+        </li>
+
+        <li>
+          <p>
+            Fair Use and Other Lawful Uses: Nothing in these Terms of Use is intended to restrict or limit you from making uses of Content  that, in the absence of rights granted hereunder, would not infringe or violate anyone's copyright, trademark or other rights.
+            To the extent permitted by law, adaptation of <%= I18n.t('sufia.product_name') %> Content to enable use and access by persons with disabilities is encouraged.
+          </p>
+        </li>
+
+        <li>
+          <p>
+            Reserved Rights; Obtaining Permissions: All rights in the Site and the Content that are not expressly granted are reserved.
+            You agree to use the Site and the Content only in ways that comply with copyright and all other applicable laws, as well as with these Terms of Use, and that do not infringe or violate anyone's rights.
+            If you wish to make any use of the Content that requires authorization under copyright, trademark or other rights, you agree to obtain all necessary permissions.
+            You are responsible for determining whether permission is needed to make any use of the Content that you wish to make.
+          </p>
+        </li>
+
+        <li>
+          <p>
+            Disclaimer of Warranties: THE SITE AND THE CONTENT ARE PROVIDED &ldquo;AS IS.
+            &rdquo; TO THE FULLEST EXTENT PERMITTED BY APPLICABLE LAW, WE DISCLAIM ALL WARRANTIES OF ANY KIND (EXPRESS, IMPLIED OR OTHERWISE) REGARDING THE SITE OR THE CONTENT, INCLUDING BUT NOT LIMITED TO ANY IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, OWNERSHIP, AND NON-INFRINGEMENT.
+            WE MAKE NO WARRANTY ABOUT THE ACCURACY, RELIABILITY, COMPLETENESS, TIMELINESS, SUFFICIENCY OR QUALITY OF THE SITE OR THE CONTENT, NOR THAT ANY PARTICULAR CONTENT WILL CONTINUE TO BE MADE AVAILABLE.
+            WE DO NOT APPROVE OR ENDORSE ANY POSTED MATERIAL OR CONTENT PROVIDED BY OTHERS, INCLUDING PENN STATE AUTHORS.
+            WE DO NOT WARRANT THAT THE SITE WILL OPERATE WITHOUT ERROR OR INTERRUPTION, OR THAT THE SITE OR ITS SERVER ARE FREE OF COMPUTER VIRUSES OR OTHER HARMFUL MATERIALS.
+          </p>
+        </li>
+
+        <li>
+          <p>
+            Limitations of Liability and Remedies: WE MAKE THE SITE AND THE CONTENT AVAILABLE FREE OF CHARGE.
+            YOUR USE OF THE SITE AND THE CONTENT IS AT YOUR OWN SOLE RISK.
+            IN NO EVENT SHALL WE BE LIABLE TO YOU, IN CONTRACT, TORT OR OTHERWISE, FOR ANY DIRECT, INDIRECT, SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY OR OTHER DAMAGES OF ANY KIND ARISING OUT OF OR RELATING TO THE SITE OR THE CONTENT, OR YOUR USE OF THE SITE OR THE CONTENT, OR ANY THIRD PARTY RIGHTS IN THE CONTENT, EVEN IF THE SITE OR CONTENT IS DEFECTIVE OR WE ARE NEGLIGENT OR OTHERWISE AT FAULT, AND REGARDLESS WHETHER WE ARE ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+            THE FOREGOING LIMITATIONS SHALL APPLY TO THE FULLEST EXTENT PERMITTED BY APPLICABLE LAW.
+          </p>
+        </li>
+
+        <li>
+          <p>
+            Indemnity: You agree to indemnify and hold harmless the <%= I18n.t('sufia.institution_name') %> and its trustees, officers, students, employees and agents, from and against all claims, actions, suits, damages, liabilities and costs (including, without limitation, reasonable legal fees) arising from or relating to your use of the Site or any of the Content or your failure to comply with any provision of these Terms of Use.
+          </p>
+        </li>
+
+        <li>
+          <p>
+            Applicable Law and Jurisdiction;.
+            These Terms of Use, and any claim or dispute that arises from or relates to your use of the Site or the Content, will be governed by the laws of Indiana, without regard to its conflicts of laws principles.
+            You agree that all such claims and disputes will be heard and resolved exclusively in the courts of St. Joseph County, Indiana.
+            You consent to the personal jurisdiction of such courts over you for this purpose, and waive and agree not to assert any objection to such proceedings in such courts (including any defense or objection of lack of proper jurisdiction or venue or inconvenience of forum).
+          </p>
+        </li>
+
+        <li>
+          <p>
+            Termination: The permissions granted to you will terminate automatically upon any breach by you of these Terms of Use.
+            Additionally, the University reserved the right to remove any <%= I18n.t('sufia.product_name') %> content for any reason in its sole discretion.
+            If we take down or otherwise cease to make a work available as an item of Content, the permission granted to you hereunder to use that Content thereafter will terminate at that time.
+            <%= I18n.t('sufia.product_name') %> is maintained as a scholarly and educational resource by University which may be modified or terminated by the University in its sole discretion.
+          </p>
+        </li>
+      </ol>
+    </article>
+
     </div>
-
-    <div class="modal-body">
-
-      <article class="terms-of-service">
-        <ol>
-          <li>
-            <p>
-              General: <%= I18n.t('sufia.product_name') %> is maintained by the <%= I18n.t('sufia.institution_name') %> Libraries in support of our mission to disseminate information and research to scholars, educators and the public.
-              As used in these Terms of Use, the terms &ldquo;University,&rdquo; &ldquo;we, &ldquo;us,&rdquo; and &ldquo;our&rdquo; refer to the <%= I18n.t('sufia.institution_name') %>.
-              Use of <%= I18n.t('sufia.product_name') %> (the Site and its contents) is subject to the following terms and conditions and all applicable laws.
-              By using the Site or any of its content, you accept and agree to be bound by these Terms of Use and all applicable laws.
-              If any of these Terms of Use are unacceptable to you, do not use the Site.
-            </p>
-          </li>
-
-          <li>
-            <p>
-              Changes to Terms of Use Are Binding: We may change these Terms of Use from time-to-time without advance notice.
-              Your use of the Site or any of its content after any changes have been made will constitute your agreement on a prospective basis to the modified Terms of Use and all of the changes.
-              Accordingly, you should read these Terms of Use from time-to-time for any changes.
-            </p>
-          </li>
-
-          <li>
-            <p>
-              Copyright and Use of <%= I18n.t('sufia.product_name') %> Content: <%= I18n.t('sufia.product_name') %> includes text, images, graphics, information, articles, multi-media objects, scholarly projects and other works protected by copyright, trademark and other laws (&ldquo;Content&rdquo;).
-              Some of the Content on this site may include materials from older published works that have passed into the &ldquo;public domain&rdquo; under U.S. copyright law.
-              Where such information is known, it is included specifically in the metadata associated with each item of Content.
-              However, the Site itself and most of the materials held as Content on the Site are protected by copyright and other laws.
-              These materials have been deposited to enable teaching, research, and other non-profit educational activities.
-              Unless otherwise specified in the metadata attached to an item of Content, you may use the Site and the Content only for non-commercial, research, educational, or related academic purposes.
-              Further, you have the responsibility to make your own assessment of the copyright or other legal concerns that might affect your use of <%= I18n.t('sufia.product_name') %> content and to assume personal responsibility for your uses of Content.
-            </p>
-          </li>
-
-          <li>
-            <p>
-              Special Permissions: <%= I18n.t('sufia.product_name') %> does not have the authority to grant or deny special permissions to use images or other Content found on the site beyond those uses that are specifically described in these Terms of Use or as noted specifically on individual items of Content.
-              <%= I18n.t('sufia.product_name') %> staff are not able to undertake copyright investigations on behalf of Site users.
-            </p>
-          </li>
-
-          <li>
-            <p>
-              <%= I18n.t('sufia.product_name') %> Access Levels: <%= I18n.t('sufia.product_name') %> often makes its Content available to the general public.
-              However, some of the Content on this Site may have been been made available only to University community users or other user subgroups by the depositor.
-              Such Content cannot be used, downloaded, or distributed outside the University community (or subgroup identified) without the specific permission of the depositor.
-            </p>
-          </li>
-
-          <li>
-            <p>
-              Use of <%= I18n.t('sufia.product_name') %> Site and Content: Unless otherwise specified in the metadata attached to an item, Content that has been made accessible to the general public may be used for non-commercial, research, educational, or related academic purposes only.
-              Such uses include personal study, distribution to students, research and scholarship (including computational research uses such as data and text-mining, citation-extraction, or cross-referencing) as long as you do not sell the Content or sell advertising on any page on which the Content is displayed.
-              If you make an item of Content available to others, you shall do so in accordance with the terms of the rights granted pursuant to the particular item of Content, or at a minimum, you will retain with the Content its title, the name of the author(s), a reference to these Terms of Use, any copyright notice included on the original, and any metadata associated with the original.
-              You may not use a facsimile of the published version of an article that may be posted in <%= I18n.t('sufia.product_name') %> under these open access terms, unless the publisher so permits.
-              You will not make any translation, adaptation or other derivative work of an item of Content except as authorized under U.S. law.
-              You may not sublicense or otherwise transfer your rights in an item of Content, unless specifically authorized by the copyright license granted to the item of Content and will only make Content  available to others for use by them under these Terms of Use.
-              Links on the Site to third-party web sites are provided solely as a convenience to you.
-              We do not approve or endorse the content of linked third-party sites, and you agree that we will have no responsibility or liability in connection with your use of any linked third-party sites.
-              Nothing in these Terms of Use or on the Site will be construed as granting you any right or license to use any trademarks, service marks or logos displayed on the Site.
-              You agree not to use or register any name, logo or insignia of the <%= I18n.t('sufia.institution_name') %> or any of its subdivisions for any purpose except with our prior written approval and in accordance with any restrictions required by us.
-            </p>
-          </li>
-
-          <li>
-            <p>
-              Fair Use and Other Lawful Uses: Nothing in these Terms of Use is intended to restrict or limit you from making uses of Content  that, in the absence of rights granted hereunder, would not infringe or violate anyone's copyright, trademark or other rights.
-              To the extent permitted by law, adaptation of <%= I18n.t('sufia.product_name') %> Content to enable use and access by persons with disabilities is encouraged.
-            </p>
-          </li>
-
-          <li>
-            <p>
-              Reserved Rights; Obtaining Permissions: All rights in the Site and the Content that are not expressly granted are reserved.
-              You agree to use the Site and the Content only in ways that comply with copyright and all other applicable laws, as well as with these Terms of Use, and that do not infringe or violate anyone's rights.
-              If you wish to make any use of the Content that requires authorization under copyright, trademark or other rights, you agree to obtain all necessary permissions.
-              You are responsible for determining whether permission is needed to make any use of the Content that you wish to make.
-            </p>
-          </li>
-
-          <li>
-            <p>
-              Disclaimer of Warranties: THE SITE AND THE CONTENT ARE PROVIDED &ldquo;AS IS.
-              &rdquo; TO THE FULLEST EXTENT PERMITTED BY APPLICABLE LAW, WE DISCLAIM ALL WARRANTIES OF ANY KIND (EXPRESS, IMPLIED OR OTHERWISE) REGARDING THE SITE OR THE CONTENT, INCLUDING BUT NOT LIMITED TO ANY IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, OWNERSHIP, AND NON-INFRINGEMENT.
-              WE MAKE NO WARRANTY ABOUT THE ACCURACY, RELIABILITY, COMPLETENESS, TIMELINESS, SUFFICIENCY OR QUALITY OF THE SITE OR THE CONTENT, NOR THAT ANY PARTICULAR CONTENT WILL CONTINUE TO BE MADE AVAILABLE.
-              WE DO NOT APPROVE OR ENDORSE ANY POSTED MATERIAL OR CONTENT PROVIDED BY OTHERS, INCLUDING PENN STATE AUTHORS.
-              WE DO NOT WARRANT THAT THE SITE WILL OPERATE WITHOUT ERROR OR INTERRUPTION, OR THAT THE SITE OR ITS SERVER ARE FREE OF COMPUTER VIRUSES OR OTHER HARMFUL MATERIALS.
-            </p>
-          </li>
-
-          <li>
-            <p>
-              Limitations of Liability and Remedies: WE MAKE THE SITE AND THE CONTENT AVAILABLE FREE OF CHARGE.
-              YOUR USE OF THE SITE AND THE CONTENT IS AT YOUR OWN SOLE RISK.
-              IN NO EVENT SHALL WE BE LIABLE TO YOU, IN CONTRACT, TORT OR OTHERWISE, FOR ANY DIRECT, INDIRECT, SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY OR OTHER DAMAGES OF ANY KIND ARISING OUT OF OR RELATING TO THE SITE OR THE CONTENT, OR YOUR USE OF THE SITE OR THE CONTENT, OR ANY THIRD PARTY RIGHTS IN THE CONTENT, EVEN IF THE SITE OR CONTENT IS DEFECTIVE OR WE ARE NEGLIGENT OR OTHERWISE AT FAULT, AND REGARDLESS WHETHER WE ARE ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
-              THE FOREGOING LIMITATIONS SHALL APPLY TO THE FULLEST EXTENT PERMITTED BY APPLICABLE LAW.
-            </p>
-          </li>
-
-          <li>
-            <p>
-              Indemnity: You agree to indemnify and hold harmless the <%= I18n.t('sufia.institution_name') %> and its trustees, officers, students, employees and agents, from and against all claims, actions, suits, damages, liabilities and costs (including, without limitation, reasonable legal fees) arising from or relating to your use of the Site or any of the Content or your failure to comply with any provision of these Terms of Use.
-            </p>
-          </li>
-
-          <li>
-            <p>
-              Applicable Law and Jurisdiction;.
-              These Terms of Use, and any claim or dispute that arises from or relates to your use of the Site or the Content, will be governed by the laws of Indiana, without regard to its conflicts of laws principles.
-              You agree that all such claims and disputes will be heard and resolved exclusively in the courts of St. Joseph County, Indiana.
-              You consent to the personal jurisdiction of such courts over you for this purpose, and waive and agree not to assert any objection to such proceedings in such courts (including any defense or objection of lack of proper jurisdiction or venue or inconvenience of forum).
-            </p>
-          </li>
-
-          <li>
-            <p>
-              Termination: The permissions granted to you will terminate automatically upon any breach by you of these Terms of Use.
-              Additionally, the University reserved the right to remove any <%= I18n.t('sufia.product_name') %> content for any reason in its sole discretion.
-              If we take down or otherwise cease to make a work available as an item of Content, the permission granted to you hereunder to use that Content thereafter will terminate at that time.
-              <%= I18n.t('sufia.product_name') %> is maintained as a scholarly and educational resource by University which may be modified or terminated by the University in its sole discretion.
-            </p>
-          </li>
-        </ol>
-      </article>
-
-      </div>
-      <div class="modal-footer centered">
+    <div class="modal-footer centered">
+      <%= form_tag terms_of_service_agreements_path, method: :post, class: "terms-of-service-form" do %>
         <%= submit_tag controller.i_agree_text, class: 'btn btn-large btn-primary' %>
         <%= submit_tag controller.i_do_not_agree_text, class: 'btn btn-large btn-link'  %>
-      </div>
+      <% end %>
     </div>
-
-<% end %>
+  </div>
+</div>


### PR DESCRIPTION
## Ensuring expanded ToS allows acceptance

49767a761b59d836ece78c57adc6d8a8997f0366

Prior to this commit, the HTML modal was rendering inside the form.
This would work, except that the modal JS would pull that HTML
and render the DOM elements outside of the form. This resulted in a
loss of the form context, and thus the submit buttons didn't know
where to submit the accept or decline action.

By moving the modal content outside of the form, and adding a form
around the submit buttons:

* the expected behavior is restored
* we don't violate HTML standards by having a form nested within
  another form

In addition, I've added a confirmation flash message to let the end
user know that the ToS was accepted.

DLTP-1521

## Updating redirect for ToS agreement

5b7756ff44b5686a6317f4ba80cec039f6e03c85

> The standard use case for users accepting ToS is that they are
> entering the system for the first time. As such, the next likely step
> is filling out their registration information.

DLTP-1521
