### PR TITLE
Removing error reporting for ActiveObjectNotFoundError

### DIFF
--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -7,5 +7,6 @@ Airbrake.configure do |config|
   config.ignore << "ActiveFedora::RecordNotFound"
   config.ignore << "ActiveRecord::RecordNotFound"
   config.ignore << "ActiveFedora::ObjectNotFoundError"
+  config.ignore << "ActiveFedora::ActiveObjectNotFoundError"
   config.ignore << "URI::InvalidComponentError"
 end


### PR DESCRIPTION
The original intent for this exception was to notify of an unexpected
state (e.g. we wanted soft deletes). However, this fires for all hits
against the /show/:id API regardless of whether something is missing or
not.