### PR TITLE
Refactor uploads controller

### DIFF
--- a/app/controllers/api/uploads_controller.rb
+++ b/app/controllers/api/uploads_controller.rb
@@ -1,27 +1,48 @@
-require 'aws-sdk-s3'
 require 'json'
 
 class Api::UploadsController < Api::BaseController
   include Sufia::IdService # for mint method
   before_filter :set_current_user!, only: [:trx_initiate, :trx_new_file, :trx_append, :trx_commit]
+  attr_reader :bucket
 
+  # begin a new work transaction
   # GET /api/uploads/new
   def trx_initiate
     if @current_user
       trx_id = ApiTransaction.new_trx_id
-      work_pid = Sufia::Noid.noidify(Sufia::IdService.mint)
-      start_transaction = ApiTransaction.new(trx_id: trx_id, user_id: @current_user.id, work_id: work_pid, trx_status: ApiTransaction.set_status(:new))
-      if start_transaction.save
-        # s3 bucket connection
-        s3 = Aws::S3::Resource.new(region:'us-east-1')
-        metadata = s3.bucket(ENV['S3_BUCKET']).object("#{trx_id}/metadata-work-#{work_pid}.json")
-        metadata.put(body: initial_work_metadata(work_pid, request.body()))
-        render json: { trx_id: trx_id, work_id: work_pid }, status: :ok
-      else
-        render json: { error: 'Transaction not initiated' }, status: :expectation_failed
+      work_pid = mint_new_id
+      metadata_formatter = Api::WorkMetadataFormatter.new(content: work_metadata_content_for(work_pid))
+      # validate metadata
+      if metadata_formatter.valid?
+        # initiate transaction & upload files
+        start_transaction = ApiTransaction.new(
+          trx_id: trx_id,
+          user_id: @current_user.id,
+          work_id: work_pid,
+          trx_status: ApiTransaction.set_status(:new)
+        )
+        # save transaction
+        if start_transaction.save
+          # write work metadata to s3 bucket connection
+          bucket.put(
+            named_path: "#{trx_id}/metadata-work-#{work_pid}.json",
+            body: metadata_formatter.initial_metadata
+          )
+          # respond ok
+          render json: { trx_id: trx_id,
+                         work_id: work_pid },
+                 status: :ok
+        else # transaction save failed, error 417
+          render json: { error: 'Transaction not initiated' },
+                 status: :expectation_failed
+        end
+      else # invalid metadata, error 406
+        render json: { error: 'Invalid metadata for work' },
+               status: :not_acceptable
       end
-    else
-      render json: { error: 'Token is required to authenticate user' }, status: :unauthorized
+    else # unauthenticated user, error 401
+      render json: { error: 'Token is required to authenticate user' },
+             status: :unauthorized
     end
   end
 
@@ -29,72 +50,84 @@ class Api::UploadsController < Api::BaseController
   # Start a new upload of a file associated with this transaction
   def trx_new_file
     if @current_user
-      #parse out trx_id
       trx_id = params[:tid]
-
-      trx_record = ApiTransaction.find_by( trx_id: trx_id)
-      work_pid = trx_record.work_id
-
-      #parse out file_name
       file_name = request.query_parameters[:file_name]
-      #get a pid for the file
-      file_pid = Sufia::Noid.noidify(Sufia::IdService.mint)
-      # s3 bucket connection
-      s3 = Aws::S3::Resource.new(region:'us-east-1')
+      work_pid = ApiTransaction.find(trx_id).work_id
+      file_pid = mint_new_id
       next_sequence = next_file_sequence(trx_id: trx_id, file_id: file_pid)
-      content = s3.bucket(ENV['S3_BUCKET']).object("#{trx_id}/#{file_pid}-#{next_sequence}")
-      #copy body of message to bucket
-      content.put(body: request.body())
-      metadata = s3.bucket(ENV['S3_BUCKET']).object("#{trx_id}/metadata-file-#{file_pid}.json")
-      metadata.put(body: initial_file_metadata(file_name, file_pid, work_pid))
 
