### PR TITLE
Updating logger version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -363,7 +363,7 @@ GEM
     jwt (1.5.6)
     kgio (2.11.0)
     libv8 (3.16.14.19)
-    logger (1.2.8)
+    logger (1.3.0)
     lograge (0.5.0)
       actionpack (>= 4, <= 5.1.0)
       activesupport (>= 4, <= 5.1.0)


### PR DESCRIPTION
Ran the following command:

```console
$ bundle update logger
```

The 1.2.8 version was yanked (originally published May 2011) and
replaced by 1.3.0. This commit fixes that behavior.