### PR TITLE
Create temporary access token via api

### DIFF
--- a/app/services/time_limited_token_create_service.rb
+++ b/app/services/time_limited_token_create_service.rb
@@ -1,0 +1,72 @@
+class TimeLimitedTokenCreateService
+  # TimeLimitedTokenService.new(noid: "0r96736668t", user: User.third).make_token
+  attr_reader :noid, :user
+
+  # @param noid [String] the noid of a GenericFile
+  # @param issued_by [User] the user issuing the token
+  def initialize(noid:, issued_by:)
+    @noid = noid
+    @user = issued_by
+  end
+
+  # @return [Hash] {:test, :valid, :notice, :token}
+  def make_token
+    validated_request = validate_request
+    if validated_request[:valid]
+      token = create_token
+      if token
+        validated_request[:notice] = "Temporary access token was successfully created."
+        validated_request[:token] = token
+      end
+    end
+    validated_request
+  end
+
+  # @param noid [String] the noid of a GenericFile
+  # @param user [User] the user adding the token
+  # @return [Hash] {:test, :valid, :notice}
+  def validate_request
+    item_to_access = begin
+      ActiveFedora::Base.load_instance_from_solr(Sufia::Noid.namespaceize(@noid))
+    rescue ActiveFedora::ObjectNotFoundError
+      nil
+    end
+
+    # object must exist
+    return { test: :not_found,
+             valid: false,
+             notice: "Unable to create temporary access token: file '#{@noid}' does not exist."
+            } unless item_to_access
+
+    # must be given a user
+    return { test: :no_user,
+             valid: false,
+             notice: "Unable to create temporary access token without a user."
+            } unless @user
+
+    # object must be a generic_file
+    return { test: :not_file,
+             valid: false,
+             notice: "Unable to create temporary access token: item '#{@noid}' is not a file."
+            } unless item_to_access.is_a? GenericFile
+
+    # must be allowed to edit file or token manager
+    return { test: :not_authorized,
+             valid: false,
+             notice: "Error: Not authorized to create temporary access token for file '#{@noid}."
+            } unless (@user.can? :edit, item_to_access) || (@user.can? :manage, TemporaryAccessToken)
+
+    # otherwise valid
+    { test: :passed,
+      valid: true,
+      notice: nil }
+  end
+
+  def create_token
+    token = TemporaryAccessToken.new(noid: @noid, issued_by: @user.user_key)
+    if token.save
+      return token
+    end
+    false
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -125,7 +125,9 @@ CurateNd::Application.routes.draw do
     post 'uploads/:tid/file/:fid', as: 'trx_append', controller: 'uploads', action: 'trx_append'
     get 'uploads/:tid/status', controller: 'uploads', action: 'trx_status'
     post 'uploads/:tid/commit', as: 'trx_commit', controller: 'uploads', action: 'trx_commit'
+    post 'items/:id/token', as: 'token', controller: 'items', action: 'token'
   end
+
   # manage ingest callbacks: batch ingest responds with a post
   post 'uploads/:tid/callback/:response', controller: 'admin/callbacks', action: 'callback_response'
 

--- a/spec/controllers/api/items_controller_spec.rb
+++ b/spec/controllers/api/items_controller_spec.rb
@@ -4,6 +4,7 @@ describe Api::ItemsController do
   let(:public_article) { FactoryGirl.create(:public_article, title: 'Fried Green Tomatoes',) }
   let(:private_article) { FactoryGirl.create(:article, title: 'All About Cats', user: user) }
   let(:private_work) { FactoryGirl.create(:private_generic_work, title: 'More About Cats', user: user) }
+  let(:generic_file) { FactoryGirl.create(:generic_file, user: user) }
   let(:user) { FactoryGirl.create(:user) }
   let(:token) { ApiAccessToken.create(issued_by: user.id, user: user) }
 
@@ -131,6 +132,25 @@ describe Api::ItemsController do
             expect(response).to be_bad_request
           end
         end
+      end
+    end
+  end
+
+  describe '#token' do
+    context 'with a valid request' do
+      it 'returns 200 and a json document' do
+        request.headers['X-Api-Token'] = token
+        request.headers['HTTP_ACCEPT'] = "application/json"
+        post :token, { id: generic_file.to_param }
+        expect(response).to be_successful
+      end
+    end
+    context 'with an invalid request' do
+      it 'returns 400 and a json document' do
+        request.headers['X-Api-Token'] = token
+        request.headers['HTTP_ACCEPT'] = "application/json"
+        post :token, { id: private_article.to_param }
+        expect(response).to be_bad_request
       end
     end
   end

--- a/spec/services/time_limited_token_create_service_spec.rb
+++ b/spec/services/time_limited_token_create_service_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+describe TimeLimitedTokenCreateService do
+  let(:subject) { TimeLimitedTokenCreateService.new(noid: my_file.id, issued_by: user) }
+  let(:user) { FactoryGirl.create(:user) }
+  let(:your_file) { FactoryGirl.create(:generic_file) }
+  let(:my_file) { FactoryGirl.create(:generic_file, user: user) }
+  let(:generic_work) { FactoryGirl.create(:generic_work, user: user) }
+
+  context 'with no errors' do
+    it 'creates a token and returns a hash' do
+      expect{ subject.make_token }.to change(TemporaryAccessToken, :count).by(1)
+      make_a_token = subject.make_token
+      expect(make_a_token[:test]).to eq(:passed)
+      expect(make_a_token[:valid]).to eq(true)
+    end
+  end
+
+  context 'with errors' do
+    context 'when file does not exist' do
+      let(:subject) { TimeLimitedTokenCreateService.new(noid: 'abcde', issued_by: user) }
+
+      it 'does not create a token and reports error' do
+        expect{ subject.make_token }.not_to change(TemporaryAccessToken, :count)
+        make_a_token = subject.make_token
+        expect(make_a_token[:test]).to eq(:not_found)
+        expect(make_a_token[:valid]).to eq(false)
+      end
+    end
+
+    context 'when there is no user' do
+      let(:subject) { TimeLimitedTokenCreateService.new(noid: my_file.id, issued_by: nil) }
+
+      it 'does not create a token and reports error' do
+        expect{ subject.make_token }.not_to change(TemporaryAccessToken, :count)
+        make_a_token = subject.make_token
+        expect(make_a_token[:test]).to eq(:no_user)
+        expect(make_a_token[:valid]).to eq(false)
+      end
+    end
+
+    context 'when user is unauthorized' do
+      let(:subject) { TimeLimitedTokenCreateService.new(noid: your_file.id, issued_by: user) }
+
+      it 'does not create a token and reports error' do
+        expect{ subject.make_token }.not_to change(TemporaryAccessToken, :count)
+        make_a_token = subject.make_token
+        expect(make_a_token[:test]).to eq(:not_authorized)
+        expect(make_a_token[:valid]).to eq(false)
+      end
+    end
+
+    context 'when id is not a file' do
+      let(:subject) { TimeLimitedTokenCreateService.new(noid: generic_work.id, issued_by: user) }
+
+      it 'does not create a token and reports error' do
+        expect{ subject.make_token }.not_to change(TemporaryAccessToken, :count)
+        make_a_token = subject.make_token
+        expect(make_a_token[:test]).to eq(:not_file)
+        expect(make_a_token[:valid]).to eq(false)
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
Completes https://jira.library.nd.edu/browse/DLTP-1723

Adds TimeLimitedTokenCreateService to perform validations and create tokens.
Use service for creating tokens both via the API the UI.