### PR TITLE
Adding branching logic for Hesburgh Mark rendering

### DIFF
--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -20,7 +20,8 @@
 
       <div class="span4 footer-right">
         <div>
-          <%= link_to image_tag("hesburgh-mark-white.png", alt: "University of Notre Dame Hesburgh Libraries", class: "hesburgh-mark"), "http://library.nd.edu" %>
+          <% image_to_use = (controller_name == "static_pages" && action_name == "home") ? "hesburgh-mark-white.png" : "hesburgh-mark-blue.png" %>
+          <%= link_to image_tag(image_to_use, alt: "University of Notre Dame Hesburgh Libraries", class: "hesburgh-mark"), "http://library.nd.edu" %>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Prior to this commit, the 996cb9c1b36d76f803ca6c903ed675f42f757052
commit switched the image rendering from CSS-based to img tag based. The
goal was to create a link to the Hesburgh Libraries.

However, there are two layouts (more specifically footers) in which the
image is rendered. One with a white background and one with a blue
background.

The aforementioned commit addressed the homepage rendering (e.g., the
one with the blue background for the footer). However, that rippled
through and rendered a transparent image on a white background.

This logic looks to not use CSS but to echo how the CSS is applied and
pick the right image.