### PR TITLE
Add api route to return trx status

### DIFF
--- a/app/controllers/api/uploads_controller.rb
+++ b/app/controllers/api/uploads_controller.rb
@@ -75,6 +75,20 @@ class Api::UploadsController < Api::BaseController
     end
   end
 
+  # GET /api/uploads/:tid/status
+  # Return status of this transaction
+  def trx_status
+    #parse out trx_id
+    trx_id = params[:tid]
+
+    begin
+      status = ApiTransaction.find(trx_id).trx_status
+      render json: { trx_id: trx_id, status: status }, status: :ok
+    rescue ActiveRecord::RecordNotFound
+      render json: { trx_id: trx_id, status: "Transaction not found" }, status: :not_found
+    end
+  end
+
   private
 
     def next_file_sequence(trx_id:, file_id:)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -122,6 +122,7 @@ CurateNd::Application.routes.draw do
     get 'uploads/new', as: 'trx_initiate', controller: 'uploads', action: 'trx_initiate'
     post 'uploads/:tid/file/new', as: 'trx_new_file', controller: 'uploads', action: 'trx_new_file'
     post 'uploads/:tid/file/:fid', as: 'trx_append', controller: 'uploads', action: 'trx_append'
+    get 'uploads/:tid/status', controller: 'uploads', action: 'trx_status'
     post 'uploads/:tid/commit', as: 'trx_commit', controller: 'uploads', action: 'trx_commit'
   end
 

--- a/spec/controllers/api/uploads_controller_spec.rb
+++ b/spec/controllers/api/uploads_controller_spec.rb
@@ -3,7 +3,8 @@ require 'spec_helper'
 describe Api::UploadsController do
   let(:user) { FactoryGirl.create(:user) }
   let(:token) { ApiAccessToken.create(issued_by: user.id, user: user) }
-  let(:transaction) { double }
+  let(:transaction) { ApiTransaction.new(trx_id: '12345', user_id: user.id, trx_status: "test") }
+  let(:failed_trx) { double(ApiTransaction) }
 
   describe '#trx_initiate' do
     context 'with api token which grants access' do
@@ -12,20 +13,22 @@ describe Api::UploadsController do
         request.headers['HTTP_ACCEPT'] = "application/json"
         get :trx_initiate
         expect(response).to be_successful
+        expect(response.body).to include("trx_id")
       end
     end
 
     context 'when save fails' do
       before do
-        allow(ApiTransaction).to receive(:new).and_return(:transaction)
-        allow(transaction).to receive(:save).and_return false
+        allow(ApiTransaction).to receive(:new).and_return(failed_trx)
+        allow(failed_trx).to receive(:save).and_return false
       end
 
       it 'returns 417 and json document' do
         request.headers['X-Api-Token'] = token.sha
         request.headers['HTTP_ACCEPT'] = "application/json"
         get :trx_initiate
-        expect(response).to be_successful
+        expect(response.status).to eq(417)
+        expect(response.body).to include("Transaction not initiated")
       end
     end
 
@@ -34,6 +37,47 @@ describe Api::UploadsController do
         request.headers['HTTP_ACCEPT'] = "application/json"
         get :trx_initiate
         expect(response.status).to eq(401) #expectation_failed
+        expect(response.body).to include("Token is required to authenticate user")
+      end
+    end
+  end
+
+  describe '#trx_new_file' do
+  end
+
+  describe '#trx_new_file' do
+  end
+
+  describe '#trx_append' do
+  end
+
+  describe '#trx_commit' do
+  end
+
+  describe '#trx_status' do
+    let(:trx) { transaction }
+
+    context 'with a valid transaction id' do
+      before do
+        trx.save
+      end
+
+      it 'returns 200 and json document' do
+        request.headers['X-Api-Token'] = token.sha
+        request.headers['HTTP_ACCEPT'] = "application/json"
+        get :trx_status, { tid: trx.trx_id }
+        expect(response).to be_successful
+        expect(response.body).to eq "{\"trx_id\":\"12345\",\"status\":\"test\"}"
+      end
+    end
+
+    context 'with an invalid transaction id' do
+      it 'returns 200 and json document' do
+        request.headers['X-Api-Token'] = token.sha
+        request.headers['HTTP_ACCEPT'] = "application/json"
+        get :trx_status, { tid: 'bbbbb' }
+        expect(response).to be_not_found
+        expect(response.body).to include("Transaction not found")
       end
     end
   end


### PR DESCRIPTION
Implements `/api/uploads/:tid/status` to return the current status for a given transaction id

Enhances spec expectations for uploads_controller to validate the json responses.