### PR TITLE
Adding "Use Permission" to remaining models

### DIFF
--- a/app/repository_datastreams/audio_datastream.rb
+++ b/app/repository_datastreams/audio_datastream.rb
@@ -138,5 +138,7 @@ class AudioDatastream < ActiveFedora::NtriplesRDFDatastream
     map.rights(:in => RDF::DC) do |index|
       index.as :stored_searchable, :facetable
     end
+
+    map.permission({in: RDF::QualifiedDC, to: 'rights#permissions'})
   end
 end

--- a/app/repository_datastreams/catholic_document_datastream.rb
+++ b/app/repository_datastreams/catholic_document_datastream.rb
@@ -120,5 +120,7 @@ class CatholicDocumentDatastream < ActiveFedora::NtriplesRDFDatastream
     map.alephIdentifier(in: RDF::ND) do |index|
       index.as :stored_searchable
     end
+
+    map.permission({in: RDF::QualifiedDC, to: 'rights#permissions'})
   end
 end

--- a/app/repository_datastreams/etd_metadata.rb
+++ b/app/repository_datastreams/etd_metadata.rb
@@ -114,6 +114,7 @@ class EtdMetadata < ActiveFedora::NtriplesRDFDatastream
     map.alephIdentifier(:in =>RDF::ND) do |index|
       index.as :stored_searchable
     end
+    map.permission({in: RDF::QualifiedDC, to: 'rights#permissions'})
   end
 
   accepts_nested_attributes_for :degree, :contributor

--- a/app/repository_datastreams/finding_aid_rdf_datastream.rb
+++ b/app/repository_datastreams/finding_aid_rdf_datastream.rb
@@ -59,5 +59,7 @@ class FindingAidRdfDatastream < ActiveFedora::NtriplesRDFDatastream
     map.alephIdentifier(:in =>RDF::ND)  do |index|
       index.as :stored_searchable
     end
+
+    map.permission({in: RDF::QualifiedDC, to: 'rights#permissions'})
   end
 end

--- a/app/repository_datastreams/generic_file_rdf_datastream.rb
+++ b/app/repository_datastreams/generic_file_rdf_datastream.rb
@@ -50,6 +50,7 @@ class GenericFileRdfDatastream < ActiveFedora::NtriplesRDFDatastream
       index.as :stored_searchable, :facetable
     end
     map.related_url(:to => "seeAlso", :in => RDF::RDFS)
+    map.permission({in: RDF::QualifiedDC, to: 'rights#permissions'})
   end
   begin
     LocalAuthority.register_vocabulary(self, "subject", "lc_subjects")

--- a/app/repository_datastreams/generic_work_rdf_datastream.rb
+++ b/app/repository_datastreams/generic_work_rdf_datastream.rb
@@ -94,5 +94,6 @@ class GenericWorkRdfDatastream < ActiveFedora::NtriplesRDFDatastream
     map.alephIdentifier(:in =>RDF::ND) do |index|
       index.as :stored_searchable
     end
+    map.permission({in: RDF::QualifiedDC, to: 'rights#permissions'})
   end
 end

--- a/app/repository_datastreams/image_metadata.rb
+++ b/app/repository_datastreams/image_metadata.rb
@@ -244,5 +244,6 @@ class ImageMetadata < ActiveFedora::NtriplesRDFDatastream
     	index.as :stored_searchable
     end
 
+    map.permission({in: RDF::QualifiedDC, to: 'rights#permissions'})
   end
 end

--- a/app/repository_datastreams/library_collection_rdf_datastream.rb
+++ b/app/repository_datastreams/library_collection_rdf_datastream.rb
@@ -82,5 +82,6 @@ class LibraryCollectionRdfDatastream < ActiveFedora::NtriplesRDFDatastream
     map.date(:in => RDF::DC) do |index|
       index.as :stored_searchable
     end
+    map.permission({in: RDF::QualifiedDC, to: 'rights#permissions'})
   end
 end

