### PR TITLE
Update docker build

### DIFF
--- a/README_DOCKER.md
+++ b/README_DOCKER.md
@@ -5,54 +5,78 @@ Install Docker: https://www.docker.com/
 
 Install docker-sync: http://docker-sync.io/
 
-Start the stack:
+## Starting services
+### Dependencies only
+If you want to run the dependencies without running rails, such as when running rails on your host machine, just run the base compose:
+```console
+docker-compose up
+```
+Then load the database schema:
+```console
+bundle exec rake db:schema:load
+```
+
+### Dependencies + Rails
+If you want to run all services, including the rails application:
+```console
+docker-compose -f docker-compose.yml -f docker-compose-rails.yml up
+```
+
+### Developing rails on OSX
+If you're going to be developing the application inside of the container on OSX, you'll need to use docker-sync to copy files from the local file system into the container volume. To start the stack, which will start all of the dependencies along with the rails container, run the following:
 ```console
 docker-sync-stack start
 ```
 
-## Testing
+## Interacting with the running rails container
+### Testing
 To execute the full test suite, run
 ```console
-docker-compose exec rails bundle exec rake
+docker-compose -f docker-compose.yml -f docker-compose-rails.yml \
+  exec rails bundle exec rake
 ```
 To run individual specs, run
 ```console
-docker-compose exec rails bundle exec rspec spec/path/to/file_spec.rb
+docker-compose -f docker-compose.yml -f docker-compose-rails.yml \
+  exec rails bundle exec rspec spec/path/to/file_spec.rb
 ```
 
-## Debugging the application
+### Debugging the application
 ```console
-docker-compose exec rails bundle exec byebug --remote localhost:9876
+docker-compose -f docker-compose.yml -f docker-compose-rails.yml \
+  exec rails bundle exec byebug --remote localhost:9876
 ```
-## Interacting with Rails Command Line
+
+### Interacting with Rails Command Line
 If you need to open a rails console, run seed scripts, or any of the normal rails activities that you used to do on your terminal, you'll need to first open a shell inside the running rails container:
 ```console
-docker-compose exec rails bash
+docker-compose -f docker-compose.yml -f docker-compose-rails.yml \
+  exec rails bash
 ```
 
-## Rebuilding rails Docker image
-
+### Rebuilding rails Docker image
 Do this when you change Gemfile or Gemfile.lock or anything that Rails won't hotload.
-
 ```console
-docker-compose build rails
+docker-compose -f docker-compose.yml -f docker-compose-rails.yml \
+  build rails
+docker-compose -f docker-compose.yml -f docker-compose-rails.yml \
+  restart rails
 ```
 
-## Rebuilding curate-jetty Docker image
-
+## Dockerhub image maintenance
+### Rebuilding curate-jetty Docker image
 To rebuild the Docker image for running jetty, use the following command:
-
 ```console
 docker build . -t ndlib/curate-jetty -f docker/Dockerfile.jetty
 ```
 
 To push your image to Dockerhub:
-
 ```console
 docker login
 docker push ndlib/curate-jetty
 ```
 
