### PR TITLE
Adding cap "db:bootstrap" task (CURATE-130)

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -79,6 +79,15 @@ namespace :db do
   end
 end
 
+namespace :db do
+  desc "Create the database, load the schema, and add the db:seeds (NOTE: This will only working in staging, because it will destroy DB data)"
+  task :bootstrap, roles: :app do
+    if rails_env == 'staging'
+      run "cd #{release_path}; #{rake} RAILS_ENV=#{rails_env} db:create db:schema:load db:seed"
+    end
+  end
+end
+
 #############################################################
 #  Deploy
 #############################################################


### PR DESCRIPTION
The three rake tasks will:

-  Optionally create the database for the given environment; If the
   database exists, then this task is skipped.
-  Destructively load the db/schema.rb file into the environment's
   database.  Any data in the database will be lost.
-  Load any associated database seeds for this environment (see
   `./db/seeds/data.rb`).

I believe this will address CURATE-130.

Note: None of this directly impacts the Fedora instance.  However, there
exists a relationship between users in the database and people in
Fedora.  Any Users before the script runs will be deleted, but their
People record in Fedora will remain (and in essence be abandoned).