### PR TITLE
Add sorting to API

### DIFF
--- a/app/presenters/api/items_search_presenter.rb
+++ b/app/presenters/api/items_search_presenter.rb
@@ -10,6 +10,7 @@ class Api::ItemsSearchPresenter
     depositor: ["depositor_tesim"],
     deposit_date: ["system_create_dtsi"],
     modify_date: ["system_modified_dtsi"],
+    upload_date: ["desc_metadata__date_uploaded_dtsi"],
     part_of: ["library_collections_pathnames_tesim"],
     admin_unit: ["desc_metadata__administrative_unit_tesim"]
   }.freeze
@@ -83,6 +84,10 @@ class Api::ItemsSearchPresenter
       @params = params
       @request_url = request_url
       @fields = (params[:fl].nil? ? nil : params[:fl].split(","))
+      # include sort value in results field list
+      if params[:sort].present?
+        @fields = @fields.nil? ? Array.wrap(params[:sort].split(" ").first) : (@fields.push(params[:sort].split(" ").first))
+      end
     end
 
     attr_reader :item, :fields, :params, :request_url
@@ -157,8 +162,16 @@ class Api::ItemsSearchPresenter
       @item.fetch('system_modified_dtsi', "")
     end
 
+    def include_upload_date
+      @item.fetch('desc_metadata__date_uploaded_dtsi', "")
+    end
+
     def include_part_of
       @item.fetch('library_collections_pathnames_tesim', "")
+    end
+
+    def include_admin_unit
+      @item.fetch("desc_metadata__administrative_unit_tesim", "")
     end
   end
 

--- a/app/presenters/api/show_item_presenter.rb
+++ b/app/presenters/api/show_item_presenter.rb
@@ -132,7 +132,12 @@ class Api::ShowItemPresenter
     data['downloadUrl'] = url_for(pid: ds.pid, url_type: :download)
     data['label'] = ds.label
     data['mimeType'] = ds.mimeType
-    bendo_url = bendo_location(ds.datastream_content)
+    begin
+      bendo_url = bendo_location(ds.datastream_content)
+    rescue SocketError => e
+      Raven.capture_exception(e)
+      bendo_url = ""
+    end
     data['bendoUrl'] = bendo_url unless bendo_url.blank?
     data
   end


### PR DESCRIPTION
Sort results by modify_date or deposit_date.
Include sorted term in results hash.
Add admin_unit to returned data... this was missed when admin_unit search was added.

Fixes CURATE-256