### PR TITLE
Ability to orphan a file

### DIFF
--- a/app/assets/stylesheets/layout/positioning.scss
+++ b/app/assets/stylesheets/layout/positioning.scss
@@ -8,6 +8,11 @@ body {
   margin-bottom: 0;
 }
 
+.same-line {
+  display: inline-block;
+  margin-bottom: 0;
+}
+
 .site-search {
   form {
     margin: 1em 0;

--- a/app/assets/stylesheets/layout/positioning.scss
+++ b/app/assets/stylesheets/layout/positioning.scss
@@ -13,6 +13,10 @@ body {
   margin-bottom: 0;
 }
 
+.shift-right {
+  margin-left: 2em;
+}
+
 .site-search {
   form {
     margin: 1em 0;

--- a/app/controllers/curation_concern/generic_files_controller.rb
+++ b/app/controllers/curation_concern/generic_files_controller.rb
@@ -95,6 +95,12 @@ class CurationConcern::GenericFilesController < CurationConcern::BaseController
     redirect_to common_object_path(curation_concern)
   end
 
+  def orphan
+    result = OrphanFileService.orphan_file(file_id: curation_concern.pid, requested_by: current_user)
+    notice = (result == true ? 'File has been successfully orphaned' : 'Unable to orphan this file')
+    redirect_to common_object_path(curation_concern), notice: notice
+  end
+
   register :actor do
     CurationConcern::Utility.actor(curation_concern, current_user, attributes_for_actor)
   end

--- a/app/controllers/curation_concern/generic_files_controller.rb
+++ b/app/controllers/curation_concern/generic_files_controller.rb
@@ -96,8 +96,13 @@ class CurationConcern::GenericFilesController < CurationConcern::BaseController
   end
 
   def orphan
+    parent_id = begin
+      curation_concern.parent.id
+    rescue
+      "null"
+    end
     result = OrphanFileService.orphan_file(file_id: curation_concern.pid, requested_by: current_user)
-    notice = (result == true ? 'File has been successfully orphaned' : 'Unable to orphan this file')
+    notice = (result == true ? "File has been successfully orphaned from parent '#{ parent_id}'" : 'Unable to orphan this file')
     redirect_to common_object_path(curation_concern), notice: notice
   end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -23,8 +23,10 @@ class Ability
 
       if super_administrators.include?(current_user.to_s)
         can [:manage], Admin::AuthorityGroup
+        can [:orphan], GenericFile
       else
         cannot [:manage], Admin::AuthorityGroup
+        cannot [:orphan], GenericFile
       end
 
       if repository_administrators.include?(current_user.to_s)

--- a/app/services/orphan_file_service.rb
+++ b/app/services/orphan_file_service.rb
@@ -1,0 +1,31 @@
+class OrphanFileService
+  def self.orphan_file(file_id:, requested_by:)
+    return false unless requested_by.can?(:orphan, GenericFile)
+    @object = find_object(file_id)
+    return false unless @object
+    remove_parent!
+    @object = find_object(file_id) #reload updated object
+    @object.update_index
+    true
+  end
+
+  def self.remove_parent!
+    ds = @object.datastreams["RELS-EXT"].to_rels_ext
+    ds_array = ds.lines
+    ds_array.each do |line|
+        ds_array -= [line] if line.include?('fedora-relations-model:isPartOf')
+    end
+    newds = ds_array.join('')
+    @object.datastreams["RELS-EXT"].content = newds
+    @object.save
+    true
+  end
+
+  def self.find_object(file_id)
+    begin
+      abc = GenericFile.find(file_id)
+    rescue ActiveFedora::ObjectNotFoundError
+      return nil
+    end
+  end
+end

--- a/app/services/orphan_file_service.rb
+++ b/app/services/orphan_file_service.rb
@@ -9,6 +9,8 @@ class OrphanFileService
     true
   end
 
+  private
+
   def self.remove_parent!
     ds = @object.datastreams["RELS-EXT"].to_rels_ext
     ds_array = ds.lines

--- a/app/views/common_objects/show.html.erb
+++ b/app/views/common_objects/show.html.erb
@@ -53,8 +53,10 @@
       </div>
     <% end %>
     <% if has_edit_rights %>
+        <div class="same-line shift-right">
         <%= mail_to('curate@nd.edu', subject: "Requesting removal of file", body: "I am requesting removal of file #{curation_concern.title} located in CurateND at #{Rails.configuration.application_root_url+common_object_path(curation_concern)}.") do %>
         <i class="icon icon-trash"></i> Request File Removal <% end %>
+        </div>
     <% end %>
   <% when FindingAid %>
     <%# Only display file list of finding aids to editors. See DLTP-1304 %>

--- a/app/views/common_objects/show.html.erb
+++ b/app/views/common_objects/show.html.erb
@@ -34,6 +34,9 @@
     <% if RepoManager.with_active_privileges?(current_user) %>
       <%= link_to 'Reindex this Item', admin_reindex_pid_path(curation_concern.id) , class: 'btn btn-primary' %>
     <% end %>
+    <% if curation_concern.is_a?(GenericFile) && can?(:orphan, GenericFile) %>
+      <%= link_to 'Orphan File', orphan_path(id: curation_concern.noid) , class: 'btn btn-danger' %>
+    <% end %>
 <% end %>
 
 <% details = capture do %>

--- a/app/views/common_objects/show.html.erb
+++ b/app/views/common_objects/show.html.erb
@@ -47,8 +47,14 @@
   <% case curation_concern %>
   <% when GenericFile %>
     <% if has_read_rights %>
+      <div class="same-line">
       <% bendo_datastream = Bendo::DatastreamPresenter.new(datastream: curation_concern.datastreams.fetch('content')) %>
       <%= render 'curation_concern/base/download_file_button', generic_file: curation_concern, bendo_datastream: bendo_datastream %>
+      </div>
+    <% end %>
+    <% if has_edit_rights %>
+        <%= mail_to('curate@nd.edu', subject: "Requesting removal of file", body: "I am requesting removal of file #{curation_concern.title} located in CurateND at #{Rails.configuration.application_root_url+common_object_path(curation_concern)}.") do %>
+        <i class="icon icon-trash"></i> Request File Removal <% end %>
     <% end %>
   <% when FindingAid %>
     <%# Only display file list of finding aids to editors. See DLTP-1304 %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -169,6 +169,7 @@ CurateNd::Application.routes.draw do
 
   get'/usage/:id(.:format)', to: 'metrics/usage#show', as: 'metrics_usage'
   get'/characterize/:id', to: 'curation_concern/generic_files#characterize_file', as: 'characterize'
+  get'/orphan/:id', to: 'curation_concern/generic_files#orphan', as: 'orphan'
 
   get 'get_started', to: redirect('deposit')
   get 'deposit', to: 'classify_concerns#new'

--- a/spec/services/orphan_file_service_spec.rb
+++ b/spec/services/orphan_file_service_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe OrphanFileService do
+  let(:subject) { OrphanFileService.orphan_file(file_id: my_file.pid, requested_by: some_user) }
+  let(:authorized_user) { FactoryGirl.create(:user) }
+  let(:my_article) { FactoryGirl.create_curation_concern(:article, user2) }
+  let(:my_file) { FactoryGirl.create_generic_file(my_article, user2) }
+  let(:user2) { FactoryGirl.create(:user) }
+  let!(:super_admin) { FactoryGirl.create(:super_admin_grp, authorized_usernames: authorized_user.username) }
+
+  before do
+    my_file
+    super_admin
+  end
+
+  context 'with ability to orphan a file' do
+    let(:some_user) { authorized_user }
+    it 'orphans the file and returns true' do
+      expect(subject).to eq true
+      expect(GenericFile.find(my_file.pid).parent).to be nil
+    end
+  end
+
+  context 'when file is not found' do
+    let(:some_user) { authorized_user }
+    before do
+      allow(GenericFile).to receive(:find).and_return(nil)
+    end
+    it 'returns false' do
+      expect(subject).to eq false
+    end
+  end
+
+  context 'without ability to orphan a file' do
+    let(:some_user) { user2 }
+    it 'returns false and does not remove parent' do
+      expect(subject).to eq false
+      expect(GenericFile.find(my_file.pid).parent).to eq(my_article)
+    end
+  end
+end


### PR DESCRIPTION
Add a button for users with super admin rights to be able to orphan a file. Also adds email link for user with edit rights to contact with a request to remove file.

This provides an automated method to disconnect a file from a work when removal is requested, bypassing Fedora's issues with actually deleting an object. 

Completes CURATE-299.