### PR TITLE
Add static licenses page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -25,6 +25,7 @@
  *= require 'modules/flash-message'
  *= require 'modules/grant-temporary-access'
  *= require 'modules/home'
+ *= require 'modules/licenses'
  *= require 'modules/masquerade_controls'
  *= require 'modules/page-footer'
  *= require 'modules/policies'

--- a/app/assets/stylesheets/modules/faq.scss.erb
+++ b/app/assets/stylesheets/modules/faq.scss.erb
@@ -65,6 +65,13 @@
     margin-bottom: 1em;
     margin-left: 0;
   }
+
+  p {
+    font-size: 18px;
+    line-height: 1.4;
+    margin-bottom: 1em;
+    margin-left: 0;
+  }
 }
 
 @media (min-width: 400px) {

--- a/app/assets/stylesheets/modules/licenses.scss
+++ b/app/assets/stylesheets/modules/licenses.scss
@@ -60,6 +60,13 @@
     margin-bottom: 1em;
     margin-left: 0;
   }
+
+  p {
+    font-size: 18px;
+    line-height: 1.4;
+    margin-bottom: 1em;
+    margin-left: 0;
+  }
 }
 
 @media (min-width: 400px) {

--- a/app/assets/stylesheets/modules/licenses.scss
+++ b/app/assets/stylesheets/modules/licenses.scss
@@ -1,33 +1,27 @@
 @import 'global-variables';
 
-.page-main.faq {
+.page-main.licenses {
   border-bottom: 1px solid $gray-faint;
 }
 
-.faq-page-header {
+.licenses-page-header {
   padding: 1em;
   text-align: center;
-
-  .svg-title {
-    font-size: 16px;
-    margin: 0 auto -3px;
-    max-width: 65px; // 22px tall SVG character
-  }
 }
 
 @media (max-width: 550px) {
-  .faq-page-header h2 {
+  .licenses-page-header h2 {
     font-size: 20px;
     line-height: 1.2;
     margin-bottom: 0;
   }
 }
 
-.faq-wrapper {
+.licenses-wrapper {
   padding: 0 1em 1em;
 }
 
-.curate-nd-faqs {
+.licenses-content {
   background-color: white;
   border: 1px solid $gray-faint;
   box-sizing: border-box;
@@ -42,6 +36,7 @@
   ul {
     margin: 0;
     padding-left: 1.5em;
+    list-style: none;
   }
 
   li {
@@ -68,25 +63,21 @@
 }
 
 @media (min-width: 400px) {
-  .curate-nd-faqs {
+  .licenses-content {
     padding: 0 2em 2em;
     margin-bottom: 2em;
   }
 }
 
 @media (min-width: 768px) {
-  .faq-page-header .svg-title {
-    max-width: 211px; // 72px tall SVG character
-  }
-
-  .curate-nd-faqs {
+  .licenses-content {
     padding: 0 4em 4em;
     margin-bottom: 6em;
   }
 }
 
 @media (min-width: 900px) {
-  .faq-page-header {
+  .licenses-page-header {
     padding: 32px 1em;
   }
 }

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -49,6 +49,11 @@ class StaticPagesController < ApplicationController
     render 'terms_of_service', layout: 'curate_nd_home'
   end
 
+  def licenses
+    @hide_title = false;
+    render 'licenses', layout: 'curate_nd_home'
+  end
+
   private
 
   def build_help_request

--- a/app/views/curation_concern/base/_license_modal.html.erb
+++ b/app/views/curation_concern/base/_license_modal.html.erb
@@ -4,17 +4,7 @@
     <h2><%= t('sufia.product_name') %> License Descriptions</h2>
   </div>
   <div class="modal-body" aria-hidden="true">
-    <p><%= t('sufia.product_name') %> offers the following licenses for deposited items.
-    The majority come from the set of <a href="http://creativecommons.org/licenses/">Creative Commons licenses</a>.
-    See these <a href="https://creativecommons.org/share-your-work/licensing-examples/">examples</a> of
-    uses of Creative Commons licenses.
-    (The Creative Commons 4.0 licenses are preferred over the 3.0 licenses, but CurateND offers both to choose from.)
-    </p>
-    <ul>
-      <% Copyright.active.each do |item| %>
-        <li><strong><%= item.term_label %></strong><br /><%= item.description %></li>
-      <% end %>
-    </ul>
+    <%= render partial: '/static_pages/licenses_content' %>
   </div>
   <div class="modal-footer">
     <button class="btn btn-primary" data-dismiss="modal" aria-hidden="true">Close</button>

--- a/app/views/static_pages/_licenses_content.erb
+++ b/app/views/static_pages/_licenses_content.erb
@@ -1,14 +1,16 @@
-    <dd><%= t('sufia.product_name') %> offers the following licenses for deposited items.
+    <p><%= t('sufia.product_name') %> offers the following licenses for deposited items.
     The majority come from the set of <a href="http://creativecommons.org/licenses/">Creative Commons licenses</a>.
     See these <a href="https://creativecommons.org/share-your-work/licensing-examples/">examples</a> of
     uses of Creative Commons licenses.
     (The Creative Commons 4.0 licenses are preferred over the 3.0 licenses, but CurateND offers both to choose from.)
-    </dd>
-    <ul>
-      <% Copyright.active.each do |item| %>
-        <li>
-          <dt><%= item.term_label %></dt>
-          <dd><%= item.description %></dd>
-        </li>
-      <% end %>
-    </ul>
+    </p>
+    <dl>
+      <ul>
+        <% Copyright.active.each do |item| %>
+          <li>
+            <dt><%= item.term_label %></dt>
+            <dd><%= item.description %></dd>
+          </li>
+        <% end %>
+      </ul>
+    </dl>

--- a/app/views/static_pages/_licenses_content.erb
+++ b/app/views/static_pages/_licenses_content.erb
@@ -1,0 +1,14 @@
+    <dd><%= t('sufia.product_name') %> offers the following licenses for deposited items.
+    The majority come from the set of <a href="http://creativecommons.org/licenses/">Creative Commons licenses</a>.
+    See these <a href="https://creativecommons.org/share-your-work/licensing-examples/">examples</a> of
+    uses of Creative Commons licenses.
+    (The Creative Commons 4.0 licenses are preferred over the 3.0 licenses, but CurateND offers both to choose from.)
+    </dd>
+    <ul>
+      <% Copyright.active.each do |item| %>
+        <li>
+          <dt><%= item.term_label %></dt>
+          <dd><%= item.description %></dd>
+        </li>
+      <% end %>
+    </ul>

--- a/app/views/static_pages/faqs.html.erb
+++ b/app/views/static_pages/faqs.html.erb
@@ -31,10 +31,7 @@
 <div class="faq-wrapper">
   <article class="curate-nd-faqs">
     <h2 id="help">Help</h2>
-    <ul>
-      <li>Questions? Contact the CurateND Support team at <%= mail_to('curate@nd.edu', 'curate@nd.edu', subject: 'Questions about CurateND') %></li>
-      <li><%= link_to 'Report a Problem', new_help_request_path, class: 'help-report-a-problem request-help' %></li>
-    </ul>
+    <dd>Questions? Contact the CurateND Support team at <%= mail_to('curate@nd.edu', 'curate@nd.edu', subject: 'Questions about CurateND') %> or use the form to <%= link_to 'report a problem.', new_help_request_path, class: 'help-report-a-problem request-help' %></dd>
 
     <h2 id="policies"><%= link_to 'Governing policies', policies_path %></h2>
     <ul>
@@ -137,25 +134,14 @@
         No. You keep all your rights.
       </dd>
 
-      <dt>What is a Creative Commons license?</dt>
+      <dt>What licensing options are available in CurateND?</dt>
       <dd>
-        A Creative Commons license is one of a <a href="http://creativecommons.org/licenses/">set of licenses</a> providing others various degrees of permission for use.
-        Some of these permissions require attribution, allow for commercial use and re-use, or permit others to make derivative works.
+        CurateND allows users to assign a license of their choosing. Primarily, these are Creative Commons license, a <a href="http://creativecommons.org/licenses/">set of licenses</a> providing others various degrees of permission for use. Some of these permissions require attribution, allow for commercial use and re-use, or permit others to make derivative works. For more help choosing a license, use the <a href="http://creativecommons.org/choose/">Creative Commons License Chooser tool.</a> For all of the licenses available in CurateND, including non-Creative Commons options, view the <%= link_to 'List of Licensing Options.', licenses_path %>
       </dd>
-      
-      <dt>What other licensing options are available?</dt>
-<dd>
-   The button below lists information on each of the licenses available in CurateND.
-</dd>
-  <p>
-    <a href="#licenseModal" role="button" class="btn fright" data-toggle="modal">Help me choose a license</a>
-    <%= render :partial => "curation_concern/base/license_modal" %>
-  </p>
-
 
       <dt>How do I deposit a dissertation?</dt>
       <dd>
-      Submit electronic dissertations for fulfilling Graduate School requirements using <a href="https://deposit.library.nd.edu/areas/etd">this submission portal</a>.
+        Submit electronic dissertations for fulfilling Graduate School requirements using <a href="https://deposit.library.nd.edu/areas/etd">this submission portal</a>.
       </dd>
 
       <dt>How do I deposit a large number of collections or files?</dt>
@@ -209,15 +195,7 @@
         See <a href="http://policy.nd.edu/assets/203012/intellectualpropertypolicy.pdf">University Policy on Intellectual Property</a> for guidance.
         Section 2.2 may be the most useful:
         <quote>
-        The University owns all copyrightable materials (including computer programs, software, or
-multi-media productions) that are works made for hire under copyright law or that are
-developed pursuant to University Work unless otherwise provided in this policy. Consistent
-with long-standing academic tradition, the University does not normally claim ownership of
-works such as textbooks, articles, papers, scholarly monographs, or artistic works. Creators
-therefore retain copyright in such works, unless such works are created under a grant or
-sponsored program that specifies ownership rights in some entity other than the Creator, such
-works are the subject of a contract modifying ownership rights, or rights in such works are
-otherwise addressed in this policy.
+          The University owns all copyrightable materials (including computer programs, software, or multi-media productions) that are works made for hire under copyright law or that are developed pursuant to University Work unless otherwise provided in this policy. Consistent with long-standing academic tradition, the University does not normally claim ownership of works such as textbooks, articles, papers, scholarly monographs, or artistic works. Creators therefore retain copyright in such works, unless such works are created under a grant or sponsored program that specifies ownership rights in some entity other than the Creator, such works are the subject of a contract modifying ownership rights, or rights in such works are otherwise addressed in this policy.
         </quote>
       </dd>
     </dl>

--- a/app/views/static_pages/faqs.html.erb
+++ b/app/views/static_pages/faqs.html.erb
@@ -136,7 +136,7 @@
 
       <dt>What licensing options are available in CurateND?</dt>
       <dd>
-        CurateND allows users to assign a license of their choosing. Primarily, these are Creative Commons license, a <a href="http://creativecommons.org/licenses/">set of licenses</a> providing others various degrees of permission for use. Some of these permissions require attribution, allow for commercial use and re-use, or permit others to make derivative works. For more help choosing a license, use the <a href="http://creativecommons.org/choose/">Creative Commons License Chooser tool.</a> For all of the licenses available in CurateND, including non-Creative Commons options, view the <%= link_to 'List of Licensing Options.', licenses_path %>
+        CurateND allows users to assign content a license of their choosing. Licenses can range from an "all rights reserved", to a Creative Commons license, to a CC0 (public domain). For all of the licenses available in CurateND, view the <%= link_to 'List of Licensing Options.', licenses_path %> The Creative Commons licenses is a <a href="http://creativecommons.org/licenses/">set of licenses</a> providing others various degrees of permission for use. Some of these permissions require attribution, allow for commercial use and re-use, or permit others to make derivative works. For more information on them, refer to the <a href="http://creativecommons.org/choose/">Creative Commons License Chooser tool.</a>
       </dd>
 
       <dt>How do I deposit a dissertation?</dt>

--- a/app/views/static_pages/faqs.html.erb
+++ b/app/views/static_pages/faqs.html.erb
@@ -31,7 +31,7 @@
 <div class="faq-wrapper">
   <article class="curate-nd-faqs">
     <h2 id="help">Help</h2>
-    <dd>Questions? Contact the CurateND Support team at <%= mail_to('curate@nd.edu', 'curate@nd.edu', subject: 'Questions about CurateND') %> or use the form to <%= link_to 'report a problem.', new_help_request_path, class: 'help-report-a-problem request-help' %></dd>
+    <p>Questions? Contact the CurateND Support team at <%= mail_to('curate@nd.edu', 'curate@nd.edu', subject: 'Questions about CurateND') %> or use the form to <%= link_to 'report a problem.', new_help_request_path, class: 'help-report-a-problem request-help' %></p>
 
     <h2 id="policies"><%= link_to 'Governing policies', policies_path %></h2>
     <ul>

--- a/app/views/static_pages/licenses.erb
+++ b/app/views/static_pages/licenses.erb
@@ -1,0 +1,16 @@
+<%
+  content_for :page_title, construct_page_title('CurateNd License Descriptions')
+  content_for :page_main_class, 'licenses'
+%>
+
+<header class="licenses-page-header">
+  <h1 id="curatend-licenses">
+    <%= I18n.t('sufia.product_name')%> License Descriptions
+  </h1>
+</header>
+
+<div class="licenses-wrapper">
+  <div class="licenses-content"">
+    <%= render partial: '/static_pages/licenses_content' %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -183,6 +183,7 @@ CurateNd::Application.routes.draw do
   get 'orcid_settings', to: 'user_profiles#orcid_settings'
   get 'policies', to: 'static_pages#policies'
   get 'tos', to: 'static_pages#tos'
+  get 'licenses', to: 'static_pages#licenses'
   get 'policies/:policyname', to: 'static_pages#policies', as: :named_policy
   get '500', to: 'static_pages#error'
   get '502', to: 'static_pages#error', default: { status_code: '502' }


### PR DESCRIPTION
Rework FAQ page to link to a static licenses page rather than a modal.
Completes https://jira.library.nd.edu/browse/DLTP-1824

Adjust formatting of lists on FAQ page to fix https://github.com/ndlib/curate_nd/pull/903