### PR TITLE
Create new users for API use only

### DIFF
--- a/app/controllers/api/access_tokens_controller.rb
+++ b/app/controllers/api/access_tokens_controller.rb
@@ -37,7 +37,7 @@ module Api
       def api_access_token_list
         @api_access_tokens =
         begin
-          if can? :manage, ApiAccessToken
+          if can? :edit, ApiAccessToken
             @api_access_tokens = ApiAccessToken.all
           else
             @api_access_tokens = ApiAccessToken.where(issued_by: current_user.user_key)
@@ -63,7 +63,7 @@ module Api
 
       def api_access_token_params_with_user
         param_list = api_access_token_params.merge!({ :issued_by => current_user.user_key })
-        if cannot? :manage, ApiAccessToken
+        if cannot? :edit, ApiAccessToken
           param_list[:user_id] = params[:api_access_token][:user_id]
         end
         param_list

--- a/app/controllers/api/app_users_controller.rb
+++ b/app/controllers/api/app_users_controller.rb
@@ -1,0 +1,45 @@
+module Api
+  class AppUsersController < ApplicationController
+    with_themed_layout '1_column'
+  # permits creation of basic user for api data access equal to registered access
+
+    # GET /api/app_users/new
+    def new
+      if cannot? :manage, ApiAccessToken
+        redirect_to new_api_access_token_path, notice: 'Not authorized to create an API app user'
+      end
+    end
+
+    # POST /api/access_tokens
+    def create
+      api_user = (params.has_key?(:new_api_user) ?  params.fetch(:new_api_user) : nil)
+      if api_user && (can? :manage, ApiAccessToken)
+        if user_exists?(username: api_user[:user_name])
+          redirect_to api_app_users_new_path, notice: "Username #{api_user[:user_name]} already exists"
+        else
+          create_app_user(username: api_user[:user_name], name: api_user[:application])
+          redirect_to new_api_access_token_path, notice: "User #{api_user[:user_name]} has been created"
+        end
+      else
+        redirect_to new_api_access_token_path, notice: "Cannot create API app user"
+      end
+    end
+
+    private
+
+    # validate unique user before proceeding
+    def user_exists?(username:)
+      return true if User.find_by(username: username)
+      false
+    end
+
+    # Creates a new user without duplicating usernames
+    def create_app_user(username:, name:)
+      user = User.find_or_create_by(username: name) do |u|
+        u.username = username
+        u.name = name
+      end
+      user
+    end
+  end
+end

--- a/app/controllers/api/app_users_controller.rb
+++ b/app/controllers/api/app_users_controller.rb
@@ -1,19 +1,16 @@
 module Api
   class AppUsersController < ApplicationController
     with_themed_layout '1_column'
+    before_filter :validate_permissions!
   # permits creation of basic user for api data access equal to registered access
 
     # GET /api/app_users/new
     def new
-      if cannot? :manage, ApiAccessToken
-        redirect_to new_api_access_token_path, notice: 'Not authorized to create an API app user'
-      end
     end
 
-    # POST /api/access_tokens
     def create
       api_user = (params.has_key?(:new_api_user) ?  params.fetch(:new_api_user) : nil)
-      if api_user && (can? :manage, ApiAccessToken)
+      if api_user
         if user_exists?(username: api_user[:user_name])
           redirect_to api_app_users_new_path, notice: "Username #{api_user[:user_name]} already exists"
         else
@@ -40,6 +37,12 @@ module Api
         u.name = name
       end
       user
+    end
+
+    def validate_permissions!
+      if current_ability.cannot? :manage, ApiAccessToken
+        redirect_to new_api_access_token_path, notice: 'Not authorized to create an API app user'
+      end
     end
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -97,10 +97,15 @@ class Ability
   end
 
   def api_token_permissions
-    if CurateND::AdminConstraint.is_admin?(current_user)
+    # no special authority = able to create token for self & view own tokens
+    # edit = able to create token for all users & view all tokens
+    # manage = edit permissions + able to create api only users
+    if super_administrators.include?(current_user.to_s)
       can [:manage], ApiAccessToken
+    elsif CurateND::AdminConstraint.is_admin?(current_user)
+      can [:edit], ApiAccessToken
     else
-      cannot [:manage], ApiAccessToken
+      cannot [:edit, :manage], ApiAccessToken
     end
   end
 

--- a/app/views/api/access_tokens/_form.html.erb
+++ b/app/views/api/access_tokens/_form.html.erb
@@ -1,11 +1,17 @@
 <%= simple_form_for(@api_access_token) do |f| %>
   <%= f.error_notification %>
 
-  <fieldset>
-    <%= f.association :user, label: "Create token for user", :label_method => lambda { |user| "#{user.name}" }, selected: current_user.id %>
-  </fieldset>
+    <fieldset>
+      <div class='same-line'>
+        <%= f.association :user, label: "Create token for user", :label_method => lambda { |user| "#{user.name} (#{user.username})" }, selected: current_user.id, input_html: { class: 'input-xlarge' } %>
+      </div>
+      <div class='same-line pull-right'>
+        <%= link_to 'Create Application User', api_app_users_new_path %>
+      </div>
+    </fieldset>
 
   <div class="form-actions">
     <%= f.button :submit, 'Create API Token', class: 'btn btn-danger' %>
