### PR TITLE
Make Hesburgh Library logo link

### DIFF
--- a/app/assets/stylesheets/modules/home.scss.erb
+++ b/app/assets/stylesheets/modules/home.scss.erb
@@ -302,7 +302,8 @@
   }
 
   .hesburgh-mark {
-    background-image: url(<%= asset_path 'hesburgh-mark-white.png'%>);
+    height: 68px;
+    width: 200px;
   }
 }
 

--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -19,8 +19,8 @@
       </div>
 
       <div class="span4 footer-right">
-        <div class="hesburgh-mark">
-          <a href="http://library.nd.edu"><span class="visuallyhidden">University of Notre Dame Hesburgh Libraries</span></a>
+        <div>
+          <%= link_to image_tag("hesburgh-mark-white.png", alt: "University of Notre Dame Hesburgh Libraries", class: "hesburgh-mark"), "http://library.nd.edu" %>
         </div>
       </div>
     </div>


### PR DESCRIPTION
In the lower right corner of CurateND pages, there is a Hesburgh Library logo.
As a user, I expected to be able to click the logo and have a new screen open with the Library's website.

Fix https://jira.library.nd.edu/browse/DLTP-1803