### PR TITLE
Handling ActionController::UnknownFormat

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -86,6 +86,7 @@ module CurateNd
     config.action_dispatch.rescue_responses["Hydra::AccessDenied"] = :unauthorized
     config.action_dispatch.rescue_responses["CanCan::AccessDenied"] = :unauthorized
     config.action_dispatch.rescue_responses["Rubydora::RecordNotFound"] = :not_found
+    config.action_dispatch.rescue_responses["ActionController::UnknownFormat"] = :not_found
 
     Curate.configuration.build_identifier = begin
       identifier = Rails.root.join('VERSION').read.strip


### PR DESCRIPTION
Prior to this commit, these exceptions would bubble up to our error
reporting application. This change now ensures that we don't raise
an exception to the user, but instead tell them "Not Found"