### PR TITLE
Process API Callbacks

### DIFF
--- a/app/controllers/admin/callbacks_controller.rb
+++ b/app/controllers/admin/callbacks_controller.rb
@@ -13,12 +13,12 @@ module Admin
     # params: {"controller"=>"admin/callbacks", "action"=>"callback_response", "tid"=>"c7af186a8d75c44a", "response"=>"ingest_completed", "format"=>"json"}
 
     def callback_response
+      @trx_id = params[:tid]
       response = params[:response]
 
       if validated
         response_data = JSON.parse(request.body.read)
         update_transaction_status_based_on(trx_id: trx_id, ingest_status: response_data["job_state"])
-
         render json: { trx_id: trx_id, ingest_response: response_data["job_state"] }, status: :ok
       else
         render json: { trx_id: trx_id, callback_response: "unauthorized callback" }, status: :unauthorized

--- a/app/controllers/admin/callbacks_controller.rb
+++ b/app/controllers/admin/callbacks_controller.rb
@@ -1,0 +1,64 @@
+module Admin
+  class CallbacksController < Api::BaseController
+  respond_to :jsonld
+  before_filter :validate_authentication
+  attr_reader :trx_id, :validated
+
+    # The WEBHOOK posts the following JSON body:
+    # ```json
+    #   { "host" : "libvirt8.library.nd.edu", "version" : "1.0.1", "job_name" : "ingest-45", "job_state" : "success" }
+    # ```
+    # @see https://github.com/ndlib/curatend-batch/blob/master/webhook.md
+
+    # params: {"controller"=>"admin/callbacks", "action"=>"callback_response", "tid"=>"c7af186a8d75c44a", "response"=>"ingest_completed", "format"=>"json"}
+
+    def callback_response
+      response = params[:response]
+
+      if validated
+        response_data = JSON.parse(request.body.read)
+        update_transaction_status_based_on(trx_id: trx_id, ingest_status: response_data["job_state"])
+
+        render json: { trx_id: trx_id, ingest_response: response_data["job_state"] }, status: :ok
+      else
+        render json: { trx_id: trx_id, callback_response: "unauthorized callback" }, status: :unauthorized
+      end
+    end
+
+    private
+
+    def validate_authentication
+      @validated = authenticate_with_http_basic do |user, pass|
+        authenticate_trx(user_name_hash: user, trx_id_hash: pass)
+      end
+      @validated
+    end
+
+    def update_transaction_status_based_on(trx_id:, ingest_status:)
+      case ingest_status
+      when "success"
+        ApiTransaction.update(trx_id, trx_status: ApiTransaction.set_status(:complete))
+      when "error"
+        ApiTransaction.update(trx_id, trx_status: ApiTransaction.set_status(:error))
+      when "processing"
+        # do nothing
+      else
+        # do nothing
+      end
+    end
+
+    def authenticate_trx(user_name_hash:, trx_id_hash:)
+      @trx_id = params[:tid]
+      return false unless trx_id
+      return false unless user_name_hash
+      return false unless trx_id_hash
+      begin
+        trx_user = ApiTransaction.find(trx_id).user.username
+      rescue ActiveRecord::RecordNotFound
+        return false
+      end
+      return true if (Digest::MD5.hexdigest(trx_id) == trx_id_hash && Digest::MD5.hexdigest(trx_user) == user_name_hash)
+      false
+    end
+  end
+end

--- a/app/controllers/admin/callbacks_controller.rb
+++ b/app/controllers/admin/callbacks_controller.rb
@@ -1,5 +1,5 @@
 module Admin
-  class CallbacksController < Api::BaseController
+  class CallbacksController < ApplicationController
   respond_to :jsonld
   before_filter :validate_authentication
   attr_reader :trx_id, :validated

--- a/app/models/api_transaction.rb
+++ b/app/models/api_transaction.rb
@@ -23,6 +23,8 @@ class ApiTransaction < ActiveRecord::Base
       'submitted_for_ingest'
     when :complete
       'ingest_complete'
+    when :error
+      'error_during_ingest'
     else
       nil
     end

--- a/app/services/api/callback_trx_validator.rb
+++ b/app/services/api/callback_trx_validator.rb
@@ -1,0 +1,24 @@
+module Api
+  class CallbackTrxValidator
+    attr_reader :trx_id, :user_name_hash, :trx_id_hash
+
+    def initialize(trx_id:, user_name_hash:, trx_id_hash:)
+      @trx_id = trx_id
+      @user_name_hash = user_name_hash
+      @trx_id_hash = trx_id_hash
+    end
+
+    def validate
+      return false unless trx_id
+      return false unless user_name_hash
+      return false unless trx_id_hash
+      begin
+        trx_user = ApiTransaction.find(trx_id).user.username
+      rescue ActiveRecord::RecordNotFound
+        return false
+      end
+      return true if (Digest::MD5.hexdigest(trx_id) == trx_id_hash && Digest::MD5.hexdigest(trx_user) == user_name_hash)
+      false
+    end
+  end
+end

--- a/app/services/api/storage_for_ingest.rb
+++ b/app/services/api/storage_for_ingest.rb
@@ -15,11 +15,12 @@ module Api
 
     private
     def default_bucket
-      if Rails.application.config.bucket_for_ingest
+      bucket = begin
         Rails.application.config.bucket_for_ingest
-      else
+      rescue
         Aws::S3::Resource.new(region: 'us-east-1').bucket(ENV['S3_BUCKET'])
       end
+      bucket
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -125,6 +125,8 @@ CurateNd::Application.routes.draw do
     get 'uploads/:tid/status', controller: 'uploads', action: 'trx_status'
     post 'uploads/:tid/commit', as: 'trx_commit', controller: 'uploads', action: 'trx_commit'
   end