--- a/app/repository_datastreams/osf_archive_datastream.rb
+++ b/app/repository_datastreams/osf_archive_datastream.rb
@@ -64,5 +64,6 @@ class OsfArchiveDatastream < ActiveFedora::NtriplesRDFDatastream
     map.alephIdentifier(:in =>RDF::ND) do |index|
       index.as :stored_searchable
     end
+    map.permission({in: RDF::QualifiedDC, to: 'rights#permissions'})
   end
 end

--- a/app/repository_datastreams/patent_metadata_datastream.rb
+++ b/app/repository_datastreams/patent_metadata_datastream.rb
@@ -105,6 +105,6 @@ class PatentMetadataDatastream < ActiveFedora::NtriplesRDFDatastream
     map.alephIdentifier(:in =>RDF::ND) do |index|
       index.as :stored_searchable
     end
-
+    map.permission({in: RDF::QualifiedDC, to: 'rights#permissions'})
   end
 end

--- a/app/repository_datastreams/senior_thesis_rdf_datastream.rb
+++ b/app/repository_datastreams/senior_thesis_rdf_datastream.rb
@@ -95,6 +95,6 @@ class SeniorThesisRdfDatastream < ActiveFedora::NtriplesRDFDatastream
     map.alephIdentifier(:in =>RDF::ND) do |index|
       index.as :stored_searchable
     end
-
+    map.permission({in: RDF::QualifiedDC, to: 'rights#permissions'})
   end
 end

--- a/app/repository_datastreams/sufia/generic_file_rdf_datastream.rb
+++ b/app/repository_datastreams/sufia/generic_file_rdf_datastream.rb
@@ -55,6 +55,7 @@ module Sufia
       map.alephIdentifier(:in =>RDF::ND)  do |index|
         index.as :stored_searchable
       end
+      map.permission({in: RDF::QualifiedDC, to: 'rights#permissions'})
     end
     begin
       LocalAuthority.register_vocabulary(self, "subject", "lc_subjects")

--- a/app/repository_datastreams/video_datastream.rb
+++ b/app/repository_datastreams/video_datastream.rb
@@ -136,5 +136,6 @@ class VideoDatastream < ActiveFedora::NtriplesRDFDatastream
     map.rights(:in => RDF::DC) do |index|
       index.as :stored_searchable, :facetable
     end
+    map.permission({in: RDF::QualifiedDC, to: 'rights#permissions'})
   end
 end

--- a/app/repository_models/article.rb
+++ b/app/repository_models/article.rb
@@ -143,6 +143,7 @@ class Article < ActiveFedora::Base
     default: "All rights reserved",
     validates: { presence: { message: 'You must select a license for your work.' } }
   attribute :permission,
+    label: "Use Permission",
     datastream: :descMetadata, multiple: false
   attribute :relation,
     hint: "Link to External Content",

--- a/app/repository_models/audio.rb
+++ b/app/repository_models/audio.rb
@@ -122,6 +122,9 @@ class Audio < ActiveFedora::Base
       datastream: :descMetadata, multiple: false,
       default: "All rights reserved",
       validates: { presence: { message: 'You must select a license for your work.' } }
+  attribute :permission,
+    label: "Use Permission",
+    datastream: :descMetadata, multiple: false
   attribute :files,
     multiple: true, form: {as: :file}, label: "Upload Files",
     hint: "CTRL-Click (Windows) or CMD-Click (Mac) to select multiple files."

--- a/app/repository_models/catholic_document.rb
+++ b/app/repository_models/catholic_document.rb
@@ -94,6 +94,9 @@ class CatholicDocument < ActiveFedora::Base
     datastream: :descMetadata, multiple: false,
     label: 'Rights Holder',
     hint: 'A statement about entities who own the rights to the material along with any additional information about contact or use.'
