### PR TITLE
Image Viewer - Use small representative on show view

### DIFF
--- a/app/assets/javascripts/curate/image_viewer_build.js
+++ b/app/assets/javascripts/curate/image_viewer_build.js
@@ -12,7 +12,7 @@ Blacklight.onLoad(function() {
       var thumbnail_url = response.thumbnail[0].id;
       if(thumbnail_url) {
 
-        var $expand_link = $("<img src='" + thumbnail_url + "' /><p><a href='https://viewer-iiif.libraries.nd.edu/universalviewer/index.html#?manifest=" + manifest_url+ "'>Expand</a></p>");
+        var $expand_link = $("<a href='https://viewer-iiif.libraries.nd.edu/universalviewer/index.html#?manifest=" + manifest_url+ "'><img src='" + thumbnail_url + "' /><p>Click to Expand</a></p>");
         $work_representation.html($expand_link);
       }
       $this.find(".spinner").hide();

--- a/app/assets/stylesheets/modules/image_viewer.scss
+++ b/app/assets/stylesheets/modules/image_viewer.scss
@@ -13,7 +13,7 @@
   #image-viewer {
     background: $black;
     border: 3px solid $black;
-    height: 400px;
+    height: 800px;
     margin-bottom: 15px;
   }
 

--- a/app/controllers/common_objects_controller.rb
+++ b/app/controllers/common_objects_controller.rb
@@ -54,4 +54,11 @@ class CommonObjectsController < ApplicationController
       format.jsonld { render json: curation_concern.as_jsonld.slice('@contect', '@id', 'nd:afmodel') }
     end
   end
+
+  # This renders a full-size image in the old "leaflet" image viewer in cases where an item doesn't have a iiif manifest.
+  # Note: permission is checked in representative_viewer partial, so to save processing time,permission checking is not duplicated here.
+  def original_viewer
+    @curation_concern = curation_concern
+    render :original_viewer
+  end
 end

--- a/app/views/catalog/_index_partials/_identifier_and_action.html.erb
+++ b/app/views/catalog/_index_partials/_identifier_and_action.html.erb
@@ -14,6 +14,6 @@
 
   <div class="span7 search-result-link">
     <%# Minimize Fedora hits by using solr_doc rather than document %>
-    <%= link_to richly_formatted_text(title_link_text), title_link_target, :id => "src_copy_link_#{solr_doc.noid}" %>
+    <%= link_to richly_formatted_text(title_link_text, title: true), title_link_target, :id => "src_copy_link_#{solr_doc.noid}" %>
   </div>
 </div>

--- a/app/views/common_objects/original_viewer.html.erb
+++ b/app/views/common_objects/original_viewer.html.erb
@@ -1,0 +1,13 @@
+<% content_for :page_title, construct_page_title(curation_concern.title) if curation_concern.title %>
+
+<% content_for :page_header do %>
+  <% if curation_concern.kind_of?(GenericFile) %>
+    <h1><%= curation_concern.filename %></h1>
+  <% else %>
+    <h1><%= richly_formatted_text(curation_concern.to_s, title: true) %></h1>
+  <% end %>
+
+  <span class="human-readable-type"><%= curation_concern.human_readable_type %></span>
+<% end %>
+
+<%= render partial: 'curation_concern/base/image_viewer', locals: { generic_file: curation_concern } %>

--- a/app/views/curation_concern/base/_representative_viewer.html.erb
+++ b/app/views/curation_concern/base/_representative_viewer.html.erb
@@ -16,12 +16,16 @@
     <!-- else if Image class and representative file is image... use iiif image viewer -->
     <% elsif gf_read_permission && is_image %>
       <div class="image-viewer-integration" data-manifest-url="<%= manifest_url_for(id: work.pid) %>">
-        <div class="spinner"></div>
-        <div class="row iiif-work-representation span12">
-          <%= render partial: 'curation_concern/base/image_viewer', locals: { generic_file: generic_file } %>
-        </div>
-        <div class="row work-attributes span12">
-          <%= details %>
+        <div class="row">
+          <div class="spinner"></div>
+          <div class="iiif-work-representation span3">
+            <a href="/image_viewer/<%= generic_file.noid %>">
+              <%= image_tag download_path(work.representative,'thumbnail'), class: 'representative_image' %>
+              <p>Click to Expand</p></a>
+          </div>
+          <div class="work-attributes span9">
+            <%= details %>
+          </div>
         </div>
       </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,6 +70,7 @@ CurateNd::Application.routes.draw do
   resources :help_requests, only: [:new, :create]
   resources :classify_concerns, only: [:new, :create]
 
+  get '/image_viewer/:id', controller: 'common_objects', action: 'original_viewer'
   match "show/:id" => "common_objects#show", via: :get, as: "common_object"
   match "show/stub/:id" => "common_objects#show_stub_information", via: :get, as: "common_object_stub_information"
   match 'users/:id/edit' => 'users#edit', via: :get, as: 'edit_user'


### PR DESCRIPTION
Displays the representative image to the left of the metadata, and uses `click to expand` links to open either the iiif viewer or the original viewer.

Also changes to use `title: true` to insure that titles appear on the catalog search results list.