### PR TITLE
Fix Long Seach

### DIFF
--- a/app/assets/stylesheets/modules/search_constraints.scss
+++ b/app/assets/stylesheets/modules/search_constraints.scss
@@ -11,12 +11,15 @@
   }
 
   .applied-filter {
-    direction: ltr;
+    white-space: normal;
   }
 
   .applied-constraints {
-    direction: rtl;
-    overflow-y: auto;
+    .btn {
+      text-align: left;
+      max-width: 88%;
+      vertical-align:top;
+    }
   }
 
   .btn-group + .btn-group {


### PR DESCRIPTION
A long search term was not wrapping, and resulted in a long scroll to
get to the "x" to remove the term. This PR modifies the CSS to result in
wrapping rather than showing the term all in one line with a scroll bar.