### PR TITLE
Remove unnecessary sentry error report

### DIFF
--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -2,5 +2,5 @@ Raven.configure do |config|
   config.dsn = ENV['SENTRY_DSN']
   config.current_environment = Rails.env
   config.release = Curate.configuration.build_identifier
-  config.excluded_exceptions += ['ActiveFedora::RecordNotFound', 'ActiveRecord::RecordNotFound', 'ActiveFedora::ObjectNotFoundError', 'ActiveFedora::ActiveObjectNotFoundError', 'URI::InvalidComponentError']
+  config.excluded_exceptions += ['ActiveFedora::RecordNotFound', 'ActiveRecord::RecordNotFound', 'ActiveFedora::ObjectNotFoundError', 'ActiveFedora::ActiveObjectNotFoundError', 'URI::InvalidComponentError', 'ActionController::UnknownFormat']
 end


### PR DESCRIPTION
ActionController::UnknownFormat is not needed to be reported in Sentry.