### PR TITLE
Skip "owner" datastream from processing

### DIFF
--- a/app/presenters/api/show_item_presenter.rb
+++ b/app/presenters/api/show_item_presenter.rb
@@ -68,13 +68,14 @@ class Api::ShowItemPresenter
     data = {}
     object.datastreams.each do |dsname, ds|
       next if dsname == 'DC'
+      next if dsname == 'owner'
       method_key = "process_#{dsname.gsub('-', '')}".to_sym
       if respond_to?(method_key, true)
         parsed_data = self.send(method_key, ds)
         data = merge_hashes(data, parsed_data)
       else
-        datastream_error = Rails.logger.error("#{item_id}: unknown datastream #{dsname}")
-        Raven.capture_exception(datastream_error)
+        error_message = "#{item_id}: unknown datastream #{dsname}"
+        Raven.capture_exception(error_message)
       end
     end
     data


### PR DESCRIPTION
Some items were incorrectly ingested with an unknown datastream.
The reporting of unknown datastreams had a bug as well. This PR fixes
both issues.

Resolves https://jira.library.nd.edu/browse/DLTP-1794