### PR TITLE
Fix Access Token Renewal Request

### DIFF
--- a/app/views/errors/_access_denied_alert.html.erb
+++ b/app/views/errors/_access_denied_alert.html.erb
@@ -2,7 +2,7 @@
   <div class="alert alert-warn">
     <p>Your single-use URL has expired or is no longer valid.</p>
     <% if access_renewal_request_allowed?(params[:token]) %>
-      <% build_renewal_request(params[:token]).html_safe %>
+      <% build_access_renewal_request(params[:token]).html_safe %>
     <% end %>
   </div>
 <% end %>


### PR DESCRIPTION
Correct method called in partial, causing ActionView::Template::Error when requesting an expired access token be renewed.