### PR TITLE
Ensuring Array passed to `render_filter_element`

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -99,7 +99,7 @@ module BlacklightFacetExtras
         content = []
         if localized_params[:f]
           localized_params[:f].each_pair do |facet,values|
-            content << render_filter_element(facet, values, localized_params)
+            content << render_filter_element(facet, Array.wrap(values), localized_params)
           end
         end
         if localized_params[:f_inclusive]


### PR DESCRIPTION
In reviewing exceptions, I noticed a case where an unexpected
URL (eg. `https://curate.nd.edu/catalog?_=1522360201810`) raised an
exception. I don't believe this should be a hard-fail (see exception
below). By wrapping the value in an Array, we ensure that we don't
raise the given exception.

```console
NoMethodError: undefined method `map' for nil:NilClass
  app/controllers/catalog_controller.rb:102:in `block in render_constraints_filters'
    content << render_filter_element(facet, values, localized_params)
```