### PR TITLE
Removing app/models/generic_file.rb

### DIFF
--- a/app/models/generic_file.rb
+++ b/app/models/generic_file.rb
@@ -1,3 +1,0 @@
-class GenericFile < ActiveFedora::Base
-  include Sufia::GenericFile
-end


### PR DESCRIPTION
This was copied over from sufia, but we have an overlay in the following
location:

```console
./app/repository_models/generic_file.rb
```