### PR TITLE
Use token to authenticate API request

### DIFF
--- a/app/controllers/api/items_controller.rb
+++ b/app/controllers/api/items_controller.rb
@@ -1,11 +1,17 @@
-class Api::ItemsController < CommonObjectsController
+class Api::ItemsController < ApplicationController
+  respond_to :jsonld
+  include Sufia::Noid # for normalize_identifier method
+  prepend_before_filter :normalize_identifier
+  before_filter :validate_permissions!
+  before_filter :item, only: [:show]
+
   # GET /api/items
   def index
   end
 
   # GET /api/items/1
   def show
-    render json: curation_concern.as_jsonld
+    render json: item.as_jsonld
   end
 
   # GET /api/items/new
@@ -31,12 +37,11 @@ class Api::ItemsController < CommonObjectsController
   def dismiss
   end
 
-  def enforce_show_permissions
-    set_current_user!
-    super
-  end
-
   private
+
+    def item
+      @this_item ||= ActiveFedora::Base.find(params[:id], cast: true)
+    end
 
     def set_current_user!
       token_sha = request.headers['X-Api-Token']
@@ -49,6 +54,15 @@ class Api::ItemsController < CommonObjectsController
         end
       else
         @current_user = nil
+      end
+    end
+
+    def validate_permissions!
+      set_current_user!
+      item_id = params[:id]
+      user_name = @current_user.try(:username) || @current_user
+      if current_ability.cannot? :read, item_id
+        render json: { error: 'Forbidden', user: user_name, item: item_id }, status: :forbidden
       end
     end
 end

--- a/spec/controllers/api/items_controller_spec.rb
+++ b/spec/controllers/api/items_controller_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe Api::ItemsController do
-  let(:work1) { FactoryGirl.create(:public_generic_work) }
-  let(:work2) { FactoryGirl.create(:private_generic_work, user: user) }
+  let(:public_work) { FactoryGirl.create(:public_generic_work) }
+  let(:private_work) { FactoryGirl.create(:private_generic_work, user: user) }
   let(:user) { FactoryGirl.create(:user) }
   let(:token) { ApiAccessToken.create(issued_by: user.id, user: user) }
 
@@ -11,7 +11,7 @@ describe Api::ItemsController do
       it 'returns 200 and json document' do
         request.headers['X-Api-Token'] = token.sha
         request.headers['HTTP_ACCEPT'] = "application/json"
-        get :show, { id: work2.to_param }
+        get :show, { id: private_work.to_param }
         expect(response).to be_successful
       end
     end
@@ -20,14 +20,14 @@ describe Api::ItemsController do
       it 'returns 403 and json document for private work' do
         request.headers['X-Api-Token'] = 'abc'
         request.headers['HTTP_ACCEPT'] = "application/json"
-        get :show, { id: work2.to_param }
+        get :show, { id: private_work.to_param }
         expect(response).to be_forbidden
       end
 
       it 'returns 200 and json document for public work' do
         request.headers['X-Api-Token'] = 'abc'
         request.headers['HTTP_ACCEPT'] = "application/json"
-        get :show, { id: work1.to_param }
+        get :show, { id: public_work.to_param }
         expect(response).to be_successful
       end
     end
@@ -35,13 +35,13 @@ describe Api::ItemsController do
     context 'without api token' do
       it 'returns 403 and json document' do
         request.headers['HTTP_ACCEPT'] = "application/json"
-        get :show, { id: work2.to_param }
+        get :show, { id: private_work.to_param }
         expect(response).to be_forbidden
       end
 
       it 'returns 200 and json document for public work' do
         request.headers['HTTP_ACCEPT'] = "application/json"
-        get :show, { id: work1.to_param }
+        get :show, { id: public_work.to_param }
         expect(response).to be_successful
       end
     end

--- a/spec/controllers/api/items_controller_spec.rb
+++ b/spec/controllers/api/items_controller_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe Api::ItemsController do
+  let(:work) { FactoryGirl.create(:generic_work) }
+  let(:user) { FactoryGirl.create(:user) }
+  let(:token) { ApiAccessToken.create(issued_by: user.id, user: user) }
+
+  describe '#show' do
+    context 'with api token which grants access' do
+      it 'returns 200 and json document' do
+        request.headers['X-Api-Token'] = token.sha
+        request.headers['HTTP_ACCEPT'] = "application/json"
+        get :show, { id: work.to_param }
+        expect(response).to be_successful
+      end
+    end
+
+    context 'with api token which does not grant access' do
+      it 'returns 403 and json document' do
+        request.headers['X-Api-Token'] = 'abc'
+        request.headers['HTTP_ACCEPT'] = "application/json"
+        get :show, { id: work.to_param }
+        expect(response).to be_forbidden
+      end
+    end
+
+    context 'without api token' do
+      it 'returns 403 and json document' do
+        request.headers['HTTP_ACCEPT'] = "application/json"
+        get :show, { id: work.to_param }
+        expect(response).to be_forbidden
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fix logic so API token will mimic token's user to grant access to items.