### PR TITLE
Handle missing collection title

### DIFF
--- a/app/views/curation_concern/base/_collections.html.erb
+++ b/app/views/curation_concern/base/_collections.html.erb
@@ -13,7 +13,8 @@
         <% curation_concern.library_collections.each do |collection| %>
           <tr class="collection attributes">
             <%= content_tag :td, class: 'attribute title', data: { noid: collection.noid } do %>
-              <%= link_to collection, common_object_path(collection.noid) %>
+              <% collection_title = collection.title.nil? ? common_object_path(collection.noid).to_s : collection.title %>
+              <%= link_to collection_title, common_object_path(collection.noid) %>
             <% end %>
           </tr>
         <% end %>


### PR DESCRIPTION
When the collection is missing a title, the item show page fails when trying to display the link to the collection. This change uses the path name as a string in place of the collection's missing title.