### PR TITLE
Hide citations for library collections

### DIFF
--- a/app/views/common_objects/show.html.erb
+++ b/app/views/common_objects/show.html.erb
@@ -13,7 +13,7 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <% if display_citation_generation? %>
+  <% if display_citation_generation? && !curation_concern.is_a?(LibraryCollection) %>
     <%= link_to 'Generate Citation', citation_path(curation_concern) , class: 'btn citation-modal-js' %>
   <% end %>
   <%= link_to 'Usage Details', metrics_usage_path(id: curation_concern.noid) , class: 'btn btn-default' %>

--- a/app/views/curation_concern/base/show.html.erb
+++ b/app/views/curation_concern/base/show.html.erb
@@ -6,7 +6,7 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <% if display_citation_generation? %>
+  <% if display_citation_generation? && !curation_concern.is_a?(LibraryCollection) %>
     <%= link_to 'Generate Citation', citation_path(curation_concern) , class: 'btn citation-modal-js' %>
   <% end %>
   <% if can?(:edit, curation_concern) %>


### PR DESCRIPTION
Citations were failing due to missing collection metadata. This removes the citation options on the show view for LibraryCollection objects.

Resolves CURATE-140