### PR TITLE
Add config for image viewer

### DIFF
--- a/app/assets/javascripts/curate/image_viewer_build.js
+++ b/app/assets/javascripts/curate/image_viewer_build.js
@@ -3,6 +3,7 @@ Blacklight.onLoad(function() {
 
   $('.image-viewer-integration').each(function() {
     var $this = $(this);
+    var manifest_viewer = $this.data("manifest-viewer");
     var manifest_url = $this.data("manifest-url");
     $.ajax({
       url: manifest_url,
@@ -12,9 +13,10 @@ Blacklight.onLoad(function() {
       var thumbnail_url = response.thumbnail[0].id;
       if(thumbnail_url) {
 
-        var $expand_link = $("<a href='https://viewer-iiif.libraries.nd.edu/universalviewer/index.html#?manifest=" + manifest_url+ "'><img src='" + thumbnail_url + "' /><p>Click to Expand</a></p>");
+        var $expand_link = $("<a target='_blank' href='" + manifest_viewer + manifest_url + "'><img src='" + thumbnail_url + "' /><p>Click to Expand</a></p>");
         $work_representation.html($expand_link);
       }
+
       $this.find(".spinner").hide();
       $work_representation.fadeIn();
     }).fail(function(response) {

--- a/app/views/curation_concern/base/_representative_viewer.html.erb
+++ b/app/views/curation_concern/base/_representative_viewer.html.erb
@@ -15,7 +15,7 @@
 
     <!-- else if Image class and representative file is image... use iiif image viewer -->
     <% elsif gf_read_permission && is_image %>
-      <div class="image-viewer-integration" data-manifest-url="<%= manifest_url_for(id: work.pid) %>">
+      <div class="image-viewer-integration" data-manifest-url="<%= manifest_url_for(id: work.pid) %>" data-manifest-viewer="<%= Rails.configuration.manifest_viewer %>">
         <div class="row">
           <div class="spinner"></div>
           <div class="iiif-work-representation span3">

--- a/config/application.rb
+++ b/config/application.rb
@@ -103,7 +103,7 @@ module CurateNd
       Devise::RegistrationsController.layout('curate_nd/1_column')
     end
 
-    config.manifest_url_generator = ->(id:) { sprintf("https://presentation-iiif.library.nd.edu/%s/manifest/index.json", id.to_s) }
+    config.manifest_url_generator = ->(id:) { sprintf(Rails.configuration.manifest_builder_url.to_s + "%s/manifest/index.json", id.to_s) }
 
     # Version of your assets, change this if you want to expire all your assets
     config.assets.version = '1.0'

--- a/config/environments/ci.rb
+++ b/config/environments/ci.rb
@@ -35,6 +35,10 @@ CurateNd::Application.configure do
 
   config.application_root_url = "http://localhost:3000"
 
+  # for iiif image viewer
+  config.manifest_viewer = "https://viewer-iiif.libraries.nd.edu/universalviewer/index.html#?manifest="
+  config.manifest_builder_url = "https://presentation-iiif.library.nd.edu/"
+
   Curate.configuration.default_antivirus_instance = lambda {|file_path|
     AntiVirusScanner::NO_VIRUS_FOUND_RETURN_VALUE
   }

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -29,6 +29,10 @@ CurateNd::Application.configure do
 
   config.application_root_url = "https://localhost:3000"
 
+  # for iiif image viewer
+  config.manifest_viewer = "https://viewer-iiif.libraries.nd.edu/universalviewer/index.html#?manifest="
+  config.manifest_builder_url = "https://presentation-iiif.library.nd.edu/"
+
   if ENV['FULL_STACK']
     # require 'clamav'
     # ClamAV.instance.loaddb

--- a/config/environments/pre_production.rb
+++ b/config/environments/pre_production.rb
@@ -65,6 +65,10 @@ CurateNd::Application.configure do
 
   config.application_root_url = "https://curatesvrpprd.library.nd.edu"
 
+  # for iiif image viewer
+  config.manifest_viewer = "https://viewer-iiif.libraries.nd.edu/universalviewer/index.html#?manifest="
+  config.manifest_builder_url = "https://presentation-iiif.library.nd.edu/"
+
   # Log the query plan for queries taking more than this (works
   # with SQLite, MySQL, and PostgreSQL)
   # config.active_record.auto_explain_threshold_in_seconds = 0.5

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -65,6 +65,10 @@ CurateNd::Application.configure do
 
   config.application_root_url = "https://curate.nd.edu"
 
+  # for iiif image viewer
+  config.manifest_viewer = "https://viewer-iiif.libraries.nd.edu/universalviewer/index.html#?manifest="
+  config.manifest_builder_url = "https://presentation-iiif.library.nd.edu/"
+
   # Log the query plan for queries taking more than this (works
   # with SQLite, MySQL, and PostgreSQL)
   # config.active_record.auto_explain_threshold_in_seconds = 0.5

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -40,6 +40,10 @@ CurateNd::Application.configure do
 
   config.application_root_url = "https://localhost"
 
+  # for iiif image viewer
+  config.manifest_viewer = "https://viewer-iiif.libraries.nd.edu/universalviewer/index.html#?manifest="
+  config.manifest_builder_url = "https://presentation-iiif.library.nd.edu/"
+
   config.fits_path = '/opt/fits/current/fits.sh'
 
   begin

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -34,6 +34,10 @@ CurateNd::Application.configure do
 
   config.application_root_url = "http://localhost:3000"
 
+  # for iiif image viewer
+  config.manifest_viewer = "https://viewer-iiif.libraries.nd.edu/universalviewer/index.html#?manifest="
+  config.manifest_builder_url = "https://presentation-iiif.library.nd.edu/"
+
   if ENV['FULL_STACK']
     require 'clamav'
     ClamAV.instance.loaddb


### PR DESCRIPTION
Add configurable options for iiif viewer urls to environment config files. 

Currently all point to production environment, but may be changed once other environment options are available.

Also, at @dbrower request, the iiif viewer was changed to open in a new tab. 