### PR TITLE
Validate search parameters

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -9,18 +9,16 @@ class Api::BaseController < CatalogController
     end
 
     def set_current_user!
+      @current_user = nil
       token_sha = request.headers['X-Api-Token']
 
       if token_sha
-        begin
-          api_access_token = ApiAccessToken.find(token_sha)
+        api_access_token = find_token(token_sha)
+        if api_access_token
           @current_user = api_access_token.user
-        rescue ActiveRecord::RecordNotFound
-          @current_user = nil
         end
-      else
-        @current_user = nil
       end
+      @current_user
     end
 
     def validate_permissions!
@@ -32,5 +30,13 @@ class Api::BaseController < CatalogController
       end
     rescue ActiveFedora::ObjectNotFoundError
       render json: { error: 'Item not found', user: user_name, item: item_id }, status: :not_found
+    end
+
+    def find_token(token_sha)
+      begin
+        ApiAccessToken.find(token_sha)
+      rescue ActiveRecord::RecordNotFound
+        nil
+      end
     end
 end

--- a/app/controllers/api/items_controller.rb
+++ b/app/controllers/api/items_controller.rb
@@ -17,8 +17,12 @@ class Api::ItemsController < Api::BaseController
 
   # GET /api/items
   def index
-    (@response, @document_list) = get_search_results
-    render json: Api::ItemsSearchPresenter.new(@response, request.url, request.query_parameters).to_json
+    if valid_search_request_syntax?
+      (@response, @document_list) = get_search_results
+      render json: Api::ItemsSearchPresenter.new(@response, request.url, request.query_parameters).to_json
+    else
+      render json: { error: 'Invalid search request format. Please consult API documentation.' }, status: :bad_request
+    end
   end
 
   # GET /api/items/1
@@ -27,6 +31,10 @@ class Api::ItemsController < Api::BaseController
   end
 
   private
+
+    def valid_search_request_syntax?
+      Api::QueryBuilder.new(@current_user).valid_request?(params)
+    end
 
     def item
       @this_item ||= ActiveFedora::Base.find(params[:id], cast: true)

--- a/spec/controllers/api/items_controller_spec.rb
+++ b/spec/controllers/api/items_controller_spec.rb
@@ -84,21 +84,53 @@ describe Api::ItemsController do
         expect(json['results'].first.keys).to include("type", "editor", "depositor")
         expect(json['query']['queryParameters'].keys).to include("type", "editor", "depositor")
       end
+
+      it 'disallows search for self if no token' do
+        request.headers['HTTP_ACCEPT'] = "application/json"
+        get :index, { type: 'Article', editor: "self", depositor: "self" }
+        expect(response).to be_bad_request
+      end
     end
 
     context 'with date filtering' do
-      let(:requested_date) { "after:2019-01-01" }
+      context 'when dates are formatted correctly' do
+        let(:requested_date) { "after:2019-01-01" }
 
-      it 'searches dates and includes dates in the search results list' do
-        request.headers['X-Api-Token'] = token.sha
-        request.headers['HTTP_ACCEPT'] = "application/json"
-        get :index, { deposit_date: requested_date, modify_date: requested_date }
-        expect(response).to be_successful
-        json = JSON.parse(response.body)
+        it 'searches dates and includes dates in the search results list' do
+          request.headers['X-Api-Token'] = token.sha
+          request.headers['HTTP_ACCEPT'] = "application/json"
+          get :index, { deposit_date: requested_date, modify_date: requested_date }
+          expect(response).to be_successful
+          json = JSON.parse(response.body)
 
-        expect(json['pagination']['totalResults']).to eq(3)
-        expect(json['results'].first.keys).to include("depositDate", "modifyDate")
-        expect(json['query']['queryParameters'].keys).to include("deposit_date", "modify_date")
+          expect(json['pagination']['totalResults']).to eq(3)
+          expect(json['results'].first.keys).to include("depositDate", "modifyDate")
+          expect(json['query']['queryParameters'].keys).to include("deposit_date", "modify_date")
+        end
+      end
+
+      context 'when date formatting is incorrect' do
+        context 'with bad date format' do
+          let(:requested_date) { "after:2019-01-01,before:2020-01-0" }
+
+          it 'returns a bad request' do
+            request.headers['X-Api-Token'] = token.sha
+            request.headers['HTTP_ACCEPT'] = "application/json"
+            get :index, { deposit_date: requested_date }
+            expect(response).to be_bad_request
+          end
+        end
+
+        context 'with bad before/after term' do
+          let(:requested_date) { "after:2019-01-01,befor:2020-01-01" }
+
+          it 'returns a bad request' do
+            request.headers['X-Api-Token'] = token.sha
+            request.headers['HTTP_ACCEPT'] = "application/json"
+            get :index, { deposit_date: requested_date }
+            expect(response).to be_bad_request
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Resolves https://jira.library.nd.edu/browse/DLTP-1716

Add a basic structure for search format validation, which returns `Invalid search request format. Please consult API documentation` in json for errors.

Implement validation:
- searching for "self" requires a user (aka a valid token).
- date search format validated via regex, valid parsing into date, and valid `before` and `after` terms.