### PR TITLE
Set search params for groups

### DIFF
--- a/app/controllers/hydramata/groups_controller.rb
+++ b/app/controllers/hydramata/groups_controller.rb
@@ -22,7 +22,11 @@ class Hydramata::GroupsController < ApplicationController
 
   def index
     params[:per_page] ||= 50
-    Hydramata::GroupsController.solr_search_params_logic -= [:add_access_controls_to_solr_params] if current_user.manager?
+    if current_user.manager?
+      Hydramata::GroupsController.solr_search_params_logic -= [:add_access_controls_to_solr_params]
+    else
+      Hydramata::GroupsController.solr_search_params_logic += [:add_access_controls_to_solr_params]
+    end
     super
   end
 


### PR DESCRIPTION
Remove access controls from search parameters only for managers.

Fixes DLTP-1593