+  attribute :permission,
+    label: "Use Permission",
+    datastream: :descMetadata, multiple: false
   attribute :copyright_date,
     datastream: :descMetadata, multiple: false,
     validates: {

--- a/app/repository_models/dataset.rb
+++ b/app/repository_models/dataset.rb
@@ -49,7 +49,9 @@ class Dataset < ActiveFedora::Base
   attribute :creator,                 datastream: :descMetadata, multiple: true
   attribute :identifier,              datastream: :descMetadata, multiple: false
   attribute :doi,                     datastream: :descMetadata, multiple: false
-  attribute :permission,              datastream: :descMetadata, multiple: false
+  attribute :permission,
+    label: "Use Permission",
+    datastream: :descMetadata, multiple: false
   attribute :publisher,               datastream: :descMetadata, multiple: true
   attribute :contributor_institution, datastream: :descMetadata, multiple: true
   attribute :source,                  datastream: :descMetadata, multiple: true

--- a/app/repository_models/document.rb
+++ b/app/repository_models/document.rb
@@ -89,7 +89,9 @@ class Document < ActiveFedora::Base
   attribute :recommended_citation,       datastream: :descMetadata, multiple: true
   attribute :doi,                        datastream: :descMetadata, multiple: false
   attribute :identifier,                 datastream: :descMetadata, multiple: false
-  attribute :permission,                 datastream: :descMetadata, multiple: false
+  attribute :permission,
+    label: "Use Permission",
+    datastream: :descMetadata, multiple: false
   attribute :rights,
     datastream: :descMetadata, multiple: false,
     default: "All rights reserved",

--- a/app/repository_models/etd.rb
+++ b/app/repository_models/etd.rb
@@ -111,6 +111,9 @@ class Etd < ActiveFedora::Base
       default: "All rights reserved",
       multiple: false,
       validates: { presence: { message: "You must select a license for your #{etd_label}." } }
+    ds.attribute :permission,
+      label: "Use Permission",
+      multiple: false
     ds.attribute :note,
       label: "Note",
       multiple: false,

--- a/app/repository_models/finding_aid.rb
+++ b/app/repository_models/finding_aid.rb
@@ -45,6 +45,9 @@ class FindingAid < ActiveFedora::Base
     datastream: :descMetadata, multiple: false,
     default: "All rights reserved",
     validates: { presence: { message: 'You must select a license for your work.' } }
+  attribute :permission,
+    label: "Use Permission",
+    datastream: :descMetadata, multiple: false
   attribute :source,
     datastream: :descMetadata, multiple: true
   attribute :relation,

--- a/app/repository_models/generic_file.rb
+++ b/app/repository_models/generic_file.rb
@@ -38,6 +38,9 @@ class GenericFile < ActiveFedora::Base
   attribute :title,
     datastream: :descMetadata, multiple: false,
     label: "Title of your File"
+  attribute :permission,
+    label: "Use Permission",
+    datastream: :descMetadata, multiple: false
 
   attr_accessor :file, :version
 

--- a/app/repository_models/generic_work.rb
+++ b/app/repository_models/generic_work.rb
@@ -63,6 +63,9 @@ class GenericWork < ActiveFedora::Base
       allow_blank: true,
       aleph_identifier: true
     }
+  attribute :permission,
+    label: "Use Permission",
+    datastream: :descMetadata, multiple: false
 
   attribute :files, multiple: true, form: {as: :file},
     hint: "CTRL-Click (Windows) or CMD-Click (Mac) to select multiple files."

--- a/app/repository_models/image.rb
+++ b/app/repository_models/image.rb
@@ -126,6 +126,10 @@ class Image < ActiveFedora::Base
       default: "All rights reserved",
       multiple: false
 
+    ds.attribute :permission,
+      label: "Use Permission",
+      multiple: false
+
     ds.attribute :identifier,
       multiple: false,
       editable: false

