### PR TITLE
Make description box size relative

### DIFF
--- a/app/views/curation_concern/generic_files/_form.html.erb
+++ b/app/views/curation_concern/generic_files/_form.html.erb
@@ -27,7 +27,7 @@
       <% if curation_concern.persisted? %>
         <fieldset class="optional prompt">
           <%= f.input :filename, input_html: { class: 'input-xlarge'} %>
-          <%= f.input :description, input_html: { class: 'input-xxlarge'}  %>
+          <%= f.input :description, input_html: { class: 'span6'}  %>
         </fieldset>
       <% end %>
     </div>


### PR DESCRIPTION
Class input-xxlarge was causing an overrun when screen was resized.

Fixes issue related to https://github.com/ndlib/curate_nd/pull/784