### PR TITLE
Fix failing derivative generation

### DIFF
--- a/app/repository_models/collection.rb
+++ b/app/repository_models/collection.rb
@@ -56,7 +56,7 @@ class Collection < ActiveFedora::Base
   def generate_derivatives
     case mime_type
     when 'image/png', 'image/jpeg', 'image/tiff'
-      transform_datastream :content, { medium: {size: "300x300>", datastream: 'medium'}, thumb: {size: "100x100>", datastream: 'thumbnail'} }
+      transform_datastream :content, { medium: {size: "300x300", datastream: 'medium'} }
     end
   end
 

--- a/app/repository_models/person.rb
+++ b/app/repository_models/person.rb
@@ -167,7 +167,7 @@ class Person < ActiveFedora::Base
   def generate_derivatives
     case mime_type
     when 'image/png', 'image/jpeg', 'image/tiff'
-      transform_datastream :content, { medium: {size: "300x300>", datastream: 'medium'}, thumb: {size: "100x100>", datastream: 'thumbnail'} }
+      transform_datastream :content, { medium: {size: "300x300", datastream: 'medium'} }
     end
   end
 

--- a/app/views/registrations/edit.html.erb
+++ b/app/views/registrations/edit.html.erb
@@ -46,17 +46,6 @@
     </fieldset>
   </div>
 
-  <div class="row with-headroom">
-    <div class="span10">
-      <fieldset class="required">
-        <legend>
-          Attach your profile image
-        </legend>
-        <%= f.input :files, as: :file, label: 'Upload your file' %>
-      </fieldset>
-    </div>
-  </div>
-
   <div class="row">
     <div class="span10 form-actions">
       <%= f.submit class: 'btn btn-primary', value: 'Update My Account' %>

--- a/lib/sufia/models/generic_file/derivatives.rb
+++ b/lib/sufia/models/generic_file/derivatives.rb
@@ -10,14 +10,6 @@ module Sufia
             when *pdf_mime_types
               obj.transform_datastream :content,
                                        { :thumbnail => {size: "338x493", datastream: 'thumbnail'} }
-            when *audio_mime_types
-              obj.transform_datastream :content,
-                                       { :mp3 => {format: 'mp3', datastream: 'mp3'},
-                                         :ogg => {format: 'ogg', datastream: 'ogg'} }, processor: :audio
-            when *video_mime_types
-              obj.transform_datastream :content,
-                                       { :webm => {format: "webm", datastream: 'webm'},
-                                         :mp4 => {format: "mp4", datastream: 'mp4'} }, processor: :video
             when *image_mime_types
               obj.transform_datastream :content, { :thumbnail => {size: "248x272", datastream: 'thumbnail'} }
           end


### PR DESCRIPTION
Remove `transform_datastream` blocks. Derivatives cannot be generated with
two blocks... the second one fails. 

Also remove the option to upload an account image from the edit view. This option was not working and no one can see the images anyway, since person was removed from the catalog search results list.