+    <%= link_to 'Back', api_access_tokens_path %>
   </div>
 <% end %>

--- a/app/views/api/access_tokens/_form.html.erb
+++ b/app/views/api/access_tokens/_form.html.erb
@@ -5,9 +5,11 @@
       <div class='same-line'>
         <%= f.association :user, label: "Create token for user", :label_method => lambda { |user| "#{user.name} (#{user.username})" }, selected: current_user.id, input_html: { class: 'input-xlarge' } %>
       </div>
-      <div class='same-line pull-right'>
-        <%= link_to 'Create Application User', api_app_users_new_path %>
-      </div>
+      <% if can? :manage, ApiAccessToken %>
+        <div class='same-line pull-right'>
+          <%= link_to 'Create Application User', api_app_users_new_path %>
+        </div>
+      <% end %>
     </fieldset>
 
   <div class="form-actions">

--- a/app/views/api/access_tokens/index.html.erb
+++ b/app/views/api/access_tokens/index.html.erb
@@ -8,7 +8,7 @@
   <h1>API Access Token List</h1>
 <% end %>
 
-<% if current_user.can? :manage, ApiAccessToken %>
+<% if current_user.can? :edit, ApiAccessToken %>
   <%= link_to 'Create New Token', new_api_access_token_path, { class: "btn btn-success" } %>
 <% else %>
   <%= link_to 'Create New Token', new_api_access_token_path(api_access_token: { user_id: current_user.id }), class: 'btn btn-success' %>

--- a/app/views/api/access_tokens/new.html.erb
+++ b/app/views/api/access_tokens/new.html.erb
@@ -1,4 +1,4 @@
-<h1>New api_access_token</h1>
+<h1>Create API Access Token</h1>
 
 <%= render 'form' %>
 

--- a/app/views/api/app_users/_form.html.erb
+++ b/app/views/api/app_users/_form.html.erb
@@ -1,0 +1,13 @@
+<%= simple_form_for :new_api_user, url: api_app_users_new_path do |f| %>
+  <div class='same-line'>
+  <%= f.input :user_name, label: "Username" %>
+  </div>
+  <div class='same-line'>
+    <%= f.input :application, label: "Application Name" %>
+  </div>
+
+  <div class="form-actions">
+    <%= f.button :submit, 'Create App User', class: 'btn btn-danger' %>
+    <%= link_to 'Back', api_access_tokens_path %>
+  </div>
+<% end %>

--- a/app/views/api/app_users/new.html.erb
+++ b/app/views/api/app_users/new.html.erb
@@ -1,0 +1,5 @@
+<h1>Create API App User</h1>
+
+<%= render 'form' %>
+
+<%= link_to 'Back', new_api_access_token_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -128,6 +128,8 @@ CurateNd::Application.routes.draw do
     get 'items/download/:id', as: 'item_download', controller: 'downloads', action: 'download'
     resources :items, only: [:show, :index], defaults: { :format => 'json' }
     resources :access_tokens, only: [:new, :index, :create, :destroy]
+    get 'app_users/new'
+    post 'app_users/new', as: 'app_users_create', controller: 'app_users', action: 'create'
     match 'uploads/new', as: 'trx_initiate', controller: 'uploads', action: 'trx_initiate', via: [:get, :post]
     post 'uploads/:tid/file/new', as: 'trx_new_file', controller: 'uploads', action: 'trx_new_file'
     post 'uploads/:tid/file/:fid', as: 'trx_append', controller: 'uploads', action: 'trx_append'

--- a/spec/models/admin/authority_group/super_admin_spec.rb
+++ b/spec/models/admin/authority_group/super_admin_spec.rb
@@ -19,5 +19,12 @@ describe Admin::AuthorityGroup::SuperAdmin do
     it 'is also an admin' do
       expect(CurateND::AdminConstraint.is_admin?(user1)).to be_truthy
     end
+
+    it 'gives additional authority' do
+      expect(user1.can?(:orphan, GenericFile)).to be_truthy
+      expect(user1.can?(:manage, ApiAccessToken)).to be_truthy
+      expect(user2.can?(:orphan, GenericFile)).to be_falsey
+      expect(user2.can?(:manage, ApiAccessToken)).to be_falsey
+    end
   end
 end


### PR DESCRIPTION
Adds screens to create a new user for API access. The new user can be assigned an API access token, which allows access to content with "registered" visiblity via the Curate API. This user has no ability to sign-in and access Curate through the UI.

This allows for the assignment of API tokens for use by various applications to not be tied to any particular user's netid.

Super admin can create api users for applications.
Admin can create tokens for any user but not create api users.
Other users can create tokens for themself only.

CURATE-266