--- a/app/repository_models/library_collection.rb
+++ b/app/repository_models/library_collection.rb
@@ -37,7 +37,7 @@ class LibraryCollection < ActiveFedora::Base
   # accepts_nested_attributes_for :record_viewer_groups, allow_destroy: true, reject_if: :all_blank
 
   has_attributes :depositor, :representative, datastream: :properties, multiple: false
-  has_attributes :title, :date_uploaded, :date_modified, :description,
+  has_attributes :title, :date_uploaded, :date_modified, :description, :permission,
                  datastream: :descMetadata, multiple: false
   has_attributes :creator, :contributor, :based_near, :part_of, :publisher,
                  :date_created, :subject, :resource_type, :rights,

--- a/app/repository_models/osf_archive.rb
+++ b/app/repository_models/osf_archive.rb
@@ -146,6 +146,10 @@ class OsfArchive < ActiveFedora::Base
     default: "All rights reserved",
     validates: { presence: { message: 'You must select a license for your work.' } }
 
+  attribute :permission,
+    label: "Use Permission",
+    datastream: :descMetadata, multiple: false
+
   attribute :doi,
     datastream: :descMetadata, multiple: false
 

--- a/app/repository_models/patent.rb
+++ b/app/repository_models/patent.rb
@@ -69,6 +69,9 @@ class Patent < ActiveFedora::Base
   attribute :rights, datastream: :descMetadata, multiple: false,
             default: "All rights reserved",
             validates: { presence: { message: 'You must select a license for your work.' } }
+  attribute :permission,
+    label: "Use Permission",
+    datastream: :descMetadata, multiple: false
   attribute :rights_holder, datastream: :descMetadata, multiple: true,
             label: "Assignee"
   attribute :files,

--- a/app/repository_models/senior_thesis.rb
+++ b/app/repository_models/senior_thesis.rb
@@ -77,6 +77,9 @@ class SeniorThesis < ActiveFedora::Base
     datastream: :descMetadata, multiple: false,
     default: "All rights reserved",
     validates: { presence: { message: 'You must select a license for your work.' } }
+  attribute :permission,
+    label: "Use Permission",
+    datastream: :descMetadata, multiple: false
   attribute :visibility,
     skip_accessor: true,
     multiple: false,

--- a/app/repository_models/video.rb
+++ b/app/repository_models/video.rb
@@ -118,6 +118,9 @@ class Video < ActiveFedora::Base
       datastream: :descMetadata, multiple: false,
       default: "All rights reserved",
       validates: { presence: { message: 'You must select a license for your work.' } }
+  attribute :permission,
+    label: "Use Permission",
+    datastream: :descMetadata, multiple: false
   attribute :files,
     multiple: true, form: {as: :file}, label: "Upload Files",
     hint: "CTRL-Click (Windows) or CMD-Click (Mac) to select multiple files."

--- a/app/views/curation_concern/audios/_attributes.html.erb
+++ b/app/views/curation_concern/audios/_attributes.html.erb
@@ -38,6 +38,7 @@
     </tr>
     <%= curation_concern_attribute_to_html(curation_concern, :embargo_release_date, "Embargo Release Date") %>
     <%= curation_concern_attribute_to_html(curation_concern, :rights, "Content License") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :permission, "Use Permissions") %>
     <% if curation_concern.type_of_license == "Independently Licensed" %>
       <%= curation_concern_attribute_to_html(curation_concern, :license, "License Agreement") %>
     <% end %>

--- a/app/views/curation_concern/catholic_documents/_attributes.html.erb
+++ b/app/views/curation_concern/catholic_documents/_attributes.html.erb
@@ -35,10 +35,10 @@
   </tr>
 
   <%= curation_concern_attribute_to_html(curation_concern, :embargo_release_date, 'Embargo Release Date') %>
