### PR TITLE
Correct Administrative Unit selection list

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ group :default do
   # Need rubyracer to run integration tests.....really?!?
   # See https://github.com/sstephenson/execjs#readme for more supported runtimes
   gem 'libv8', '~> 3.16.14.3'
-  gem 'locabulary', github: 'ndlib/locabulary', ref: 'c3e5a8959c92bc9650e20a49d2d671c6f2e13482'
+  gem 'locabulary', github: 'ndlib/locabulary', ref: 'b8ab510dce637d37229d001fedfbc6af1ab510f2'
   gem 'lograge'
   gem 'logstash-event'
   gem 'logstash-logger'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,8 +27,8 @@ GIT
 
 GIT
   remote: https://github.com/ndlib/locabulary.git
-  revision: c3e5a8959c92bc9650e20a49d2d671c6f2e13482
-  ref: c3e5a8959c92bc9650e20a49d2d671c6f2e13482
+  revision: b8ab510dce637d37229d001fedfbc6af1ab510f2
+  ref: b8ab510dce637d37229d001fedfbc6af1ab510f2
   specs:
     locabulary (0.8.1)
       activesupport (>= 4.0, < 6.0)
@@ -268,7 +268,7 @@ GEM
     docile (1.3.1)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
-    dry-configurable (0.8.2)
+    dry-configurable (0.8.3)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.4, >= 0.4.7)
     dry-core (0.4.7)

--- a/app/helpers/curate/administrative_unit_helper.rb
+++ b/app/helpers/curate/administrative_unit_helper.rb
@@ -1,95 +1,49 @@
 module Curate::AdministrativeUnitHelper
-  def administrative_unit_option_listing(curation_concern)
-    select_administrative_unit_ids = []
-    processed_administrative_unit_ids = []
-
-    administrative_units = Array.wrap(curation_concern.administrative_unit)
-
-    administrative_units.each do |administrative_unit|
-      select_administrative_unit_ids << administrative_unit
-    end
-
-    options = ''
-
-    roots = ControlledVocabularyService.active_hierarchical_roots(name: 'administrative_units')
-
-    roots.each do |root|
-      root.children.each do |administrative_unit|
-        processed_administrative_unit_ids << administrative_unit.selectable_id
-        options << "<optgroup label=\"#{optgroup_label_for(administrative_unit)}\">".html_safe
-
-        if administrative_unit.selectable?
-          options << administrative_unit_options_from_collection_for_select_with_attributes(
-            [administrative_unit], 'selectable_id', 'selectable_label','indent', 'children', select_administrative_unit_ids
-          )
-        end
-
-        if administrative_unit.children.present?
-          selectable_children = administrative_unit.children.reject {|n| !n.selectable?}
-          not_selectable_children = administrative_unit.children.reject {|n| n.selectable?}
-          options << administrative_unit_options_from_collection_for_select_with_attributes(
-            selectable_children, 'selectable_id', 'selectable_label', 'indent', 'children', select_administrative_unit_ids
-          )
-          options << administrative_units_select_options_html(
-            not_selectable_children, processed_administrative_unit_ids, select_administrative_unit_ids
-          )
-        end
-        options << '</optgroup>'.html_safe
-      end
-    end
-    return options
+  def administrative_unit_option_listing(curation_concern, as_of:)
+    # all of the curation_concern's current admin units to mark as "selected"
+    selected_administrative_unit_ids = Array.wrap(curation_concern.administrative_unit)
+    # The list is returned in the appropriate sequence for display
+    roots = ControlledVocabularyService.active_hierarchical_roots(name: 'administrative_units', as_of: as_of)
+    # processes the above list into an array of items for the menu.
+    menu_items = ControlledVocabularyService.hierarchical_menu_options(roots: roots)
+    # return the formatted html for the menu items
+    formatted_html_for(menu_items, selected_administrative_unit_ids)
   end
 
   private
 
-  # University of Notre Dame is a three-level hierarchy
-  # Non-UND Administrative Units MUST be 2-level hierarchies
-  def optgroup_label_for(administrative_unit)
-    if administrative_unit.root_slug == "University of Notre Dame"
-      administrative_unit.selectable_label
-    else
-      administrative_unit.root_slug
-    end
-  end
-
-  def administrative_units_select_options_html(administrative_units, processed_administrative_unit_ids = [], selected_list)
-    administrative_units.map do |administrative_unit|
-      if administrative_unit.selectable?
-        content_tag(
-          :option,
-          value: administrative_unit.selectable_id,
-          selected: administrative_unit_is_selected?( administrative_unit, selected_list),
-          data: { indent: 4 }
-        ) { administrative_unit.selectable_label } + administrative_units_select_options_html(
-          administrative_unit.children, processed_administrative_unit_ids
-        )
-      else
-        content_tag(
-          :option,
-          value: administrative_unit.selectable_id,
-          disabled: true,
-          data:{ indent: 2, class: 'bold-row' }
-        ) { administrative_unit.selectable_label } + administrative_units_select_options_html(
-          administrative_unit.children, processed_administrative_unit_ids, selected_list
-        )
+    def formatted_html_for(menu_items, selected_administrative_unit_ids)
+      options = ''
+      menu_items.each do |list_item|
+        if !list_item.key?(:item)
+          # close prior group unless it was the first one
+          if !options.empty?
+            options << '</optgroup>'.html_safe
+          end
+          # start a new group with the heading row
+          options << "<optgroup label=\"#{list_item[:category_title]}\">".html_safe
+        else
+          # add administrative unit link to group
+          administrative_unit = list_item[:item]
+          options << administrative_unit_options_from_collection_for_select_with_attributes(
+            [administrative_unit], 'selectable_id', 'selectable_label','indent', 'children', selected_administrative_unit_ids
+          )
+        end
       end
