### PR TITLE
Handle zip file downloads based on item in request

### DIFF
--- a/spec/controllers/api/items_controller_spec.rb
+++ b/spec/controllers/api/items_controller_spec.rb
@@ -4,6 +4,7 @@ describe Api::ItemsController do
   let(:public_article) { FactoryGirl.create(:public_article, title: 'Fried Green Tomatoes',) }
   let(:private_article) { FactoryGirl.create(:article, title: 'All About Cats', user: user) }
   let(:private_work) { FactoryGirl.create(:private_generic_work, title: 'More About Cats', user: user) }
+  let(:generic_work_with_files) { FactoryGirl.create(:generic_work_with_files, title: 'I have 3 files', user: user) }
   let(:generic_file) { FactoryGirl.create(:generic_file, user: user) }
   let(:user) { FactoryGirl.create(:user) }
   let(:token) { ApiAccessToken.create(issued_by: user.id, user: user) }
@@ -105,16 +106,28 @@ describe Api::ItemsController do
   end
 
   describe '#download' do
-    context 'with authority to file' do
-      it 'has X-Accel-Redirect header in response' do
-        request.headers['X-Api-Token'] = token.sha
-        request.headers['HTTP_ACCEPT'] = "application/json"
-        get :download, { id: generic_file.to_param }
-        expect(response.headers.fetch('X-Accel-Redirect')).to eq("/download-content/#{generic_file.to_param}")
+    context 'with authority to item' do
+      context 'when item is a work with several files' do
+        it 'has X-Accel-Redirect header to download zip files in response' do
+          request.headers['X-Api-Token'] = token.sha
+          request.headers['HTTP_ACCEPT'] = "application/json"
+          get :download, { id: generic_work_with_files.to_param }
+          file_list = generic_work_with_files.generic_files.map{|file| Sufia::Noid.noidify(file.id) }
+          expect(response.headers.fetch('X-Accel-Redirect')).to eq("/download-content/#{generic_work_with_files.to_param}/zip/#{file_list.join(',')}")
+        end
+      end
+
+      context 'when item is a generic file' do
+        it 'has X-Accel-Redirect header to single download in response' do
+          request.headers['X-Api-Token'] = token.sha
+          request.headers['HTTP_ACCEPT'] = "application/json"
+          get :download, { id: generic_file.to_param }
+          expect(response.headers.fetch('X-Accel-Redirect')).to eq("/download-content/#{generic_file.to_param}")
+        end
       end
     end
 
-    context 'without authority to file' do
+    context 'without authority to item' do
       it 'returns 403 and json document' do
         request.headers['HTTP_ACCEPT'] = "application/json"
         get :download, { id: generic_file.to_param }


### PR DESCRIPTION
When download route receives a work id, initiate a zip download of all authorized files.
When download route receives a file id, initiate a normal download of single file.
When there are no authorized files to download on the work, return an error.