+  # manage ingest callbacks: batch ingest responds with a post
+  post 'uploads/:tid/callback/:response', controller: 'admin/callbacks', action: 'callback_response'
 
   # clean up tokens
   resources :temporary_access_tokens, path: 'access_tokens', except: [:show]

--- a/spec/controllers/admin/callbacks_controller_spec.rb
+++ b/spec/controllers/admin/callbacks_controller_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe Admin::CallbacksController do
+  let(:user) { FactoryGirl.create(:user) }
+  let(:tid) { '12345'}
+  let(:work_id) { '45678'}
+  let(:trx) { ApiTransaction.new(trx_id: tid, user_id: user.id, trx_status: "test", work_id: work_id) }
+  let(:something) { double }
+  let(:read_body) { "{ \"host\" : \"libvirt8.library.nd.edu\", \"version\" : \"1.0.1\", \"job_name\" : \"ingest-45\", \"job_state\" : \"success\" }" } #string
+  let(:parsed_body) { {"host"=>"libvirt8.library.nd.edu", "version"=>"1.0.1", "job_name"=>"ingest-45", "job_state"=>"success"} }
+
+  describe '#callback_response' do
+    let(:response_data) { 'ingest_completed' }
+
+    before do
+      trx.save
+      allow(controller).to receive(:validated).and_return(valid_response)
+      # mocking the json body because i was unable to send both the params and the body in the post
+      allow(request).to receive(:body).and_return(something)
+      allow(something).to receive(:read).and_return(read_body)
+    end
+
+    describe 'when response is authorized via basic_auth' do
+      let(:valid_response) { true }
+
+      it 'processes the callback' do
+        request.headers['HTTP_ACCEPT'] = "application/json"
+        post :callback_response, { tid: tid, response: response_data }
+        expect(response).to be_successful
+        expect(JSON.parse(response.body).keys).to contain_exactly("trx_id", "ingest_response")
+        expect(ApiTransaction.find(tid).trx_status).to eq('ingest_complete')
+      end
+    end
+
+    describe 'when response is unauthorized via basic_auth' do
+      let(:valid_response) { false }
+
+      it 'processes the callback' do
+        request.headers['HTTP_ACCEPT'] = "application/json"
+        post :callback_response, { tid: tid, response: response_data }
+        expect(response.status).to eq(401) # unauthorized
+        expect(JSON.parse(response.body).keys).to contain_exactly("trx_id", "callback_response")
+        expect(ApiTransaction.find(tid).trx_status).to eq('test')
+      end
+    end
+  end
+end

--- a/spec/models/api_transaction_spec.rb
+++ b/spec/models/api_transaction_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe ApiTransaction do
+  subject { described_class }
+  let(:tid) { '13131313' }
+  let(:new_trx) do
+    ApiTransaction.new(
+      trx_id: '13131313',
+      user_id: 1,
+      work_id: '11111',
+      trx_status: 'test'
+    )
+  end
+
+  it { is_expected.to respond_to(:new_trx_id) }
+  it { is_expected.to respond_to(:status_for) }
+  it { is_expected.to respond_to(:set_status_based_on) }
+
+  before do
+    new_trx.save
+  end
+
+  describe '#set_status_based_on' do
+    let(:update_trx_status) { subject.set_status_based_on(trx_id: tid, action: action) }
+
+    describe 'with a valid action' do
+      let(:action) { :commit }
+
+      it 'updates the ApiTransaction record and returns true' do
+        expect(update_trx_status).to eq true
+        expect(ApiTransaction.find(tid).trx_status).to eq('submitted_for_ingest')
+      end
+    end
+
+    describe 'with an invalid action' do
+      let(:action) { :invalid }
+
+      it 'does not update ApiTransaction and returns false' do
+        expect(update_trx_status).to eq false
+        expect(ApiTransaction.find(tid).trx_status).to eq('test')
+      end
+    end
+  end
+end

--- a/spec/services/api/callback_trx_validator_spec.rb
+++ b/spec/services/api/callback_trx_validator_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe Api::CallbackTrxValidator do
+  let(:user) { FactoryGirl.create(:user) }
+  let(:tid) { '12345'}
+  let(:work_id) { '45678'}
+  let(:trx) { ApiTransaction.new(trx_id: tid, user_id: user.id, trx_status: "test", work_id: work_id) }
+  let(:user_hash) { Digest::MD5.hexdigest(user.username) }
+  let(:trx_hash) { Digest::MD5.hexdigest(tid) }
+
+  describe '#validate' do
+    describe 'when authentication is missing' do
+      it 'returns false' do
+        expect(Api::CallbackTrxValidator.new(trx_id: nil , user_name_hash: user_hash, trx_id_hash: trx_hash).validate).to be false
+        expect(Api::CallbackTrxValidator.new(trx_id: tid , user_name_hash: nil, trx_id_hash: trx_hash).validate).to be false
+        expect(Api::CallbackTrxValidator.new(trx_id: tid , user_name_hash: user_hash, trx_id_hash: nil).validate).to be false
+      end
+    end
+
+    describe 'when trx_id does not exist' do
+      it 'returns false' do
+        expect(Api::CallbackTrxValidator.new(trx_id: '55555', user_name_hash: user_hash, trx_id_hash: trx_hash).validate).to be false
+      end
+    end
+
+    describe 'when authentication is validated' do
+      before do
+        trx.save
+      end
+
+      it 'returns true' do
+        expect(Api::CallbackTrxValidator.new(trx_id: tid, user_name_hash: user_hash, trx_id_hash: trx_hash).validate).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
Authenticates callback and updates transaction with status from batch ingest.

Also fix storage bucket logic. It worked for specs but not for other environments.