-    end.join.html_safe
-  end
-
-  def administrative_unit_options_from_collection_for_select_with_attributes(collection, value_method, text_method, attr_name, attr_field, selected = nil)
-    options = collection.map do |element|
-      [ element.send(text_method), element.send(value_method), "data-" + attr_name => element.send(attr_field).size ]
+      # close the final group
+      options << '</optgroup>'.html_safe
     end
 
-    selected, disabled = extract_selected_and_disabled(selected)
-    select_deselect = {}
-    select_deselect[:selected] = extract_values_from_collection(collection, value_method, selected)
-    select_deselect[:disabled] = extract_values_from_collection(collection, value_method, disabled)
+    def administrative_unit_options_from_collection_for_select_with_attributes(collection, value_method, text_method, attr_name, attr_field, selected = nil)
+      options = collection.map do |element|
+        [ element.send(text_method), element.send(value_method), "data-" + attr_name => element.send(attr_field).size ]
+      end
 
-    options_for_select(options, select_deselect)
-  end
+      selected, disabled = extract_selected_and_disabled(selected)
+      select_deselect = {}
+      select_deselect[:selected] = extract_values_from_collection(collection, value_method, selected)
+      select_deselect[:disabled] = extract_values_from_collection(collection, value_method, disabled)
 
-  def administrative_unit_is_selected?(administrative_unit,selected_list)
-    selected_list.include?(administrative_unit.id)
-  end
+      options_for_select(options, select_deselect)
+    end
 end

--- a/app/services/controlled_vocabulary_service.rb
+++ b/app/services/controlled_vocabulary_service.rb
@@ -52,9 +52,16 @@ class ControlledVocabularyService
   end
 
   # @param name [String] - the predicate name to search
-  # @return [Array] - Array of Locabulary items
-  def self.active_hierarchical_roots(name:)
-    Locabulary.active_hierarchical_roots(predicate_name: name)
+  # @param as_of [Time] - active as of date or :all
+  # @return [Array<Locabulary::Items] - Array of Locabulary items
+  def self.active_hierarchical_roots(name:, as_of: Time.zone.now)
+    Locabulary.active_hierarchical_roots(predicate_name: name, as_of: as_of)
+  end
+
+  # @param roots [Array<Locabulary::Items] - returned from active_hierarchical_roots
+  # @return [Array<Hash] - Formatted hashes for admin unit selection menu
+  def self.hierarchical_menu_options(roots:)
+    Locabulary.hierarchical_menu_options(roots: roots)
   end
 
   # @param name [String] - the predicate name to search

--- a/app/views/curation_concern/base/_form_administrative_unit.html.erb
+++ b/app/views/curation_concern/base/_form_administrative_unit.html.erb
@@ -15,7 +15,12 @@
   </span>
   <div class="controls">
     <% options = "" %>
-    <% options << administrative_unit_option_listing(curation_concern) %>
+    <% if action_name == "edit"
+        as_of = :all
+      else
+        as_of = Time.zone.now
+    end %>
+    <% options << administrative_unit_option_listing(curation_concern, as_of: as_of) %>
     <%=select_tag "#{f.object_name}[administrative_unit][]", options, {prompt: 'Please select one or more; type to search', class: 'input-xxlarge department-select', :size =>10, multiple:true, required: required }  %>
   </div>
 </div>

--- a/spec/services/controlled_vocabulary_service_spec.rb
+++ b/spec/services/controlled_vocabulary_service_spec.rb
@@ -101,12 +101,26 @@ RSpec.describe ControlledVocabularyService do
 
   describe '.active_hierarchical_roots' do
     let(:name) { 'administrative_units' }
-    let(:subject) { described_class.active_hierarchical_roots(name: name) }
+    let(:as_of) { Time.zone.now }
+    let(:subject) { described_class.active_hierarchical_roots(name: name, as_of: as_of) }
 
     it 'calls Locabulary' do
-      expect(Locabulary).to receive(:active_hierarchical_roots).with(predicate_name: name).and_call_original
+      expect(Locabulary).to receive(:active_hierarchical_roots).with(predicate_name: name, as_of: as_of).and_call_original
       expect(subject).to be_a(Array)
       expect(subject.first).to be_a(Locabulary::Items::Base)
+    end
+  end
+
+  describe '.hierarchical_menu_options' do
+    let(:name) { 'administrative_units' }
+    let(:as_of) { Time.zone.now }
+    let(:roots) { described_class.active_hierarchical_roots(name: name, as_of: as_of) }
+    let(:subject) { described_class.hierarchical_menu_options(roots: roots) }
+
+    it 'calls Locabulary' do
+      expect(Locabulary).to receive(:hierarchical_menu_options).with(roots: roots).and_call_original
+      expect(subject).to be_a(Array)
+      expect(subject.first).to be_a(Hash)
     end
   end
 


### PR DESCRIPTION
Fixes an issue where items not within the "University of Notre Dame" root category did not display properly in the hierarchical format, but instead titles were duplicated for each administrative unit.

* Moves this corrected administrative unit building of selectable items into locabulary, and uses the new version of locabulary. This allows Sipity to share the same menu building logic.
* Incorporates ability to retrieve all administrative units for edit, while new items will continue to show only active items.