### PR TITLE
Include collection membership url in item response

### DIFF
--- a/app/presenters/api/items_search_presenter.rb
+++ b/app/presenters/api/items_search_presenter.rb
@@ -146,6 +146,10 @@ class Api::ItemsSearchPresenter
     def include_modify_date
       @item.fetch('system_modified_dtsi', "")
     end
+
+    def include_part_of
+      @item.fetch('library_collections_pathnames_tesim', "")
+    end
   end
 
   class Pager

--- a/app/presenters/api/show_item_presenter.rb
+++ b/app/presenters/api/show_item_presenter.rb
@@ -46,9 +46,6 @@ class Api::ShowItemPresenter
     if item.respond_to?('generic_files')
       relationship_data['containedFiles'] = add_item_files
     end
-    if item.respond_to?('library_collection_members')
-      relationship_data['members'] = add_collection_members
-    end
     relationship_data
   end
 
@@ -65,19 +62,6 @@ class Api::ShowItemPresenter
       file_data << single_file
     end
     file_data
-  end
-
-  def add_collection_members
-    member_data = []
-    item.library_collection_members.each do |member|
-      member_id = Sufia::Noid.noidify(member.id)
-      member_content = {
-        'id' => member_id
-      }
-      single_member = member_content.merge(process_datastreams(member))
-      member_data << single_member
-    end
-    member_data
   end
 
   def process_datastreams(object)

--- a/app/presenters/api/show_item_presenter.rb
+++ b/app/presenters/api/show_item_presenter.rb
@@ -46,6 +46,9 @@ class Api::ShowItemPresenter
     if item.respond_to?('generic_files')
       relationship_data['containedFiles'] = add_item_files
     end
+    if item.is_a?(LibraryCollection)
+      relationship_data['membersUrl'] = url_for(pid: item_id, url_type: :members)
+    end
     relationship_data
   end
 
@@ -286,6 +289,8 @@ class Api::ShowItemPresenter
       return File.join(root_url, route_helper.api_item_download_path(id))
     when :thumbnail
       return File.join(root_url, route_helper.api_item_download_path(id), '/thumbnail')
+    when :members
+      return File.join(root_url, "#{route_helper.api_items_path}?part_of=#{id}")
     else # default is show
       return File.join(root_url, route_helper.api_item_path(id))
     end

--- a/app/services/api/query_builder.rb
+++ b/app/services/api/query_builder.rb
@@ -1,10 +1,13 @@
 class Api::QueryBuilder
+  include Sufia::Noid
+
   VALID_KEYS_AND_SEARCH_FIELDNAMES = {
     type: ["active_fedora_model_ssi", "desc_metadata__type_tesim"],
     editor: ["edit_access_person_ssim"],
     depositor: ["depositor_tesim"],
     deposit_date: ["system_create_dtsi"],
     modify_date: ["system_modified_dtsi"],
+    part_of: ["library_collections_pathnames_tesim"]
   }.freeze
   CONFIGURATION_KEY_MAX_VALUE = {
     rows: Api::ItemsController.blacklight_config.max_per_page
@@ -94,6 +97,10 @@ class Api::QueryBuilder
     return "[#{comparison_date.xmlschema} TO *]" if search_data.first == DATE_SEARCH_TERMS.last
     return "[* TO #{comparison_date.xmlschema}]" if search_data.first == DATE_SEARCH_TERMS.first
     "[#{comparison_date.xmlschema.to_s} TO #{(comparison_date + 1.days).xmlschema}]"
+  end
+
+  def filter_by_part_of(term)
+    Sufia::Noid.namespaceize(term)
   end
 
   # builds filter query search for a given key & array of elements


### PR DESCRIPTION
https://jira.library.nd.edu/browse/DLTP-1795

- Allows items search to return items which are part of another item based on query of field `library_collections_pathnames_tesim`. 
- Allows show of a LibraryCollection type item to include a membersUrl to the above link.
- Allows fl= to include field partOf in any search results