### PR TITLE
Add document sub-type "Case Study"

### DIFF
--- a/app/repository_models/document.rb
+++ b/app/repository_models/document.rb
@@ -24,6 +24,7 @@ class Document < ActiveFedora::Base
     'Book Chapter',
     'Book',
     'Brochure',
+    'Case Study',
     'Document',
     'Letter',
     'Manuscript',


### PR DESCRIPTION
Completes CURATE-211
Adds `Case Study` as new subtype for work type Document. Metadata matches basic Document metadata.