-  <%= curation_concern_attribute_to_html(curation_concern, :rights, 'Content License') %>
-
-  <% if curation_concern.type_of_license == 'Independently Licensed' %>
-    <%= curation_concern_attribute_to_html(curation_concern, :license, 'License Agreement') %>
+  <%= curation_concern_attribute_to_html(curation_concern, :rights, "Content License") %>
+  <%= curation_concern_attribute_to_html(curation_concern, :permission, "Use Permissions") %>
+  <% if curation_concern.type_of_license == "Independently Licensed" %>
+    <%= curation_concern_attribute_to_html(curation_concern, :license, "License Agreement") %>
   <% end %>
 
   <%= decode_administrative_unit(curation_concern, :administrative_unit, 'Departments and Units') %>

--- a/app/views/curation_concern/etds/_attributes.html.erb
+++ b/app/views/curation_concern/etds/_attributes.html.erb
@@ -64,6 +64,7 @@
   </tr>
   <%= curation_concern_attribute_to_html(curation_concern, :embargo_release_date, "Embargo Release Date") %>
   <%= curation_concern_attribute_to_html(curation_concern, :rights, "Content License") %>
+  <%= curation_concern_attribute_to_html(curation_concern, :permission, "Use Permissions") %>
   <%= curation_concern_attribute_to_html(curation_concern, :note, "Note") %>
   <%= decode_administrative_unit(curation_concern, :administrative_unit, "Departments and Units") %>
   <%= curation_concern_attribute_to_html(curation_concern, :library_collections, "Member of") %>

--- a/app/views/curation_concern/finding_aids/_attributes.html.erb
+++ b/app/views/curation_concern/finding_aids/_attributes.html.erb
@@ -24,6 +24,7 @@
   </tr>
   <%= curation_concern_attribute_to_html(curation_concern, :embargo_release_date, "Embargo Release Date") %>
   <%= curation_concern_attribute_to_html(curation_concern, :rights, "Content License") %>
+  <%= curation_concern_attribute_to_html(curation_concern, :permission, "Use Permissions") %>
   <% if curation_concern.type_of_license == "Independently Licensed" %>
     <%= curation_concern_attribute_to_html(curation_concern, :license, "License Agreement") %>
   <% end %>

--- a/app/views/curation_concern/generic_works/_attributes.html.erb
+++ b/app/views/curation_concern/generic_works/_attributes.html.erb
@@ -26,6 +26,7 @@
   </tr>
   <%= curation_concern_attribute_to_html(curation_concern, :embargo_release_date, "Embargo Release Date") %>
   <%= curation_concern_attribute_to_html(curation_concern, :rights, "Content License") %>
+  <%= curation_concern_attribute_to_html(curation_concern, :permission, "Use Permissions") %>
   <%= decode_administrative_unit(curation_concern, :administrative_unit, "Departments and Units") %>
   <%= curation_concern_attribute_to_html(curation_concern, :library_collections, "Member of") %>
   </tbody>

--- a/app/views/curation_concern/images/_attributes.html.erb
+++ b/app/views/curation_concern/images/_attributes.html.erb
@@ -83,6 +83,7 @@
     </tr>
     <%= curation_concern_attribute_to_html(curation_concern, :embargo_release_date, "Embargo Release Date") %>
     <%= curation_concern_attribute_to_html(curation_concern, :rights, "Content License") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :permission, "Use Permissions") %>
     <% if curation_concern.type_of_license == "Independently Licensed" %>
       <%= curation_concern_attribute_to_html(curation_concern, :license, "License Agreement") %>
     <% end %>

--- a/app/views/curation_concern/library_collections/_attributes.html.erb
+++ b/app/views/curation_concern/library_collections/_attributes.html.erb
@@ -22,7 +22,8 @@
     <%= curation_concern_attribute_to_html(curation_concern, :date_created, "Date Created") %>
     <%= curation_concern_attribute_to_html(curation_concern, :subject, "Subject") %>
     <%= curation_concern_attribute_to_html(curation_concern, :resource_type, "Resource Type") %>
