### PR TITLE
Api fixes

### DIFF
--- a/app/controllers/api/uploads_controller.rb
+++ b/app/controllers/api/uploads_controller.rb
@@ -6,7 +6,7 @@ class Api::UploadsController < Api::BaseController
   attr_reader :bucket
 
   # begin a new work transaction
-  # GET /api/uploads/new
+  # POST /api/uploads/new
   def trx_initiate
     if @current_user
       trx_id = ApiTransaction.new_trx_id

--- a/app/presenters/api/show_item_presenter.rb
+++ b/app/presenters/api/show_item_presenter.rb
@@ -207,13 +207,26 @@ class Api::ShowItemPresenter
           predicate = delete_prefix(string: statement.predicate.to_s)
           subject = statement.object.to_s
           if !subject.blank?
-            data[predicate] = use_url_if_is_a_pid(subject, url_type: :show)
+            new_subject = use_url_if_is_a_pid(subject, url_type: :show)
+            if data[predicate].nil?
+              data[predicate] = new_subject
+            else
+              data[predicate] = merge_subjects(data[predicate], new_subject)
+            end
           end
         end
       rescue RDF::ReaderError => e
       end
     end
     data
+  end
+
+  def merge_subjects(subject1, subject2)
+    if subject1.is_a?(Array)
+      return subject1 << subject2
+    else
+      return [subject1, subject2]
+    end
   end
 
   SINGLE_VALUE_KEYS = ['hasModel', 'hasProfile']

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -130,7 +130,7 @@ CurateNd::Application.routes.draw do
     get 'items/download/:id', as: 'item_download', controller: 'downloads', action: 'download'
     resources :items, only: [:show, :index]
     resources :access_tokens, only: [:new, :index, :create, :destroy]
-    get 'uploads/new', as: 'trx_initiate', controller: 'uploads', action: 'trx_initiate'
+    match 'uploads/new', as: 'trx_initiate', controller: 'uploads', action: 'trx_initiate', via: [:get, :post]
     post 'uploads/:tid/file/new', as: 'trx_new_file', controller: 'uploads', action: 'trx_new_file'
     post 'uploads/:tid/file/:fid', as: 'trx_append', controller: 'uploads', action: 'trx_append'
     get 'uploads/:tid/status', controller: 'uploads', action: 'trx_status'

--- a/spec/controllers/api/uploads_controller_spec.rb
+++ b/spec/controllers/api/uploads_controller_spec.rb
@@ -16,7 +16,7 @@ describe Api::UploadsController do
       it 'returns 200 and json document and updates work_id' do
         request.headers['X-Api-Token'] = token.sha
         request.headers['HTTP_ACCEPT'] = "application/json"
-        get :trx_initiate
+        post :trx_initiate
         expect(response).to be_successful
         expect(JSON.parse(response.body).keys).to contain_exactly("trx_id", "work_id")
       end


### PR DESCRIPTION
Handle multiple instances of a value in descMetadata.
https://jira.library.nd.edu/browse/DLTP-1823

Also add post option for api new item. Get is not expected to include content, but is not being removed in order to retain backward compatibility. 