+### Rebuilding curate-jetty with seed data
 To rebuild the image with pre-generated seed data:
 ```console
 # First reset to the base image

--- a/docker-compose-rails-sync.yml
+++ b/docker-compose-rails-sync.yml
@@ -1,0 +1,10 @@
+# Additionally adds a volume that can be used with docker-sync to develop the
+# application inside of docker
+version: '3'
+services:
+  rails:
+    volumes:
+      - curate_nd_rails_sync:/project_root:nocopy
+volumes:
+  curate_nd_rails_sync:
+    external: true

--- a/docker-compose-rails.yml
+++ b/docker-compose-rails.yml
@@ -1,0 +1,25 @@
+# Additionally adds a rails service that can be used with dependent services. 
+version: '3'
+services:
+  rails:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.rails
+    command: bash docker/rails_entry.sh
+    environment:
+      BUNDLE_PATH: "/bundle"
+      FEDORA_HOST: jetty
+      FEDORA_PORT: 8983
+      MYSQL_HOST: mysql
+      SOLR_HOST: jetty
+      SOLR_PORT: 8983
+      # Need to pass the user running docker into the container so that
+      # config/admin_usernames.yml pulls in the user as an admin. This is
+      # to replicate existing behavior on OSX and may not work correctly on
+      # another OS
+      USER: #{USER}
+    ports:
+      - "3000:3000"
+    depends_on:
+      - mysql
+      - jetty

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -1,3 +1,5 @@
+# Starts dependent services only, with a test database.
+# This file is currently used by Travis to start dependent services
 version: '3'
 services:
   mysql:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+# Starts dependent services only. To additionally start rails, add -f docker-compose-rails.yml
 version: '3'
 services:
   mysql:
@@ -16,33 +17,7 @@ services:
         timeout: 10s
         retries: 5
   jetty:
+    # This probably needs to be separated into an override file when using preseeded data
     image: ndlib/curate-jetty-devseed
     ports:
       - "8983:8983"
-  rails:
-    build:
-      context: .
-      dockerfile: docker/Dockerfile.rails
-    command: bash docker/rails_entry.sh
-    environment:
-      BUNDLE_PATH: "/bundle"
-      FEDORA_HOST: jetty
-      FEDORA_PORT: 8983
-      MYSQL_HOST: mysql
-      SOLR_HOST: jetty
-      SOLR_PORT: 8983
-      # Need to pass the user running docker into the container so that
-      # config/admin_usernames.yml pulls in the user as an admin. This is
-      # to replicate existing behavior on OSX and may not work correctly on
-      # another OS
-      USER: #{USER}
-    ports:
-      - "3000:3000"
-    volumes:
-      - curate_nd_rails_sync:/project_root:nocopy
-    depends_on:
-      - mysql
-      - jetty
-volumes:
-  curate_nd_rails_sync:
-    external: true

--- a/docker-sync.yml
+++ b/docker-sync.yml
@@ -1,6 +1,9 @@
 version: "2"
 
 options:
+  compose-dev-file-path:
+    - 'docker-compose-rails-sync.yml'
+    - 'docker-compose-rails.yml'
   verbose: true
 syncs:
   curate_nd_rails_sync:

--- a/docker/Dockerfile.rails
+++ b/docker/Dockerfile.rails
@@ -1,6 +1,6 @@
-FROM ruby:2.2.10
+FROM ruby:2.3.8
 
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs unzip
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs unzip libssl1.0-dev
 
 # Install Fits (which requires java)
 RUN apt-get install -y default-jre
@@ -15,9 +15,6 @@ ENV PATH="/fits/fits-0.6.2:${PATH}"
 RUN mkdir /bundle
 COPY Gemfile /bundle
 COPY Gemfile.lock /bundle
-# This gem is now in the app code, so we need to copy it into the bundle path so bundler can find it
-# See https://github.com/nahi/logger/issues/3 and https://github.com/ndlib/curate_nd/pull/765
-COPY lib/logger-1.2.8 /bundle/lib/logger-1.2.8
 WORKDIR /bundle
 RUN bundle install  --without headless --path /bundle
 


### PR DESCRIPTION
Several changes have been made to things like ruby versions and libraries. This brings the docker build up to speed with those changes.
- Changed rails image to pull ruby 2.3.8 for base image
- Added libssl1.0-dev to the rails image due to a strange segfault issue when using thin on the container
- Removed the lib/logger copy from the rails image, since this is no longer in the repo
- Additionally separated out the compose files to give us options on how to run this in development, since some users would like to use it for running dependencies only (mysql/fedora/solr). Updated the readme to describe how to run it in the different configurations

As an aside, as part of trying to figure out the segfault issue with thin, I tried both puma and passenger. Both are relatively easy to convert to. Puma is twice as slow with rendering the home page. Passenger takes an enormous hit on first load, but then is faster to load the home page. So, left it using thin, but there may be room for experimenting with this a bit more in the future to more closely match dev to how Curate will run in production.