### PR TITLE
Add search of deposit_date and modify_date to API

### DIFF
--- a/app/controllers/api/items_controller.rb
+++ b/app/controllers/api/items_controller.rb
@@ -104,8 +104,14 @@ class Api::QueryBuilder
   VALID_KEYS_AND_SEARCH_FIELDNAMES = {
     type: ["active_fedora_model_ssi", "desc_metadata__type_tesim"],
     editor: ["edit_access_person_ssim"],
-    depositor: ["depositor_tesim"]
+    depositor: ["depositor_tesim"],
+    deposit_date: ["system_create_dtsi"],
+    modify_date: ["system_modified_dtsi"],
   }.freeze
+
+  AND_SEARCH_SEPARATOR = '^'
+  OR_SEARCH_SEPARATOR = ','
+  DATE_SEARCH_SEPARATOR = ':'
 
   attr_reader :current_user
 
@@ -118,7 +124,7 @@ class Api::QueryBuilder
     user_parameters.each do |term, value|
       key = term.to_sym
       if VALID_KEYS_AND_SEARCH_FIELDNAMES[key].present?
-        solr_parameters[:fq] << do_search_for(key, Array.wrap(value.split(',')))
+        solr_parameters[:fq] << do_search_for(key, value)
       end
     end
     solr_parameters
@@ -144,21 +150,56 @@ class Api::QueryBuilder
     search_for_user
   end
 
-  # builds filter query "OR" search for a given key & array of elements
-  def do_search_for(key, search_elements)
+  def filter_by_deposit_date(term)
+    filter_by_date(term)
+  end
+
+  def filter_by_modify_date(term)
+    filter_by_date(term)
+  end
+
+  # allowed formats: "after:2019-01-01", "before:2019-01-01", "2019-01-01"
+  def filter_by_date(term)
+    search_data = term.split(DATE_SEARCH_SEPARATOR)
+    comparison_date = ActiveSupport::TimeZone.new('UTC').parse(search_data.last)
+    return "[#{comparison_date.xmlschema} TO *]" if search_data.first == 'after'
+    return "[* TO #{comparison_date.xmlschema}]" if search_data.first == 'before'
+    "[#{comparison_date.xmlschema.to_s} TO #{(comparison_date + 1.days).xmlschema}]"
+  end
+
+  # builds filter query search for a given key & array of elements
+  def do_search_for(key, value)
+    join_by = join_for(value)
+    search_elements = parse_into_search_elements(key, value)
     filter = ""
     num_elements = search_elements.size
     search_elements.each_with_index do |term, x|
       search_term = self.send("filter_by_#{key}", term)
-      filter += (prepare_search_term_for(key, search_term) + or_if_more(x, num_elements))
+      filter += (prepare_search_term_for(key, search_term) + join_if_more(x, num_elements, join_by))
     end
     filter
   end
 
-  def or_if_more(x, size)
+  def join_for(value)
+    return " OR " if value.include?(OR_SEARCH_SEPARATOR)
+    return " AND " if value.include?(AND_SEARCH_SEPARATOR)
+  end
+
+  # parse on special characters to build fq query
+  # this allows us to have our own input interface
+  def parse_into_search_elements(key, value)
+    # separate value for "OR" search if it has a comma
+    return Array.wrap(value.split(OR_SEARCH_SEPARATOR)) if value.include?(OR_SEARCH_SEPARATOR)
+    # format value for "AND" search if it has '^'
+    return Array.wrap(value.split(AND_SEARCH_SEPARATOR)) if value.include?(AND_SEARCH_SEPARATOR)
+    # make sure returned value is an array
+    Array.wrap(value)
+  end
+
+  def join_if_more(x, size, join_term)
     text = ""
     if x < size-1 # not last element
-      text += " OR "
+      text += join_term
     end
     text
   end
@@ -167,7 +208,8 @@ class Api::QueryBuilder
     num_elements = VALID_KEYS_AND_SEARCH_FIELDNAMES[key].size
     search_term = ""
     VALID_KEYS_AND_SEARCH_FIELDNAMES[key].each_with_index do |field, x|
-      search_term  += (field + ":" + "\"#{term}\"" + or_if_more(x, num_elements))
+      this_term = field.ends_with?('dtsi') ? term : "\"#{term}\""
+      search_term  += ("#{field}:#{this_term}" + join_if_more(x, num_elements, " OR "))
     end
     search_term
   end

--- a/app/presenters/api/items_search_presenter.rb
+++ b/app/presenters/api/items_search_presenter.rb
@@ -91,7 +91,7 @@ class Api::ItemsSearchPresenter
       if !fields.nil?
         fields.each do |field|
           begin
-            results_hash[field] = self.send("include_#{field}")
+            results_hash[field.camelize(:lower)] = self.send("include_#{field}")
           rescue NoMethodError
           end
         end
@@ -106,7 +106,7 @@ class Api::ItemsSearchPresenter
         if fields.present?
           fields.each do |field|
             value = @item.fetch(field, [])
-            hash[key] = value unless value.empty?
+            hash[key.to_s.camelize(:lower)] = value unless value.empty?
           end
         end
       end
@@ -118,7 +118,7 @@ class Api::ItemsSearchPresenter
     end
 
     def dc_title
-      dc_title = Array.wrap(@item.fetch('desc_metadata__title_tesim', 'title-not-found' )).first
+      Array.wrap(@item.fetch('desc_metadata__title_tesim', 'title-not-found' )).first
     end
 
     def dc_type
@@ -137,6 +137,14 @@ class Api::ItemsSearchPresenter
 
     def include_depositor
       @item.fetch('depositor_tesim', []).first
+    end
+
+    def include_deposit_date
+      @item.fetch('system_create_dtsi', "")
+    end
+
+    def include_modify_date
+      @item.fetch('system_modified_dtsi', "")
     end
   end
 

--- a/spec/controllers/api/items_controller_spec.rb
+++ b/spec/controllers/api/items_controller_spec.rb
@@ -86,6 +86,22 @@ describe Api::ItemsController do
         expect(json['query']['queryParameters'].keys).to include("type", "editor", "depositor")
       end
     end
+
+    context 'with date filtering' do
+      let(:requested_date) { "after:2019-01-01" }
+
+      it 'searches dates and includes dates in the search results list' do
+        request.headers['X-Api-Token'] = token.sha
+        request.headers['HTTP_ACCEPT'] = "application/json"
+        get :index, { deposit_date: requested_date, modify_date: requested_date }
+        expect(response).to be_successful
+        json = JSON.parse(response.body)
+
+        expect(json['pagination']['totalResults']).to eq(3)
+        expect(json['results'].first.keys).to include("depositDate", "modifyDate")
+        expect(json['query']['queryParameters'].keys).to include("deposit_date", "modify_date")
+      end
+    end
   end
 
   describe '#download' do


### PR DESCRIPTION
## Supported searches include:
### Search before date
*  `deposit_date=before:yyyy-mm-dd`
### Search after (and including) date
*  `deposit_date=after:yyyy-mm-dd`
### Search one full day
 *  `deposit_date=yyyy-mm-dd`
### Combine search values with `^` to find items meeting all of the criteria
 *  `deposit_date=before:yyyy-mm-dd^after:yyyy-mm-dd`
### Combine search values with `,` to find items meeting any of the criteria
 *  `deposit_date=before:yyyy-mm-dd,after:yyyy-mm-dd,yyyy-mm-dd`