### PR TITLE
Remove plumx widget script

### DIFF
--- a/app/views/layouts/boilerplate.html.erb
+++ b/app/views/layouts/boilerplate.html.erb
@@ -16,7 +16,6 @@
     <%= javascript_include_tag 'modernizr' %>
     <%= javascript_include_tag 'application' %>
     <%= javascript_include_tag 'rich_text_editor' if include_rich_text_editor? %>
-    <script type="text/javascript" src="//d39af2mgp1pqhg.cloudfront.net/widget-details.js"></script>
     <%= render :partial => '/ga', :formats => [:html] -%>
   </head>
   <body>


### PR DESCRIPTION
Tricky since the script doesn't have plumx in the name. It in turn was
loading other plu.mx resources, which is how I found it.