### PR TITLE
Ensuring that we can skip mysql password

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ bundle install --without headless
 ```console
 bundle exec rake curatend:jetty:start
 ```
+### 1.a Skipping MySQL password
+
+You may consider adding `export SKIP_MYSQL_PASSWORD_FOR_LOCAL_DEVELOPMENT="true"` (or adding this to your `.bashrc` or `.profile`).  That export will tell the Rails configuration to skip using a password for the `config/database.yml` user in the local environment.
 
 ### 2. Run specs
 To execute the full test suite, run

--- a/config/database.yml
+++ b/config/database.yml
@@ -33,7 +33,9 @@ local_user: &local_user
   <<: *mysql_settings
   <<: *mysql_connection
   username: root
-  password: password
+<% if ! ENV['SKIP_MYSQL_PASSWORD_FOR_LOCAL_DEVELOPMENT'] %>
+  password: root
+<% end %>
 
 development: &development
   <<: *local_user


### PR DESCRIPTION
With this change, you no longer need a mysql password.

In your shell, you can add the following:

```
export SKIP_MYSQL_PASSWORD_FOR_LOCAL_DEVELOPMENT="true"
```

I added the above line to my `config/aliases.zsh`, which should
propogate through my tests.

See https://github.com/ndlib/sipity/commit/bdbec73f77e9db993d479c0b2f0a9f3b9173e788