### PR TITLE
Synchronize Start Download for Show Page

### DIFF
--- a/app/views/common_objects/show.html.erb
+++ b/app/views/common_objects/show.html.erb
@@ -30,7 +30,10 @@
 
   <% case curation_concern %>
   <% when GenericFile %>
-    <%= link_to 'Download this File', download_path(curation_concern), class: 'btn btn-default' %>
+    <% if can? :read, curation_concern %>
+      <% bendo_datastream = Bendo::DatastreamPresenter.new(datastream: curation_concern.datastreams.fetch('content')) %>
+      <%= render 'curation_concern/base/download_file_button', generic_file: curation_concern, bendo_datastream: bendo_datastream %>
+    <% end %>
   <% when FindingAid %>
     <%# Only display file list of finding aids to editors. See DLTP-1304 %>
     <% if can?(:edit, curation_concern) %>

--- a/app/views/curation_concern/base/_download_file_button.html.erb
+++ b/app/views/curation_concern/base/_download_file_button.html.erb
@@ -1,0 +1,29 @@
+<div class="actions">
+  <% if bendo_datastream.valid? %>
+    <%= link_to(recall_bendo_item_path(generic_file.noid),
+      {
+        class: "action btn btn-info",
+        data: {
+          alternate: download_path(generic_file.noid),
+          toggle: 'tooltip',
+          placement: 'top'
+        },
+        title: t('curate.notification_messages.file_retrieval_tooltip'),
+        target: '_blank'
+      }
+    ) do %>
+      <i class="icon icon-white icon-time"></i> Begin Download
+    <% end %>
+
+  <% else %>
+    <%= link_to(
+      download_path(generic_file.noid),
+      {
+        class: "action btn",
+        target: '_blank'
+      }
+    ) do %>
+      <i class="icon icon-download"></i> Download File
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/curation_concern/base/_related_file_actions.html.erb
+++ b/app/views/curation_concern/base/_related_file_actions.html.erb
@@ -3,33 +3,7 @@
 <div class="actions">
   <% if download_permission & !generic_file.with_empty_content? %>
     <div>
-      <% if bendo_datastream.valid? %>
-        <%= link_to(recall_bendo_item_path(generic_file.noid),
-          {
-            class: "action btn btn-info",
-            data: {
-              alternate: download_path(generic_file.noid),
-              toggle: 'tooltip',
-              placement: 'top'
-            },
-            title: t('curate.notification_messages.file_retrieval_tooltip'),
-            target: '_blank'
-          }
-        ) do %>
-          <i class="icon icon-white icon-time"></i> Begin Download
-        <% end %>
-
-      <% else %>
-        <%= link_to(
-          download_path(generic_file.noid),
-          {
-            class: "action btn",
-            target: '_blank'
-          }
-        ) do %>
-          <i class="icon icon-download"></i> Download
-        <% end %>
-      <% end %>
+      <%= render 'curation_concern/base/download_file_button', generic_file: generic_file, bendo_datastream: bendo_datastream %>
     </div>
     <div>
       <%= link_to 'View Details', curation_concern_generic_file_path(generic_file), class: 'btn' %>


### PR DESCRIPTION
Completes https://jira.library.nd.edu/browse/DLTP-1713

Moves download button logic to a new partial, in order to incorporate common bendo recall logic into button from both work show and file show pages.