### PR TITLE
Use the new way to cache bendo content

### DIFF
--- a/app/services/bendo/services/refresh_file_cache.rb
+++ b/app/services/bendo/services/refresh_file_cache.rb
@@ -14,39 +14,12 @@ module Bendo
         Response = Struct.new(:status, :body)
 
         def self.call(slugs)
-          # Use a prematurely terminated GET request to warm the Bendo cache
-          #
-          # Refreshing the cache is the same processes as requesting a downlowd.
-          # The only difference is that the GET request should be closed instead
-          # of waiting for all of the body to be sent. The easiest way to do
-          # this is with HTTP streaming.
           body = slugs.each_with_object({}) do |item_slug, memo|
-            uri = URI.parse(item_url(item_slug))
-            status = 500
-            begin
-              Net::HTTP.start(uri.host, uri.port) do |http|
-                request = Net::HTTP::Get.new uri
-
-                http.request request do |response|
-                  response.read_body do |chunk|
-                    status = response.code.to_i
-                    http.finish
-                  end
-                end
-              end
-            rescue NoMethodError, IOError
-              # Since the connection is closed while the response body is still
-              # being processed the request ends up nil. This causes either an
-              # NoMethodError because read_body tries to check if the request
-              # is `#closed?`. Or an IOError since the next read to the stream
-              # will notice the connection is closed and raise this error.
-              #
-              # Both errors are expected since closing an HTTP GET connection
-              # early is not valid behavior according to the HTTP spec.
-              # https://stackoverflow.com/questions/2180183/how-to-cancel-ruby-nethttp-request
-              logger.info "Prematurely and deliberately terminated request for #{uri} to warm the cache"
+            # Use a HEAD request with the Request-Cache header set to anything.
+            resp = Faraday.head(item_url(item_slug)) do |req|
+              req.headers['Request-Cache'] = '1'
             end
-            memo[item_slug] = status
+            memo[item_slug] = resp.status
           end
 
           Response.new(200, body.to_json)


### PR DESCRIPTION
Bendo now allows using a head request with a special header to signal
that it should cache a file. This is much better than the previous
method of doing a GET request and then closing the connection early.

DLTP-1789