### PR TITLE
Map Date Archived

### DIFF
--- a/app/repository_models/curation_concern/with_standardized_metadata.rb
+++ b/app/repository_models/curation_concern/with_standardized_metadata.rb
@@ -14,6 +14,7 @@ module CurationConcern
       abstract: :description,
       description: :description,
       date_uploaded: :date_deposited,
+      date_archived: :date_deposited,
       date_modified: :date_modified,
       date_created: :date_created,
       doi: :doi,


### PR DESCRIPTION
OSF Archives does not include method `date_uploaded`. Instead, method `date_archived` is used to return to metadata item `dateSubmitted`. 

This inserts `date_archived` into the standardized field `date_uploaded` so it will be returned as `dateSubmitted` in and OAI request.