### PR TITLE
Update mini_magick vulnerability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ group :default do
   gem 'logstash-event'
   gem 'logstash-logger'
   gem 'mailboxer', '~> 0.11.0'
-  gem 'mini_magick', '~> 3.8'
+  gem 'mini_magick', ">= 4.9.4"
   gem 'morphine'
   gem 'mysql2', '~> 0.3.18'
   gem 'namae'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -392,8 +392,7 @@ GEM
     method_locator (0.0.4)
     method_source (0.9.2)
     mime-types (2.99.3)
-    mini_magick (3.8.1)
-      subexec (~> 0.2.1)
+    mini_magick (4.9.5)
     mini_mime (1.0.1)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
@@ -633,7 +632,6 @@ GEM
       sprockets (>= 2.8, < 4.0)
     stackprof (0.2.12)
     stomp (1.4.8)
-    subexec (0.2.3)
     test_after_commit (1.2.2)
       activerecord (>= 3.2, < 5.0)
     therubyracer (0.12.1)
@@ -751,7 +749,7 @@ DEPENDENCIES
   meta_request
   method_locator
   method_source
-  mini_magick (~> 3.8)
+  mini_magick (>= 4.9.4)
   morphine
   mysql2 (~> 0.3.18)
   namae


### PR DESCRIPTION
Update mini-magick to >= 4.9.4 due to vulnerability.