### PR TITLE
Remove markdown

### DIFF
--- a/app/models/curate_oai_provider/curation_concern_provider.rb
+++ b/app/models/curate_oai_provider/curation_concern_provider.rb
@@ -77,6 +77,8 @@ class CurateOaiProvider
       response_object = record.standardize
       response_object[:timestamp] = response_object[:date_modified].to_time
       response_object[:source] = File.join(Rails.configuration.application_root_url, 'show', record.noid)
+      response_object[:description] = strip_markdown(response_object[:description]) unless response_object[:description].nil?
+      response_object[:title] = strip_markdown(response_object[:title]) unless response_object[:title].nil?
       Struct.new(*response_object.keys).new(*response_object.values)
     end
 
@@ -108,6 +110,11 @@ class CurateOaiProvider
         set_list.push(OAI::Set.new(values))
       end
       set_list
+    end
+
+    def strip_markdown(text)
+      return if text.blank?
+      Curate::TextFormatter.call(text: text.to_s, strip: true)
     end
 
     # used by oai gem to override methods to load the response terms

--- a/app/models/curate_oai_provider/curation_concern_provider.rb
+++ b/app/models/curate_oai_provider/curation_concern_provider.rb
@@ -77,6 +77,8 @@ class CurateOaiProvider
       response_object = record.standardize
       response_object[:timestamp] = response_object[:date_modified].to_time
       response_object[:source] = File.join(Rails.configuration.application_root_url, 'show', record.noid)
+      # NOTE: stripping markdown from the text is necessary to accommodate Primo.
+      #       We’re doing this to accomodate PRIMO’s OAI-PMH Harvesting antics
       response_object[:description] = strip_markdown(response_object[:description]) unless response_object[:description].nil?
       response_object[:title] = strip_markdown(response_object[:title]) unless response_object[:title].nil?
       Struct.new(*response_object.keys).new(*response_object.values)

--- a/lib/curate/text_formatter.rb
+++ b/lib/curate/text_formatter.rb
@@ -1,20 +1,27 @@
 require 'redcarpet'
+require 'redcarpet/render_strip'
 require 'sanitize'
 
 module Curate
   module TextFormatter
     module_function
-    def call(text: nil, block: false, title: false)
+    def call(text: nil, block: false, title: false, strip: false)
       return if text.nil?
       if title
         markdown = title_renderer
       elsif block
         markdown = block_renderer
+      elsif strip
+        markdown = markdown_stripper
       else
         markdown = inline_renderer
       end
       html = markdown.render(text)
       Sanitize.fragment(html, Sanitize::Config::RELAXED)
+    end
+
+    def markdown_stripper
+      Redcarpet::Markdown.new(Redcarpet::Render::StripDown)
     end
 
     def title_renderer


### PR DESCRIPTION
Removes markdown from title and description for OAI response. 

Title and description in curate allow the use of markdown. This needs to be removed from the OAI response in order for Primo to harvest the records.