-      # update trx status
-      update_status(trx_id: trx_id, status: :update)
-
-      render json: { trx_id: trx_id, file_name: file_name, file_pid: file_pid, sequence: next_sequence }, status: :ok
-    else
-      render json: { error: 'Token is required to authenticate user' }, status: :unauthorized
+      metadata_formatter = Api::FileMetadataFormatter.new(content: { file_name: file_name, file_id: file_pid, work_id: work_pid } )
+      # validate metadata
+      if metadata_formatter.valid?
+        # write file from body of message to bucket
+        bucket.put(
+          named_path: "#{trx_id}/#{file_pid}-#{next_sequence}",
+          body: request.body()
+        )
+        # write file metadata to bucket
+        bucket.put(
+          named_path: "#{trx_id}/metadata-file-#{file_pid}.json",
+          body: metadata_formatter.initial_metadata
+        )
+        # update trx status
+        update_status(trx_id: trx_id, status: :update)
+        # respond ok
+        render json: { trx_id: trx_id,
+                       file_name: file_name,
+                       file_id: file_pid,
+                       sequence: next_sequence },
+               status: :ok
+      else # invalid metadata, error 406
+        render json: { error: 'Invalid metadata for file' },
+               status: :not_acceptable
+      end
+    else # unauthenticated user, error 401
+      render json: { error: 'Token is required to authenticate user' },
+             status: :unauthorized
     end
   end
 
   # POST /api/uploads/:tid/file/:fid
+  # update next segment of a file
   def trx_append
     if @current_user
-      #parse out trx_id, file_id
       trx_id = params[:tid]
       file_pid = params[:fid]
-      # s3 bucket connection
-      s3 = Aws::S3::Resource.new(region:'us-east-1')
       next_sequence = next_file_sequence(trx_id: trx_id, file_id: file_pid)
-      content = s3.bucket(ENV['S3_BUCKET']).object("#{trx_id}/#{file_pid}-#{next_sequence}")
-      #copy body of message to bucket
-      content.put(body: request.body())
-
-      render json: { trx_id: trx_id, file_pid: file_pid, sequence: next_sequence }, status: :ok
-    else
-      render json: { error: 'Token is required to authenticate user' }, status: :unauthorized
+      # write body of message to bucket
+      bucket.put(
+        named_path: "#{trx_id}/#{file_pid}-#{next_sequence}",
+        body: request.body()
+      )
+      # respond ok
+      render json: { trx_id: trx_id,
+                    file_id: file_pid,
+                    sequence: next_sequence },
+             status: :ok
+    else # unauthenticated user, error 401
+      render json: { error: 'Token is required to authenticate user' },
+             status: :unauthorized
     end
   end
 
+  # GET /api/uploads/:tid/commit
+  # submit for ingest
   def trx_commit
     if @current_user
       #parse out trx_id
       trx_id = params[:tid]
-
-      # s3 bucket connection
-      s3 = Aws::S3::Resource.new(region:'us-east-1')
-      content = s3.bucket(ENV['S3_BUCKET']).object("#{trx_id}/WEBHOOK")
       #copy body of message to bucket
-      content.put(body: callback_url(trx_id: trx_id))
-
+      bucket.put(
+        named_path: "#{trx_id}/WEBHOOK",
+        body: callback_url(trx_id: trx_id)
+      )
       # update trx status
       update_status(trx_id: trx_id, status: :commit)
-
-      # submit for ingest
-
+      # respond ok
       render json: { trx_id: trx_id }, status: :ok
-    else
-      render json: { error: 'Token is required to authenticate user' }, status: :unauthorized
+    else # unauthenticated user, error 401
+      render json: { error: 'Token is required to authenticate user' },
+             status: :unauthorized
     end
   end
 
@@ -114,6 +147,19 @@ class Api::UploadsController < Api::BaseController
 
   private
 
+    def work_metadata_content_for(work_id)
+      # comes in as json in request body
+      content = request.body().to_s
+      metadata_content = {}
+      metadata_content = content if (!content.nil? && valid_json?(content))
+      metadata_content[:work_id] = work_id
+      metadata_content
+    end
+
+    def bucket
+      @bucket ||= Api::StorageForIngest.new
+    end
+
     def next_file_sequence(trx_id:, file_id:)
       next_sequence_nbr = ApiTransactionFile.next_seq_nbr(trx_id: trx_id, file_id: file_id)
       ApiTransactionFile.new(trx_id: trx_id, file_id: file_id, file_seq_nbr: next_sequence_nbr).save
@@ -122,24 +168,6 @@ class Api::UploadsController < Api::BaseController
 
     def update_status(trx_id:, status:)
       ApiTransaction.update(trx_id, trx_status: ApiTransaction.set_status(status))
