### PR TITLE
Curate Admins Manage All Groups

### DIFF
--- a/app/controllers/hydramata/groups_controller.rb
+++ b/app/controllers/hydramata/groups_controller.rb
@@ -22,6 +22,7 @@ class Hydramata::GroupsController < ApplicationController
 
   def index
     params[:per_page] ||= 50
+    Hydramata::GroupsController.solr_search_params_logic -= [:add_access_controls_to_solr_params] if current_user.manager?
     super
   end
 

--- a/app/views/hydramata/groups/index.html.erb
+++ b/app/views/hydramata/groups/index.html.erb
@@ -4,11 +4,11 @@
   <% end %>
 </h2>
 <br/>
-<%- if has_any_group? %>
+<% if @response.response["numFound"] > 0 %>
   <%= render_pagination_info @response, :entry_name=>'item' %>
   <%= render_document_index %>
-<%- else %>
+<% else %>
   <div class="span12 main-header">
     <p>You have no groups yet.</p>
   </div>
-<%- end %>
+<% end %>


### PR DESCRIPTION
Fixes https://jira.library.nd.edu/browse/DLTP-1549

Ensures that all Curate repository administrators have the ability to view and manage all groups. While they previously had the ability granted via the ability class, the index view prevented viewing of any groups you aren't a member of.

### Before Change
Repository with two groups, manager OR non-manager index view

![screen shot 2018-10-11 at 2 02 31 pm](https://user-images.githubusercontent.com/17851674/46826888-30dd4a80-cd65-11e8-8f22-472d976ac6bc.png)

### After Change
Repository with two groups,  manager index view

![screen shot 2018-10-11 at 2 06 58 pm](https://user-images.githubusercontent.com/17851674/46826929-4fdbdc80-cd65-11e8-914d-00fd7d8445da.png)

Manager show view for group without belonging to it

![screen shot 2018-10-11 at 2 07 14 pm](https://user-images.githubusercontent.com/17851674/46826958-65510680-cd65-11e8-8e7d-d89bf0d67b39.png)

