### PR TITLE
Fix missing ND logo

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -36,6 +36,7 @@ class StaticPagesController < ApplicationController
   end
 
   def policies
+    @hide_title = false;
     render 'policies', layout: 'curate_nd_home'
   end
 


### PR DESCRIPTION
Refers to CURATE-267
New page is missing the CurateND logo