### PR TITLE
Link to ArchivesSpace

### DIFF
--- a/app/views/curation_concern/base/unauthorized.html.erb
+++ b/app/views/curation_concern/base/unauthorized.html.erb
@@ -1,8 +1,16 @@
+<% work_type = curation_concern.human_readable_type %>
+
+<% if work_type == 'Finding Aid' %>
+<h1>Content Moved</h1>
+  <p>This item has been moved to <a href="https://archivesspace.library.nd.edu">archivesspace.library.nd.edu.</p>
+
+<% else %>
 <h1>Unauthorized</h1>
-<p>Access to this <%= curation_concern.human_readable_type.downcase %> is restricted.</p>
-<p>ID: <%= curation_concern.noid %></p>
-<p><%= render partial: 'permission_badge', locals: { curation_concern: curation_concern, show_date: true } %></p>
-<% unless current_user -%>
-  <p>If you think you should have access, please try logging in.</p>
-  <%= link_to 'Log In', new_user_session_path, class: 'btn btn-primary login', role: 'menuitem' %>
-<% end -%>
+  <p>Access to this <%= work_type.downcase %> is restricted.</p>
+  <p>ID: <%= curation_concern.noid %></p>
+  <p><%= render partial: 'permission_badge', locals: { curation_concern: curation_concern, show_date: true } %></p>
+  <% unless current_user -%>
+    <p>If you think you should have access, please try logging in.</p>
+    <%= link_to 'Log In', new_user_session_path, class: 'btn btn-primary login', role: 'menuitem' %>
+  <% end %>
+<% end %>

--- a/app/views/curation_concern/base/unauthorized.html.erb
+++ b/app/views/curation_concern/base/unauthorized.html.erb
@@ -1,12 +1,10 @@
-<% work_type = curation_concern.human_readable_type %>
-
-<% if work_type == 'Finding Aid' %>
+<% if curation_concern.is_a?(FindingAid) %>
 <h1>Content Moved</h1>
-  <p>This item has been moved to <a href="https://archivesspace.library.nd.edu">archivesspace.library.nd.edu.</p>
+  <p>This item has been moved to <a href="https://archivesspace.library.nd.edu">archivesspace.library.nd.edu.</a></p>
 
 <% else %>
 <h1>Unauthorized</h1>
-  <p>Access to this <%= work_type.downcase %> is restricted.</p>
+  <p>Access to this <%= curation_concern.human_readable_type.downcase %> is restricted.</p>
   <p>ID: <%= curation_concern.noid %></p>
   <p><%= render partial: 'permission_badge', locals: { curation_concern: curation_concern, show_date: true } %></p>
   <% unless current_user -%>


### PR DESCRIPTION
Attempts to view finding aids which are private will show a link to archivesspace rather than the unauthorized page.

https://jira.library.nd.edu/browse/DLTP-1711

![Screen Shot 2019-09-03 at 3 28 11 PM](https://user-images.githubusercontent.com/17851674/64202592-82039a80-ce5f-11e9-8c40-edf1a02a0c88.png)