-    <%= curation_concern_attribute_to_html(curation_concern, :rights, "Rights") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :rights, "Content License") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :permission, "Use Permissions") %>
     <%= curation_concern_attribute_to_html(curation_concern, :identifier, "Identifier") %>
     <%= curation_concern_attribute_to_html(curation_concern, :language, "Language") %>
     <%= curation_concern_attribute_to_html(curation_concern, :related_url, "Related URL") %>

--- a/app/views/curation_concern/library_collections/_splash.html.erb
+++ b/app/views/curation_concern/library_collections/_splash.html.erb
@@ -42,7 +42,8 @@
         <%= curation_concern_attribute_to_html(curation_concern, :date_created, 'Date Created', template: 'dl') %>
         <%= curation_concern_attribute_to_html(curation_concern, :subject, 'Subject', template: 'dl') %>
         <%= curation_concern_attribute_to_html(curation_concern, :resource_type, 'Resource Type', template: 'dl') %>
-        <%= curation_concern_attribute_to_html(curation_concern, :rights, 'Rights', template: 'dl') %>
+        <%= curation_concern_attribute_to_html(curation_concern, :rights, "Content License") %>
+        <%= curation_concern_attribute_to_html(curation_concern, :permission, "Use Permissions") %>
         <%= curation_concern_attribute_to_html(curation_concern, :identifier, 'Identifier', template: 'dl') %>
         <%= curation_concern_attribute_to_html(curation_concern, :language, 'Language', template: 'dl') %>
         <%= curation_concern_attribute_to_html(curation_concern, :relation, 'Related Resource(s)', template: 'dl') %>

--- a/app/views/curation_concern/osf_archives/_attributes.html.erb
+++ b/app/views/curation_concern/osf_archives/_attributes.html.erb
@@ -27,6 +27,7 @@
     </tr>
     <%= curation_concern_attribute_to_html(curation_concern, :embargo_release_date, "Embargo Release Date") %>
     <%= curation_concern_attribute_to_html(curation_concern, :rights, "Content License") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :permission, "Use Permissions") %>
     <% if curation_concern.type_of_license == "Independently Licensed" %>
       <%= curation_concern_attribute_to_html(curation_concern, :license, "License Agreement") %>
     <% end %>

--- a/app/views/curation_concern/patents/_attributes.html.erb
+++ b/app/views/curation_concern/patents/_attributes.html.erb
@@ -38,10 +38,10 @@
   </tr>
 
   <%= curation_concern_attribute_to_html(curation_concern, :embargo_release_date, 'Embargo Release Date') %>
-  <%= curation_concern_attribute_to_html(curation_concern, :rights, 'Content License') %>
-
-  <% if curation_concern.type_of_license == 'Independently Licensed' %>
-    <%= curation_concern_attribute_to_html(curation_concern, :license, 'License Agreement') %>
+  <%= curation_concern_attribute_to_html(curation_concern, :rights, "Content License") %>
+  <%= curation_concern_attribute_to_html(curation_concern, :permission, "Use Permissions") %>
+  <% if curation_concern.type_of_license == "Independently Licensed" %>
+    <%= curation_concern_attribute_to_html(curation_concern, :license, "License Agreement") %>
   <% end %>
 
   <%= decode_administrative_unit(curation_concern, :administrative_unit, 'Departments and Units') %>

--- a/app/views/curation_concern/videos/_attributes.html.erb
+++ b/app/views/curation_concern/videos/_attributes.html.erb
@@ -37,6 +37,7 @@
     </tr>
     <%= curation_concern_attribute_to_html(curation_concern, :embargo_release_date, "Embargo Release Date") %>
     <%= curation_concern_attribute_to_html(curation_concern, :rights, "Content License") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :permission, "Use Permissions") %>
     <% if curation_concern.type_of_license == "Independently Licensed" %>
       <%= curation_concern_attribute_to_html(curation_concern, :license, "License Agreement") %>
     <% end %>


### PR DESCRIPTION
In discussion with Alex P, added `:permission` attribute to the updated
models. This is to help ensure people know the usage of objects, beyond
copyright fair use.

Closes DLTP-1629