-    end
-
-    def initial_work_metadata( work_pid, request_body)
-      metadata_hash = {}
-      metadata_hash = request_body.to_s unless request_body.nil? || not_valid_json?(request_body.to_s)
-      metadata_hash['@context'] = {} if metadata_hash['@context'].nil?
-      metadata_hash['@context']['@id'] = "und:#{work_pid}"
-      JSON.dump(metadata_hash)
-    end
-
-    def initial_file_metadata(file_name, file_pid, work_pid)
-      metadata_hash = {}
-      metadata_hash['@context'] = {}
-      metadata_hash['@context']['@id'] = "und:#{file_pid}"
-      metadata_hash['nd:filename'] = "#{file_name}"
-      metadata_hash['dc:title'] = "#{file_name}"
-      metadata_hash['frels:isPartOf'] = "und:#{work_pid}"
-      JSON.dump(metadata_hash)
     end
 
     def callback_url(trx_id:)
@@ -155,11 +183,15 @@ class Api::UploadsController < Api::BaseController
       return request.url.sub!(request.protocol, '').sub!(request.path, '')
     end
 
-    # If there's way to pick up bad json w/o throwing an exception, I'm all about it
-    def not_valid_json?(json)
+    def mint_new_id
+      Sufia::Noid.noidify(Sufia::IdService.mint)
+    end
+
+    # identify bad json
+    def valid_json?(json)
       JSON.parse(json)
-       return false
-      rescue JSON::ParserError => e
        return true
+      rescue JSON::ParserError => e
+       return false
     end
 end

--- a/app/services/api/file_metadata_formatter.rb
+++ b/app/services/api/file_metadata_formatter.rb
@@ -1,0 +1,29 @@
+module Api
+  class FileMetadataFormatter
+    attr_reader :work_id, :file_id, :file_name, :remaining_content
+
+    def initialize(content:)
+      @work_id = content[:work_id]
+      @file_id = content[:file_id]
+      @file_name = content[:file_name]
+      @remaining_content = content.except(:work_id, :file_id, :file_name)
+    end
+
+    def valid?
+      return false unless work_id
+      return false unless file_id
+      return false unless file_name
+      true
+    end
+
+    def initial_metadata
+      metadata_hash = remaining_content
+      metadata_hash['@context'] = {}
+      metadata_hash['@context']['@id'] = "und:#{file_id}"
+      metadata_hash['nd:filename'] = "#{file_name}"
+      metadata_hash['dc:title'] = "#{file_name}"
+      metadata_hash['frels:isPartOf'] = "und:#{work_id}"
+      JSON.dump(metadata_hash)
+    end
+  end
+end

--- a/app/services/api/memory_bucket.rb
+++ b/app/services/api/memory_bucket.rb
@@ -1,0 +1,20 @@
+module Api
+  # an object to assist with testing to avoid using S3
+  class MemoryBucket
+    def initialize
+      @memory = {}
+    end
+
+    def object(path)
+      @memory[path] ||= MemoryObject.new
+      @memory.fetch(path)
+    end
+
+    class MemoryObject
+      def put(body:)
+        @body = body
+      end
+      attr_reader :body
+    end
+  end
+end

--- a/app/services/api/storage_for_ingest.rb
+++ b/app/services/api/storage_for_ingest.rb
@@ -1,0 +1,25 @@
+require 'aws-sdk-s3'
+
+module Api
+  # compartmentalizes use of S3 bucket for api uploads
+  class StorageForIngest
+    attr_reader :bucket
+    def initialize(bucket: default_bucket)
+      @bucket = bucket
+    end
+
+    def put(named_path:, body:)
+      named_object = bucket.object(named_path)
+      named_object.put(body: body)
+    end
+
+    private
+    def default_bucket
+      if Rails.application.config.bucket_for_ingest
+        Rails.application.config.bucket_for_ingest
+      else
+        Aws::S3::Resource.new(region: 'us-east-1').bucket(ENV['S3_BUCKET'])
+      end
+    end
+  end
+end

