### PR TITLE
Add Search of Deposit & Modify Dates to API

### DIFF
--- a/app/presenters/api/items_search_presenter.rb
+++ b/app/presenters/api/items_search_presenter.rb
@@ -91,7 +91,7 @@ class Api::ItemsSearchPresenter
       if !fields.nil?
         fields.each do |field|
           begin
-            results_hash[field] = self.send("include_#{field}")
+            results_hash[field.camelize(:lower)] = self.send("include_#{field}")
           rescue NoMethodError
           end
         end
@@ -106,7 +106,7 @@ class Api::ItemsSearchPresenter
         if fields.present?
           fields.each do |field|
             value = @item.fetch(field, [])
-            hash[key] = value unless value.empty?
+            hash[key.to_s.camelize(:lower)] = value unless value.empty?
           end
         end
       end
@@ -118,7 +118,7 @@ class Api::ItemsSearchPresenter
     end
 
     def dc_title
-      dc_title = Array.wrap(@item.fetch('desc_metadata__title_tesim', 'title-not-found' )).first
+      Array.wrap(@item.fetch('desc_metadata__title_tesim', 'title-not-found' )).first
     end
 
     def dc_type
@@ -137,6 +137,14 @@ class Api::ItemsSearchPresenter
 
     def include_depositor
       @item.fetch('depositor_tesim', []).first
+    end
+
+    def include_deposit_date
+      @item.fetch('system_create_dtsi', "")
+    end
+
+    def include_modify_date
+      @item.fetch('system_modified_dtsi', "")
     end
   end
 

--- a/spec/controllers/api/items_controller_spec.rb
+++ b/spec/controllers/api/items_controller_spec.rb
@@ -86,6 +86,22 @@ describe Api::ItemsController do
         expect(json['query']['queryParameters'].keys).to include("type", "editor", "depositor")
       end
     end
+
+    context 'with date filtering' do
+      let(:requested_date) { "after:2019-01-01" }
+
+      it 'searches dates and includes dates in the search results list' do
+        request.headers['X-Api-Token'] = token.sha
+        request.headers['HTTP_ACCEPT'] = "application/json"
+        get :index, { deposit_date: requested_date, modify_date: requested_date }
+        expect(response).to be_successful
+        json = JSON.parse(response.body)
+
+        expect(json['pagination']['totalResults']).to eq(3)
+        expect(json['results'].first.keys).to include("depositDate", "modifyDate")
+        expect(json['query']['queryParameters'].keys).to include("deposit_date", "modify_date")
+      end
+    end
   end
 
   describe '#download' do


### PR DESCRIPTION
Add search of deposit_date and modify_date. 

## Supported searches include:
### Search before date
*  `deposit_date=before:yyyy-mm-dd`
### Search after (and including) date
  `deposit_date=after:yyyy-mm-dd`
### Search one full day
 *  `deposit_date=yyyy-mm-dd`
### Combine search values with `^` to find items meeting all of the criteria
 *  `deposit_date=before:yyyy-mm-dd^after:yyyy-mm-dd`
### Combine search values with `,` to find items meeting any of the criteria
 *  `deposit_date=before:yyyy-mm-dd,after:yyyy-mm-dd,yyyy-mm-dd`