### PR TITLE
Remove Contributor Institution From Deposit

### DIFF
--- a/app/views/curation_concern/datasets/_form_additional_information.html.erb
+++ b/app/views/curation_concern/datasets/_form_additional_information.html.erb
@@ -21,7 +21,6 @@
   <%= f.input :collection_name,         as: :multi_value, input_html: { class: 'input-xlarge' } %>
   <%= f.input :size,                    as: :multi_value, input_html: { class: 'input-xlarge' } %>
   <%= f.input :requires,                as: :multi_value, input_html: { class: 'input-xlarge' } %>
-  <%= f.input :contributor_institution, as: :multi_value, input_html: { class: 'input-xlarge' } %>
 </fieldset>
 <%
   deprecated_fields = [

--- a/app/views/curation_concern/documents/_form_additional_information.html.erb
+++ b/app/views/curation_concern/documents/_form_additional_information.html.erb
@@ -42,6 +42,5 @@
 
   <%= f.input :repository_name,            label: 'Repository Name', as: :multi_value, input_html: { class: 'input-xlarge' } %>
   <%= f.input :collection_name,            label: 'Collection Name', as: :multi_value, input_html: { class: 'input-xlarge' } %>
-  <%= f.input :contributor_institution,    label: 'Contributor Institution', as: :multi_value, input_html: { class: 'input-xlarge' } %>
   <%= f.input :recommended_citation,       label: 'Recommended Citation', as: :multi_value, input_html: { class: 'input-xlarge' } %>
 </fieldset>

--- a/app/views/curation_concern/images/_form_descriptive_fields.erb
+++ b/app/views/curation_concern/images/_form_descriptive_fields.erb
@@ -56,11 +56,6 @@
                   as: :multi_value,
                   input_html: { class: 'input-xlarge' }
       %>
-      <%= f.input :contributor_institution,
-                  as: :multi_value,
-                  labe: "Contributor Institution",
-                  input_html: { class: 'input-xlarge' }
-      %>
       <%= f.input :source,
                   as: :multi_value,
                   input_html: { class: 'input-xlarge' }


### PR DESCRIPTION
Completes https://jira.library.nd.edu/browse/DLTP-1561

Contributor Institution is defined for work types: Article, Document, Image, Dataset.
No datasets have the field indexed in Solr.
There are 9 articles, 11 images, and 223 documents.

It is not included on any views for Article.
It is on add, edit, and show views for Document.
It is on add & edit views for Image and Dataset.

The request was to remove from deposit. Removing from add also removes
from edit because they share the same partials.

It was only showing for type Document, and it remains in that view.