--- a/app/services/api/work_metadata_formatter.rb
+++ b/app/services/api/work_metadata_formatter.rb
@@ -1,0 +1,22 @@
+module Api
+  class WorkMetadataFormatter
+    attr_reader :work_id, :remaining_content
+
+    def initialize(content:)
+      @work_id = content[:work_id]
+      @remaining_content = content.except(:work_id)
+    end
+
+    def valid?
+      return false unless work_id
+      true
+    end
+
+    def initial_metadata
+      metadata_hash = remaining_content
+      metadata_hash['@context'] = {} if metadata_hash['@context'].nil?
+      metadata_hash['@context']['@id'] = "und:#{work_id}"
+      JSON.dump(metadata_hash)
+    end
+  end
+end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -34,6 +34,8 @@ CurateNd::Application.configure do
 
   config.application_root_url = "http://localhost:3000"
 
+  config.bucket_for_ingest = Api::MemoryBucket.new
+
   if ENV['FULL_STACK']
     require 'clamav'
     ClamAV.instance.loaddb

--- a/spec/controllers/api/uploads_controller_spec.rb
+++ b/spec/controllers/api/uploads_controller_spec.rb
@@ -3,28 +3,37 @@ require 'spec_helper'
 describe Api::UploadsController do
   let(:user) { FactoryGirl.create(:user) }
   let(:token) { ApiAccessToken.create(issued_by: user.id, user: user) }
-  let(:transaction) { ApiTransaction.new(trx_id: '12345', user_id: user.id, trx_status: "test") }
+  let(:tid) { '12345'}
+  let(:work_id) { '45678'}
+  let(:trx) { ApiTransaction.new(trx_id: tid, user_id: user.id, trx_status: "test", work_id: work_id) }
   let(:failed_trx) { double(ApiTransaction) }
+  let(:attached_file) { double }
 
   describe '#trx_initiate' do
     context 'with api token which grants access' do
-      let(:s3) { double }
-      let(:bucket) { double }
-      let(:bucket_object) { double }
-
-      before do
-        allow(Aws::S3::Resource).to receive(:new).and_return(s3)
-        allow(s3).to receive(:bucket).and_return(bucket)
-        allow(bucket).to receive(:object).and_return(bucket_object)
-        allow(bucket_object).to receive(:put)
-      end
-
-      it 'returns 200 and json document' do
+      it 'returns 200 and json document and updates work_id' do
         request.headers['X-Api-Token'] = token.sha
         request.headers['HTTP_ACCEPT'] = "application/json"
         get :trx_initiate
         expect(response).to be_successful
-        expect(response.body).to include("trx_id")
+        expect(JSON.parse(response.body).keys).to contain_exactly("trx_id", "work_id")
+      end
+    end
+
+    context 'when metadata fails validation' do
+      let(:formatter) { double }
+
+      before do
+        allow(Api::WorkMetadataFormatter).to receive(:new).and_return(formatter)
+        allow(formatter).to receive(:valid?).and_return(false)
+      end
+
+      it 'returns 406 and json document' do
+        request.headers['X-Api-Token'] = token.sha
+        request.headers['HTTP_ACCEPT'] = "application/json"
+        get :trx_initiate
+        expect(response.status).to eq(406) # not_acceptable
+        expect(response.body).to include('Invalid metadata for work')
       end
     end
 
@@ -38,7 +47,7 @@ describe Api::UploadsController do
         request.headers['X-Api-Token'] = token.sha
         request.headers['HTTP_ACCEPT'] = "application/json"
         get :trx_initiate
-        expect(response.status).to eq(417)
+        expect(response.status).to eq(417) # expectation_failed
         expect(response.body).to include("Transaction not initiated")
       end
     end
@@ -47,27 +56,110 @@ describe Api::UploadsController do
       it 'returns 401 and json document' do
         request.headers['HTTP_ACCEPT'] = "application/json"
         get :trx_initiate
-        expect(response.status).to eq(401) #expectation_failed
+        expect(response.status).to eq(401) # unauthorized
         expect(response.body).to include("Token is required to authenticate user")
       end
     end
   end
 
   describe '#trx_new_file' do
-  end
+    context 'with api token which grants access' do
+      let(:query_parameters) { { file_name: 'abcde.jpg' } }
 
