### PR TITLE
Add pagination info

### DIFF
--- a/app/views/catalog/_sort_and_per_page.html.erb
+++ b/app/views/catalog/_sort_and_per_page.html.erb
@@ -29,5 +29,6 @@
         <i class="icon-refresh icon-white"></i> Update
       </button>
     </span>
+  <%= render 'results_pagination' %>
 
   <% end %>


### PR DESCRIPTION
Duplicate the pagination info on the search results page at both the bottom and top.
Completes CURATE-237.