### PR TITLE
OAIPMH query search

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,7 @@ group :default do
   gem 'noid', '~> 0.6.6'
   gem 'noids_client', github: 'ndlib/noids_client'
   gem 'nokogiri', '~> 1.10'
-  gem "oai", "~> 1.0.0"
+  gem "oai"
   gem 'omniauth-oktaoauth'
   gem 'qa', github: 'ndlib/questioning_authority', branch: 'stable_0_8'
   gem 'rails_autolink'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -438,7 +438,7 @@ GEM
       activesupport (>= 3.2.18)
       i18n
       nokogiri
-    oai (1.0.1)
+    oai (1.1.0)
       builder (>= 3.1.0)
       faraday
       faraday_middleware
@@ -785,7 +785,7 @@ DEPENDENCIES
   noid (~> 0.6.6)
   noids_client!
   nokogiri (~> 1.10)
-  oai (~> 1.0.0)
+  oai
   omniauth-oauth2
   omniauth-oktaoauth
   omniauth-orcid (= 0.6)

--- a/app/controllers/oai_controller.rb
+++ b/app/controllers/oai_controller.rb
@@ -16,10 +16,6 @@ class OaiController < CatalogController
     render body: response, content_type: "text/xml"
   end
 
-  def valid_search_request_syntax?(options)
-    Oai::QueryBuilder.new.valid_request?(options)
-  end
-
   private
 
     def oai_params

--- a/app/controllers/oai_controller.rb
+++ b/app/controllers/oai_controller.rb
@@ -16,24 +16,14 @@ class OaiController < CatalogController
     render body: response, content_type: "text/xml"
   end
 
-  def load_data(options = {})
-    if valid_search_request_syntax?(options)
-      params.merge!(options)
-      # returns [ Blacklight::SolrResponse, Array(SolrDocument) ]
-      (@response, @document_list) = get_search_results
-    else
-      return nil
-    end
+  def valid_search_request_syntax?(options)
+    Oai::QueryBuilder.new.valid_request?(options)
   end
 
   private
 
     def oai_params
       params.permit(:verb, :identifier, :metadataPrefix, :set, :from, :until, :resumptionToken)
-    end
-
-    def valid_search_request_syntax?(options)
-      Oai::QueryBuilder.new.valid_request?(options)
     end
 
     def build_oai_query(solr_parameters, user_parameters)

--- a/app/controllers/oai_controller.rb
+++ b/app/controllers/oai_controller.rb
@@ -1,20 +1,42 @@
 class OaiController < CatalogController
+  self.solr_search_params_logic = [
+    :default_solr_parameters,
+    :add_query_to_solr,
+    :add_paging_to_solr,
+    :add_sorting_to_solr,
+    :add_access_controls_to_solr_params,
+    :enforce_embargo,
+    :exclude_unwanted_models,
+    :build_oai_query
+  ]
+
   def index
-    provider = OaiProvider.new
+    provider = OaiProvider.new(controller: self)
     response = provider.process_request(oai_params.to_h)
     render body: response, content_type: "text/xml"
   end
 
-  private
-
-  def oai_params
-    params.permit(:verb, :identifier, :metadataPrefix, :set, :from, :until, :resumptionToken)
+  def load_data(options = {})
+    if valid_search_request_syntax?(options)
+      params.merge!(options)
+      # returns [ Blacklight::SolrResponse, Array(SolrDocument) ]
+      (@response, @document_list) = get_search_results
+    else
+      return nil
+    end
   end
 
+  private
 
-      # Need to figure out where to implement this search
-      # def load_data
-      #   (@response, @document_list) = @controller.get_search_results
-      #   Api::ItemsSearchPresenter.new(@response, @controller.request.url, @controller.request.query_parameters)
-      # end
+    def oai_params
+      params.permit(:verb, :identifier, :metadataPrefix, :set, :from, :until, :resumptionToken)
+    end
+
+    def valid_search_request_syntax?(options)
+      Oai::QueryBuilder.new.valid_request?(options)
+    end
+
+    def build_oai_query(solr_parameters, user_parameters)
+      Oai::QueryBuilder.new.build_filter_queries(solr_parameters, user_parameters)
+    end
 end

--- a/app/models/oai_provider.rb
+++ b/app/models/oai_provider.rb
@@ -3,7 +3,11 @@ class OaiProvider < OAI::Provider::Base
   repository_url 'http://localhost/provider'
   record_prefix "oai"
   admin_email ""
-  source_model CurationConcernProvider.new
   sample_id "1"
   register_format(CurationConcernProvider::CurateFormat.instance)
+
+  def initialize(controller:)
+    super({ provider_context: :instance_based })
+    self.model= CurationConcernProvider.new(controller: controller)
+  end
 end

--- a/app/models/oai_provider/curation_concern_provider.rb
+++ b/app/models/oai_provider/curation_concern_provider.rb
@@ -22,11 +22,21 @@ class OaiProvider
           if options[:resumption_token]
             options = next_set(options[:resumption_token])
           end
-          controller.load_data(options.merge(rows: limit))
+          load_data(options.merge(rows: limit))
         end
         wrap_results(response_data, options)
       else
         format_response_terms(ActiveFedora::Base.find(selector, cast: true))
