### PR TITLE
Add characterize file button

### DIFF
--- a/app/controllers/curation_concern/generic_files_controller.rb
+++ b/app/controllers/curation_concern/generic_files_controller.rb
@@ -85,6 +85,11 @@ class CurationConcern::GenericFilesController < CurationConcern::BaseController
     end
   end
 
+  def characterize_file
+    Sufia.queue.push(CharacterizeJob.new(curation_concern.pid))
+    redirect_to common_object_path(curation_concern)
+  end
+
   register :actor do
     CurationConcern::Utility.actor(curation_concern, current_user, attributes_for_actor)
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -26,6 +26,12 @@ class Ability
       else
         cannot [:manage], Admin::AuthorityGroup
       end
+
+      if repository_administrators.include?(current_user.to_s)
+        can :characterize_file, :all
+      else
+        cannot :characterize_file, :all
+      end
     end
   end
 

--- a/app/views/common_objects/show.html.erb
+++ b/app/views/common_objects/show.html.erb
@@ -22,6 +22,9 @@
       <i class="icon icon-pencil"></i> Edit
     <% end %>
   <% end %>
+  <% if curation_concern.is_a?(GenericFile) && can?(:characterize_file, curation_concern) %>
+    <%= link_to 'Characterize File', characterize_path(id: curation_concern.noid) , class: 'btn btn-primary' %>
+  <% end %>
   <% if RepoManager.with_active_privileges?(current_user) %>
     <%= link_to 'Reindex this Item', admin_reindex_pid_path(curation_concern.id) , class: 'btn btn-primary' %>
   <% end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -56,6 +56,10 @@ CurateNd::Application.configure do
     }
   end
 
+  # to run characterization, comment out the characterization_runner above, and
+  # uncomment the line below, filling in the path to fits on your system.
+  # config.fits_path = '/usr/local/bin/fits.sh'
+
   config.logger = Logger.new(STDOUT)
   config.default_oai_limit = 5
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -170,6 +170,7 @@ CurateNd::Application.routes.draw do
   get '/show/citation/:id', to: 'citation#show', as: 'citation'
 
   get'/usage/:id(.:format)', to: 'metrics/usage#show', as: 'metrics_usage'
+  get'/characterize/:id', to: 'curation_concern/generic_files#characterize_file', as: 'characterize'
 
   get 'get_started', to: redirect('deposit')
   get 'deposit', to: 'classify_concerns#new'


### PR DESCRIPTION
Add a button to initiate characterization to generic file show page.
Limit ability to perform characterization and visibility of button to repository administrators.