### PR TITLE
Correctly identify a bendo url

### DIFF
--- a/app/services/bendo/datastream_presenter.rb
+++ b/app/services/bendo/datastream_presenter.rb
@@ -4,7 +4,7 @@ module Bendo
   class DatastreamPresenter
     attr_reader :datastream
 
-    def initialize(datastream:, service_url: Bendo.url)
+    def initialize(datastream:)
       @datastream = datastream
     end
 

--- a/app/services/bendo/datastream_presenter.rb
+++ b/app/services/bendo/datastream_presenter.rb
@@ -6,7 +6,6 @@ module Bendo
 
     def initialize(datastream:, service_url: Bendo.url)
       @datastream = datastream
-      @service_url = service_url
     end
 
     def valid?
@@ -27,10 +26,6 @@ module Bendo
     alias_method :item_slug, :item_path
 
     private
-
-    def service_url
-      @service_url
-    end
 
     def find_item_path
       uri = URI.parse(location)
@@ -59,7 +54,7 @@ module Bendo
 
     def is_bendo_url?
       return false unless location
-      service_url == location[0...service_url.length]
+      true
     end
   end
 end

--- a/spec/services/bendo/datastream_presenter_spec.rb
+++ b/spec/services/bendo/datastream_presenter_spec.rb
@@ -3,7 +3,6 @@ require 'bendo/datastream_presenter'
 
 module Bendo
   RSpec.describe DatastreamPresenter do
-    let(:service_url) { 'http://bendo.io/' }
     let(:bendo_url) { 'http://bendo.io/item/01234' }
     let(:non_bendo_url) { 'https://archive.org'}
     let(:mock_datastream) do
@@ -30,8 +29,7 @@ module Bendo
 
     let(:instance) do
       described_class.new(
-        datastream: bendo_datastream,
-        service_url: service_url
+        datastream: bendo_datastream
       )
     end
 
@@ -56,18 +54,16 @@ module Bendo
       context 'redirect datastream with a non-Bendo URL'do
         subject do
           described_class.new(
-            datastream: non_bendo_datastream,
-            service_url: service_url
+            datastream: non_bendo_datastream
           ).valid?
         end
-        it { is_expected.to be_falsey }
+        it { is_expected.to be_truthy }
       end
 
       context 'non-redirect datastream with a Bendo URL' do
         subject do
           described_class.new(
-            datastream: bendo_datastream_without_redirect,
-            service_url: service_url
+            datastream: bendo_datastream_without_redirect
           ).valid?
         end
         it { is_expected.to be_falsey }
@@ -76,8 +72,7 @@ module Bendo
       context 'non-redirect datastream with a non-Bendo URL' do
         subject do
           described_class.new(
-            datastream: non_bendo_datastream_without_redirect,
-            service_url: service_url
+            datastream: non_bendo_datastream_without_redirect
           ).valid?
         end
         it { is_expected.to be_falsey }
@@ -93,8 +88,7 @@ module Bendo
       context 'datastream does NOT respond to `:location`' do
         subject do
           described_class.new(
-            datastream: invalid_datastream,
-            service_url: service_url
+            datastream: invalid_datastream
           ).location
         end
         it { is_expected.to be_nil }
@@ -105,8 +99,7 @@ module Bendo
       context '#location is a valid URI with a #path' do
         subject do
           described_class.new(
-            datastream: bendo_datastream,
-            service_url: service_url
+            datastream: bendo_datastream
           ).item_path
         end
         it { is_expected.to eq('/item/01234') }
@@ -115,8 +108,7 @@ module Bendo
       context '#location is a valid URI WITHOUT a #path' do
         subject do
           described_class.new(
-            datastream: non_bendo_datastream,
-            service_url: service_url
+            datastream: non_bendo_datastream
           ).item_path
         end
         it { is_expected.to eq('') }
@@ -128,8 +120,7 @@ module Bendo
           non_uri_datastream.location = 'asdfasdf'
 
           described_class.new(
-            datastream: non_uri_datastream,
-            service_url: service_url
+            datastream: non_uri_datastream
           ).item_path
         end
         it { is_expected.to be_nil }


### PR DESCRIPTION
Bendo url logic was too fragile. Logic was changed to not validate the url as bendo... if a url exists with a redirect, we are assuming it is bendo.