+      end
+    end
+
+    def load_data(options = {})
+      if controller.valid_search_request_syntax?(options)
+        controller.params.merge!(options)
+        # returns [ Blacklight::SolrResponse, Array(SolrDocument) ]
+        (response, document_list) = controller.get_search_results
+      else
+        return nil
       end
     end
 

--- a/app/models/oai_provider/curation_concern_provider.rb
+++ b/app/models/oai_provider/curation_concern_provider.rb
@@ -4,7 +4,7 @@ class OaiProvider
       @identifier_field = 'identifier'
       @timestamp_field = 'timestamp'
       @controller = controller
-      @limit = 12
+      @limit = 100
     end
     attr_reader :controller, :limit
 
@@ -31,13 +31,17 @@ class OaiProvider
     end
 
     def load_data(options = {})
-      if controller.valid_search_request_syntax?(options)
+      if valid_search_request_syntax?(options)
         controller.params.merge!(options)
         # returns [ Blacklight::SolrResponse, Array(SolrDocument) ]
         (response, document_list) = controller.get_search_results
       else
         return nil
       end
+    end
+
+    def valid_search_request_syntax?(options)
+      Oai::QueryBuilder.new.valid_request?(options)
     end
 
     def next_set(token_string)

--- a/app/repository_models/library_collection.rb
+++ b/app/repository_models/library_collection.rb
@@ -69,6 +69,10 @@ class LibraryCollection < ActiveFedora::Base
     solr_doc
   end
 
+  def terms_for_display
+    self.descMetadata.class.fields
+  end
+
   private :date_uploaded=, :date_modified=
 
   private

--- a/app/services/oai/query_builder.rb
+++ b/app/services/oai/query_builder.rb
@@ -1,0 +1,107 @@
+class Oai::QueryBuilder
+  include Sufia::Noid
+
+  VALID_KEYS_AND_SEARCH_FIELDNAMES = {
+    from: "desc_metadata__date_modified_dtsi",
+    until: "desc_metadata__date_modified_dtsi"
+  }.freeze
+
+  attr_reader :current_user
+
+  def initialize
+    @current_user = nil
+  end
+
+  def valid_request?(user_parameters)
+    user_parameters.each do |term, value|
+      key = term.to_sym
+      if VALID_KEYS_AND_SEARCH_FIELDNAMES[key].present?
+        return false unless valid_value(key, value)
+      end
+    end
+    return true
+  end
+
+  def build_filter_queries(solr_parameters, user_parameters)
+    solr_parameters[:fq] ||= []
+    user_parameters.each do |term, value|
+      key = term.to_sym
+      if VALID_KEYS_AND_SEARCH_FIELDNAMES[key].present?
+        solr_parameters[:fq] << do_search_for(key, value)
+      end
+    end
+    solr_parameters
+  end
+
+    private
+
+  # perform validations of the value of a search term
+  def valid_value(key, value)
+    case key
+    when (:from || :until)
+      return valid_date_format?(value)
+    when :set
+      return valid_set_type
+    else
+      # no value validation for key
+      return true
+    end
+  end
+
+  def filter_by_set(term)
+    set_info = term.split(':',2)
+    case set_info[0]
+    when 'collection'
+      filter_by_part_of(set_info[1])
+    when 'model'
+      filter_by_worktype(set_info[1])
+    else
+      # do nothing - not a valid set
+    end
+  end
+
+  def filter_by_worktype(term)
+    require 'byebug'; debugger; true
+  end
+
+  def filter_by_part_of(term)
+    Sufia::Noid.namespaceize(term)
+  end
+
+  # allowed format: "2020-03-31T21:51:03Z"
+  def filter_by_from(term)
+    term.utc unless term.utc?
+    "[#{term.xmlschema} TO *]"
+  end
+
+  # allowed format: "2020-03-31T21:51:03Z"
+  def filter_by_until(term)
+    term.utc unless term.utc?
+    "[* TO #{term.xmlschema}]"
+  end
+
+  # builds filter query search for a given key & array of elements
+  def do_search_for(key, value)
+    search_term = self.send("filter_by_#{key}", value)
+    prepare_search_term_for(key, search_term)
+  end
+
+  def join_for(value)
+    " AND "
+  end
+
+  def prepare_search_term_for(key, term)
+    field = VALID_KEYS_AND_SEARCH_FIELDNAMES[key]
+    this_term = field.ends_with?('dtsi') ? term : "\"#{term}\""
+    search_term  = "#{field}:#{this_term}"
+  end
+
+  def valid_date_format?(value)
+    value.is_a?(Time)
+  end
+
+  def valid_set_type(term)
+    return true if term.start_with?("und:") || term.is_a?(CurationConcern)
+    false
+  end
+end

--- a/app/services/oai/query_builder.rb
+++ b/app/services/oai/query_builder.rb
@@ -10,12 +10,6 @@ class Oai::QueryBuilder
     model: "type"
   }
 
-  attr_reader :current_user
-
-  def initialize
-    @current_user = nil
-  end
-
   def valid_request?(user_parameters)
     user_parameters.each do |term, value|
       (search_key, search_value) = search_terms_for(term, value)

