### PR TITLE
Fix docker build logger-1.2.8 error

### DIFF
--- a/docker/Dockerfile.rails
+++ b/docker/Dockerfile.rails
@@ -15,6 +15,9 @@ ENV PATH="/fits/fits-0.6.2:${PATH}"
 RUN mkdir /bundle
 COPY Gemfile /bundle
 COPY Gemfile.lock /bundle
+# This gem is now in the app code, so we need to copy it into the bundle path so bundler can find it
+# See https://github.com/nahi/logger/issues/3 and https://github.com/ndlib/curate_nd/pull/765
+COPY lib/logger-1.2.8 /bundle/lib/logger-1.2.8
 WORKDIR /bundle
 RUN bundle install  --without headless --path /bundle
 


### PR DESCRIPTION
## Fix docker build logger-1.2.8 error

9ae24a0b0d7856a630ac3aab48ff76d79ba522fd

Performing a `docker-compose build rails` was producing the following error:
```console
The path '/bundle/lib/logger-1.2.8' does not exist.
ERROR: Service 'rails' failed to build: The command '/bin/sh -c bundle install  --without headless --path /bundle' returned a non-zero code: 13
```

This gem is now in the app code, so we need to copy it into the bundle path so bundler can find it.
See https://github.com/nahi/logger/issues/3 and https://github.com/ndlib/curate_nd/pull/765