### PR TITLE
change capistrano hostnames

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -307,8 +307,8 @@ task :pre_production do
   set :dest_solr_confdir, '/global/data/solr/pre_production/curate/conf'
 
   default_environment['PATH'] = '/opt/ruby/current/bin:$PATH'
-  server 'app@curatesvrpprd.library.nd.edu', :app, :web, :db, primary: true
-  server 'app@curatewkrpprd.library.nd.edu', :work, primary: true
+  server 'app@curatesvrpprd.lc.nd.edu', :app, :web, :db, primary: true
+  server 'app@curatewkrpprd.lc.nd.edu', :work, primary: true
 
   before 'bundle:install', 'solr:configure'
   after 'deploy:update_code', 'und:write_env_vars', 'und:write_build_identifier', 'und:update_secrets', 'deploy:symlink_update', 'deploy:migrate', 'db:seed', 'deploy:precompile'
@@ -333,8 +333,8 @@ task :production do
   set :dest_solr_confdir, '/global/data/solr/production/curate/conf'
 
   default_environment['PATH'] = '/opt/ruby/current/bin:$PATH'
-  server 'app@curatesvrprod.library.nd.edu', :app, :web, :db, primary: true
-  server 'app@curatewkrprod.library.nd.edu', :work, primary: true
+  server 'app@curatesvrprod.lc.nd.edu', :app, :web, :db, primary: true
+  server 'app@curatewkrprod.lc.nd.edu', :work, primary: true
 
   before 'bundle:install', 'solr:configure'
   after 'deploy:update_code', 'und:write_env_vars', 'und:write_build_identifier', 'und:update_secrets', 'deploy:symlink_update', 'deploy:migrate', 'db:seed', 'deploy:precompile'


### PR DESCRIPTION
The pre_production and production capistrano environments for curate, being multimachine, have the target hostname in the capisrano deploy file. Since the new jenkins server is in AWS, the ssh ports are accessible onlt through our AWS Campus VPN, lc.nd.edu, so we need to use those hostnames