### PR TITLE
Add messages for related files

### DIFF
--- a/app/controllers/common_objects_controller.rb
+++ b/app/controllers/common_objects_controller.rb
@@ -87,4 +87,11 @@ class CommonObjectsController < ApplicationController
   def show_tombstone_page
     'curation_concern/base/tombstone'
   end
+
+  def show_file_text
+    return "Please access via the DOI." if curation_concern.respond_to?(:doi) && !curation_concern.doi.blank?
+    return "Please access via the source shown above." if curation_concern.respond_to?(:source) && !curation_concern.source.blank?
+    return "Please contact the department listed above for additional information about this #{curation_concern.human_readable_type.downcase}." if curation_concern.respond_to?(:administrative_unit) && !curation_concern.administrative_unit.blank?
+    "Please contact the creator for more information."
+  end
 end

--- a/app/views/curation_concern/base/_related_files.html.erb
+++ b/app/views/curation_concern/base/_related_files.html.erb
@@ -2,10 +2,10 @@
 <% editor = can?(:edit, curation_concern)%>
 
 <section id="attached-files">
+  <h2>Files</h2>
   <% if curation_concern.respond_to?(:generic_files) %>
     <% (files_solr_response, files) = curation_concern.generic_files_page(params[:files_page].to_i, params[:files_per_page].to_i) %>
     <% if files.any? %>
-      <h2>Files</h2>
       <table class="table table-striped related-files">
         <thead>
           <tr>
@@ -33,19 +33,22 @@
       <div class="pager">
         <%= paginate_rsolr_response files_solr_response, :outer_window => 2, :theme => 'blacklight', param_name: :files_page, solr_response: files_solr_response %>
       </div>
-      <% elsif editor %>
-        <h2>Files</h2>
-        <p><em>This <%= curation_concern.human_readable_type.downcase %> has no files associated with it.
-          <br />You must attach at least one file to choose a thumbnail for this <%= curation_concern.human_readable_type.downcase %>.
-        </em></p>
-      <% end %>
-      <% if editor %>
-        <div class="section-actions">
-          <%= link_to new_curation_concern_generic_file_path(curation_concern), class: 'btn' do %>
-            <i class="icon icon-upload"></i> Attach a File
-          <% end %>
-        </div>
-      <% end %>
+    <% elsif editor %>
+      <p><em>This <%= curation_concern.human_readable_type.downcase %> has no files associated with it.
+        <br />You must attach at least one file to choose a thumbnail for this <%= curation_concern.human_readable_type.downcase %>.
+      </em></p>
+    <% else %>
+      <p><em>This <%= curation_concern.human_readable_type.downcase %> has no files associated with it.
+      <%= controller.show_file_text if controller.respond_to?(:show_file_text) %>
+      </em></p>
     <% end %>
+    <% if editor %>
+      <div class="section-actions">
+        <%= link_to new_curation_concern_generic_file_path(curation_concern), class: 'btn' do %>
+          <i class="icon icon-upload"></i> Attach a File
+        <% end %>
+      </div>
+    <% end %>
+  <% end %>
 </section>
 <% end %>


### PR DESCRIPTION
When a work has no related files attached, add messages to clarify how a viewer can access the work.

Completes CURATE-238