### PR TITLE
Lock bundler version for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ bundler_args: --without headless debug
 before_install:
   - sudo service mysql stop
   - docker-compose -f docker-compose-test.yml up -d
-  - gem install bundler
+  - gem install bundler -v 1.16.6


### PR DESCRIPTION
Bundler can't install on the current version of Ruby. Need to lock the version until Ruby is updated.