-  describe '#trx_new_file' do
+      before do
+        trx.save
+        allow(request).to receive(:query_parameters).and_return(query_parameters)
+      end
+
+      it 'returns 200 and json document' do
+        request.headers['X-Api-Token'] = token.sha
+        request.headers['HTTP_ACCEPT'] = "application/json"
+        post :trx_new_file, tid: tid
+        expect(response.status).to eq(200) # ok
+        expect(JSON.parse(response.body).keys).to contain_exactly("trx_id", "file_name", "file_id", "sequence")
+      end
+    end
+
+    context 'without file_name in query_parameters' do
+      before do
+        trx.save
+      end
+
+      it 'returns 406 and json document' do
+        request.headers['X-Api-Token'] = token.sha
+        request.headers['HTTP_ACCEPT'] = "application/json"
+        post :trx_new_file, tid: tid
+        expect(response.status).to eq(406) # not_acceptable
+        expect(response.body).to include('Invalid metadata for file')
+      end
+    end
+
+    context 'without api token which grants access' do
+      it 'returns 401 and json document' do
+        request.headers['HTTP_ACCEPT'] = "application/json"
+        post :trx_new_file, tid: tid
+        expect(response.status).to eq(401) # unauthorized
+        expect(response.body).to include("Token is required to authenticate user")
+      end
+    end
   end
 
   describe '#trx_append' do
+    let(:fid) { "abcde" }
+
+    context 'with api token which grants access' do
+      before do
+        trx.save
+        allow(request).to receive(:body).and_return(attached_file)
+      end
+
+      it 'returns 200 and json document' do
+        request.headers['X-Api-Token'] = token.sha
+        request.headers['HTTP_ACCEPT'] = "application/json"
+        post :trx_append, tid: tid, fid: fid
+        expect(response.status).to eq(200) # ok
+        expect(JSON.parse(response.body).keys).to contain_exactly("trx_id", "file_id", "sequence")
+      end
+    end
+
+    context 'without api token which grants access' do
+      it 'returns 401 and json document' do
+        request.headers['HTTP_ACCEPT'] = "application/json"
+        post :trx_append,  tid: tid, fid: fid
+        expect(response.status).to eq(401) # unauthorized
+        expect(response.body).to include("Token is required to authenticate user")
+      end
+    end
   end
 
   describe '#trx_commit' do
+    context 'with api token which grants access' do
+      before do
+        trx.save
+        allow(controller).to receive(:callback_url).and_return('some/url')
+      end
+
+      it 'returns 200 and json document' do
+        request.headers['X-Api-Token'] = token.sha
+        request.headers['HTTP_ACCEPT'] = "application/json"
+        post :trx_commit, tid: tid
+        expect(response.status).to eq(200) # ok
+        expect(JSON.parse(response.body).keys).to contain_exactly("trx_id")
+        expect(ApiTransaction.find(tid).trx_status).to eq('submitted_for_ingest')
+      end
+    end
+
+    context 'without api token which grants access' do
+      it 'returns 401 and json document' do
+        request.headers['HTTP_ACCEPT'] = "application/json"
+        post :trx_commit,  tid: tid
+        expect(response.status).to eq(401) # unauthorized
+        expect(response.body).to include("Token is required to authenticate user")
+      end
+    end
   end
 
   describe '#trx_status' do
-    let(:trx) { transaction }
-
     context 'with a valid transaction id' do
       before do
         trx.save
@@ -78,7 +170,7 @@ describe Api::UploadsController do
         request.headers['HTTP_ACCEPT'] = "application/json"
         get :trx_status, { tid: trx.trx_id }
         expect(response).to be_successful
-        expect(response.body).to eq "{\"trx_id\":\"12345\",\"status\":\"test\"}"
+        expect(JSON.parse(response.body)).to eq( {"trx_id"=>"12345", "status"=>"test"} )
       end
     end
 

--- a/spec/services/api/storage_for_ingest_spec.rb
+++ b/spec/services/api/storage_for_ingest_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe Api::StorageForIngest do
+ describe '#put' do
+    let(:bucket) { Api::StorageForIngest.new }
+    let(:path) { "abcdefg/WEBHOOK" }
+    let(:body) { 'https://uploads/abcdefg/callback/ingest_completed.json' }
+    let(:storage_object) { bucket.put(named_path: path, body: body) }
+
+    it 'writes body to path' do
+      expect(storage_object).to eq(body)
+    end
+  end
+end


### PR DESCRIPTION
* Move S3 logic into `storage_for_ingest` service.
* Create `memory_bucket` to replace S3 logic in tests.
* Move metadata logic into separate formatters.
* Add simple metadata validation (returns 406 error)
* Complete specs for uploads controller methods.