### PR TITLE
Patching critical vulnerability

### DIFF
--- a/config/initializers/formats_filter.rb
+++ b/config/initializers/formats_filter.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# This monkey patch is a current vulnerability work-around.
+# See https://groups.google.com/forum/#!topic/rubyonrails-security/GN7w9fFAQeI for further
+# details. If you update the Rails version, please check that the patch is included.
+raise "MonkeyPatch may no longer apply" unless Rails.version == "4.1.16"
+
+ActionDispatch::Request.prepend(Module.new do
+  def formats
+    super().select do |format|
+      format.symbol || format.ref == "*/*"
+    end
+  end
+end)


### PR DESCRIPTION
I do not believe that Curate exposed this vulnerability, however this
patch is the recommended "monkey patch" if a version upgrade is not
feasible at this time.