--- a/app/services/oai/query_builder.rb
+++ b/app/services/oai/query_builder.rb
@@ -1,10 +1,14 @@
 class Oai::QueryBuilder
-  include Sufia::Noid
-
   VALID_KEYS_AND_SEARCH_FIELDNAMES = {
     from: "desc_metadata__date_modified_dtsi",
-    until: "desc_metadata__date_modified_dtsi"
+    until: "desc_metadata__date_modified_dtsi",
+    collection: "library_collections_pathnames_tesim",
+    model: "active_fedora_model_ssi"
   }.freeze
+  VALID_SET_TYPE_SEARCHES = {
+    collection: "und:",
+    model: "type"
+  }
 
   attr_reader :current_user
 
@@ -14,9 +18,9 @@ class Oai::QueryBuilder
 
   def valid_request?(user_parameters)
     user_parameters.each do |term, value|
-      key = term.to_sym
-      if VALID_KEYS_AND_SEARCH_FIELDNAMES[key].present?
-        return false unless valid_value(key, value)
+      (search_key, search_value) = search_terms_for(term, value)
+      if VALID_KEYS_AND_SEARCH_FIELDNAMES[search_key].present?
+        return false unless valid_value(search_key, search_value)
       end
     end
     return true
@@ -25,9 +29,9 @@ class Oai::QueryBuilder
   def build_filter_queries(solr_parameters, user_parameters)
     solr_parameters[:fq] ||= []
     user_parameters.each do |term, value|
-      key = term.to_sym
-      if VALID_KEYS_AND_SEARCH_FIELDNAMES[key].present?
-        solr_parameters[:fq] << do_search_for(key, value)
+      (search_key, search_value) = search_terms_for(term, value)
+      if VALID_KEYS_AND_SEARCH_FIELDNAMES[search_key].present?
+        solr_parameters[:fq] << do_search_for(search_key, search_value)
       end
     end
     solr_parameters
@@ -35,37 +39,33 @@ class Oai::QueryBuilder
 
     private
 
+    def search_terms_for(term, value)
+      if term.to_sym == :set
+        split_set_search(value)
+      else
+        [term.to_sym, value]
+      end
+    end
+
   # perform validations of the value of a search term
   def valid_value(key, value)
     case key
     when (:from || :until)
       return valid_date_format?(value)
-    when :set
-      return valid_set_type
+    when :model || :collection
+      return valid_set_type?(key, value)
     else
       # no value validation for key
       return true
     end
   end
 
-  def filter_by_set(term)
-    set_info = term.split(':',2)
-    case set_info[0]
-    when 'collection'
-      filter_by_part_of(set_info[1])
-    when 'model'
-      filter_by_worktype(set_info[1])
-    else
-      # do nothing - not a valid set
-    end
+  def filter_by_model(term)
+    term
   end
 
-  def filter_by_worktype(term)
-    require 'byebug'; debugger; true
-  end
-
-  def filter_by_part_of(term)
-    Sufia::Noid.namespaceize(term)
+  def filter_by_collection(term)
+    term
   end
 
   # allowed format: "2020-03-31T21:51:03Z"
@@ -86,10 +86,6 @@ class Oai::QueryBuilder
     prepare_search_term_for(key, search_term)
   end
 
-  def join_for(value)
-    " AND "
-  end
-
   def prepare_search_term_for(key, term)
     field = VALID_KEYS_AND_SEARCH_FIELDNAMES[key]
     this_term = field.ends_with?('dtsi') ? term : "\"#{term}\""
@@ -100,8 +96,31 @@ class Oai::QueryBuilder
     value.is_a?(Time)
   end
 
-  def valid_set_type(term)
-    return true if term.start_with?("und:") || term.is_a?(CurationConcern)
+  def valid_set_type?(key, value)
+    return false unless VALID_SET_TYPE_SEARCHES[key].present?
+    return false if value.nil?
+    return true if key == :collection && value.start_with(VALID_SET_TYPE_SEARCHES[key])
+    return true if key == :model && valid_worktypes.include?(value)
     false
+  end
+
+  def split_set_search(value)
+    (search_key, search_value) = value.split(':',2)
+    new_value = begin
+      if search_value.start_with?("und:")
+        search_value
+      elsif valid_worktypes.include?(search_value.constantize)
+        search_value.constantize
+      else
+        nil
+      end
+    rescue NameError
+      nil
+    end
+    [search_key.to_sym, new_value]
+  end
+
+  def valid_worktypes
+    @worktypes ||= Curate.configuration.registered_curation_concern_types.sort.collect(&:constantize)
   end
 end


### PR DESCRIPTION
1. Support ListIdentifiers and ListRecords verbs (for from & until searches), along with resumptionToken to paginate through records.
2. Support ListSets
3. Support ListRecords search for set (collection & model searches)
* collection:und:xxxxxxxx selects subcollection and work members of a LibraryCollection
* model:Article allows search any registered CurationConcern and returns paginated list of items of that model

Completes a portion of https://jira.library.nd.edu/browse/DLTP-1758

Does not yet include specs