### PR TITLE
Addressing "TypeError: no implicit conversion of nil into String"

### DIFF
--- a/app/controllers/metrics/usage_controller.rb
+++ b/app/controllers/metrics/usage_controller.rb
@@ -76,7 +76,7 @@ module Metrics
         item = ActiveFedora::Base.load_instance_from_solr(id)
         item_type = item.human_readable_type
         item_type = "File" if item_type == "Generic File"
-        return item_type + ": " + item.title
+        return "#{item_type}: #{item}"
       rescue ActiveFedora::ObjectNotFoundError
         return nil
       end


### PR DESCRIPTION
Instead of using string concatenation, I'm switching to use string
interpolation. This is fault tolerant of `nil` values. In addition, I'm
switching from using the `#title` method to use `#to_s`. The `#to_s`
aliases the title or filename/label of objects.

The following two Ruby lines are logically equivalent:

```ruby
"#{item_type}: #{item}"
item_type.to_s + ": " + item.to_s
```

To test that it resolves the specific problem, I ran the following
logic against the live data.

```ruby
usage = FedoraAccessEvent.all_usage_including_child_objects_for(pid: "und:z029p270r6v")
pid_list = usage.all.group(:pid).pluck(:pid)
# => ["z029p270r6v", "z316pz5417c"]
item = ActiveFedora::Base.load_instance_from_solr('und:z029p270r6v')
item_type = item.human_readable_type
item_type = "File" if item_type == "Generic File"
"#{item_type}: #{item}"
# => "Article: The Rise and Fall of Favor-Based Digitization: Workflows Taste Better on a Cake"

item = ActiveFedora::Base.load_instance_from_solr('und:z316pz5417c')
item_type = item.human_readable_type
item_type = "File" if item_type == "Generic File"
"#{item_type}: #{item}"
# => "File: October2019vol47no2.pdf"
```