### PR TITLE
Allow xml response for API

### DIFF
--- a/app/controllers/api/items_controller.rb
+++ b/app/controllers/api/items_controller.rb
@@ -19,15 +19,27 @@ class Api::ItemsController < Api::BaseController
   def index
     if valid_search_request_syntax?
       (@response, @document_list) = get_search_results
-      render json: Api::ItemsSearchPresenter.new(@response, request.url, request.query_parameters).to_json
+      response_data = Api::ItemsSearchPresenter.new(@response, request.url, request.query_parameters)
+      respond_to do |format|
+        format.xml { render xml: response_data.to_xml }
+        format.json { render json: response_data.to_json }
+      end
     else
-      render json: { error: 'Invalid search request format. Please consult API documentation.' }, status: :bad_request
+      error_data = { error: 'Invalid search request format. Please consult API documentation.' }
+      respond_to do |format|
+        format.xml { render xml: error_data.to_xml, status: :bad_request }
+        format.json { render json: error_data.to_json, status: :bad_request }
+      end
     end
   end
 
   # GET /api/items/1
   def show
-    render json: Api::ShowItemPresenter.new(item, request.url).to_json
+    show_data = Api::ShowItemPresenter.new(item, request.url, request.format)
+    respond_to do |format|
+      format.xml {render xml: show_data.to_xml }
+      format.json { render json: show_data.to_json }
+    end
   end
 
   # POST /api/items/1/token

--- a/app/presenters/api/items_search_presenter.rb
+++ b/app/presenters/api/items_search_presenter.rb
@@ -77,6 +77,11 @@ class Api::ItemsSearchPresenter
     @json
   end
 
+  # @return [String] the XML document
+  def to_xml
+    @json.to_xml
+  end
+
   private
 
   def build_json!

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -126,7 +126,7 @@ CurateNd::Application.routes.draw do
 
   namespace :api do
     get 'items/download/:id', as: 'item_download', controller: 'downloads', action: 'download'
-    resources :items, only: [:show, :index]
+    resources :items, only: [:show, :index], defaults: { :format => 'json' }
     resources :access_tokens, only: [:new, :index, :create, :destroy]
     match 'uploads/new', as: 'trx_initiate', controller: 'uploads', action: 'trx_initiate', via: [:get, :post]
     post 'uploads/:tid/file/new', as: 'trx_new_file', controller: 'uploads', action: 'trx_new_file'


### PR DESCRIPTION
Json remains the default format so interface remains unchanged.
Allows either xml or json response for search and show requests.

Request formatted as `/api/items.xml`

CURATE-274