### PR TITLE
Clean up doi

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -376,7 +376,7 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name("desc_metadata__rights", :stored_searchable, type: :string), label: "Rights"
     config.add_index_field solr_name("human_readable_type", :stored_searchable, type: :string), label: "Resource Type"
     config.add_index_field solr_name("desc_metadata__format", :stored_searchable, type: :string), label: "File Format"
-    config.add_index_field solr_name("desc_metadata__identifier", :stored_searchable, type: :string), label: "Identifier"
+    config.add_index_field solr_name("desc_metadata__identifier", :stored_searchable, type: :string), label: "DOI Identifier"
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
@@ -395,7 +395,7 @@ class CatalogController < ApplicationController
     config.add_show_field solr_name("desc_metadata__rights", :stored_searchable, type: :string), label: "Rights"
     config.add_show_field solr_name("human_readable_type", :stored_searchable, type: :string), label: "Resource Type"
     config.add_show_field solr_name("desc_metadata__format", :stored_searchable, type: :string), label: "File Format"
-    config.add_show_field solr_name("desc_metadata__identifier", :stored_searchable, type: :string), label: "Identifier"
+    config.add_show_field solr_name("desc_metadata__identifier", :stored_searchable, type: :string), label: "DOI Identifier"
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields
@@ -427,7 +427,7 @@ class CatalogController < ApplicationController
       contributor_institution_name = solr_name("desc_metadata__contributor_institution", :stored_searchable, type: :string)
       subject_name = solr_name("desc_metadata__subject", :stored_searchable, type: :string)
       author_name = solr_name("desc_metadata__author", :stored_searchable, type: :string)
-      identifier_name = solr_name("desc_metadata__identifier", :facetable, type: :string)
+      identifier_name = solr_name("desc_metadata__identifier", :stored_searchable, type: :string)
       urn  = solr_name("desc_metadata__urn", :stored_searchable, type: :string)
       degree_name  = solr_name("degree_name", :stored_searchable, type: :string)
       degree_disciplines = solr_name("degree_disciplines", :stored_searchable, type: :string)
@@ -583,7 +583,7 @@ class CatalogController < ApplicationController
       field.solr_parameters = {
         :"spellcheck.dictionary" => "identifier"
       }
-      solr_name = solr_name("desc_metadata__id", :stored_searchable, type: :string)
+      solr_name = solr_name("desc_metadata__identifier", :stored_searchable, type: :string)
       field.solr_local_parameters = {
         :qf => solr_name,
         :pf => solr_name

--- a/app/repository_datastreams/article_metadata_datastream.rb
+++ b/app/repository_datastreams/article_metadata_datastream.rb
@@ -122,13 +122,15 @@ class ArticleMetadataDatastream < ActiveFedora::NtriplesRDFDatastream
 
     map.size({to: "format#extent", in: RDF::QualifiedDC})
 
-    map.identifier({to: 'identifier#doi', in: RDF::QualifiedDC}) do |index|
-      index.as :stored_searchable, :facetable
+    map.basic_identifier({to: 'identifier', in: RDF::DC}) do |index|
+      index.as :stored_searchable
+    end
+
+    map.doi(to: "identifier#doi", in: RDF::QualifiedDC) do |index|
+      index.as :stored_searchable
     end
 
     map.issn({to: 'identifier#issn', in: RDF::QualifiedDC})
-
-    map.doi({to: 'identifier#doi', in: RDF::QualifiedDC})
 
     map.source(to: 'source', in: RDF::DC) do |index|
       index.type :text

--- a/app/repository_datastreams/audio_datastream.rb
+++ b/app/repository_datastreams/audio_datastream.rb
@@ -127,6 +127,9 @@ class AudioDatastream < ActiveFedora::NtriplesRDFDatastream
       index.as :stored_sortable
     end
 
+    map.basic_identifier({to: 'identifier', in: RDF::DC}) do |index|
+      index.as :stored_searchable
+    end
     map.doi(to: 'identifier#doi', in: RDF::QualifiedDC) do |index|
       index.as :stored_searchable
     end

--- a/app/repository_datastreams/catholic_document_datastream.rb
+++ b/app/repository_datastreams/catholic_document_datastream.rb
@@ -99,6 +99,9 @@ class CatholicDocumentDatastream < ActiveFedora::NtriplesRDFDatastream
       index.as :stored_searchable, :facetable
     end
 
+    map.basic_identifier({to: 'identifier', in: RDF::DC}) do |index|
+      index.as :stored_searchable
+    end
     map.doi(to: 'identifier#doi', in: RDF::QualifiedDC) do |index|
       index.as :stored_searchable
     end

--- a/app/repository_datastreams/dataset_metadata_datastream.rb
+++ b/app/repository_datastreams/dataset_metadata_datastream.rb
@@ -67,11 +67,12 @@ class DatasetMetadataDatastream < ActiveFedora::NtriplesRDFDatastream
       index.as :stored_searchable, :facetable
     end
 
-    map.identifier({to: 'identifier#doi', in: RDF::QualifiedDC}) do |index|
-      index.as :stored_searchable,:facetable
+    map.basic_identifier({to: 'identifier', in: RDF::DC}) do |index|
+      index.as :stored_searchable
     end
-
-    map.doi({to: 'identifier#doi', in: RDF::QualifiedDC})
+    map.doi(to: "identifier#doi", in: RDF::QualifiedDC) do |index|
+      index.as :stored_searchable
+    end
 
     map.permission(to: 'rights#permissions', in: RDF::QualifiedDC)
 

--- a/app/repository_datastreams/dissertation_datastream.rb
+++ b/app/repository_datastreams/dissertation_datastream.rb
@@ -89,11 +89,10 @@ class DissertationDatastream < ActiveFedora::NtriplesRDFDatastream
     map.coverage_temporal(to: "coverage#temporal", in: RDF::QualifiedDC) do |index|
       index.as :stored_searchable, :facetable
     end
-
-    map.identifier(in: RDF::DC) do |index|
-      index.as :stored_searchable,:facetable
+ 
+    map.basic_identifier({to: 'identifier', in: RDF::DC}) do |index|
+      index.as :stored_searchable
     end
-
     map.doi(to: "identifier#doi", in: RDF::QualifiedDC) do |index|
       index.as :stored_searchable
     end

--- a/app/repository_datastreams/document_datastream.rb
+++ b/app/repository_datastreams/document_datastream.rb
@@ -75,10 +75,11 @@ class DocumentDatastream < ActiveFedora::NtriplesRDFDatastream
 
     map.recommended_citation(to: 'bibliographicCitation', in: RDF::DC)
 
-    map.doi(to: 'identifier#doi', in: RDF::QualifiedDC)
-
-    map.identifier(to: 'identifier#doi', in: RDF::QualifiedDC) do |index|
-      index.as :stored_searchable,:facetable
+    map.basic_identifier({to: 'identifier', in: RDF::DC}) do |index|
+      index.as :stored_searchable
+    end
+    map.doi(to: "identifier#doi", in: RDF::QualifiedDC) do |index|
+      index.as :stored_searchable
     end
 
     map.permission(to: 'rights#permissions', in: RDF::QualifiedDC)

--- a/app/repository_datastreams/etd_metadata.rb
+++ b/app/repository_datastreams/etd_metadata.rb
@@ -84,14 +84,13 @@ class EtdMetadata < ActiveFedora::NtriplesRDFDatastream
 
     map.code_list(to: 'description#code_list', in: RDF::QualifiedDC)
 
-    map.identifier(in: RDF::DC) do |index|
-      index.as :stored_searchable,:facetable
-    end
-
     map.urn(to: "identifier#other", in: RDF::QualifiedDC) do |index|
       index.as :stored_searchable, :symbol
     end
 
+    map.basic_identifier({to: 'identifier', in: RDF::DC}) do |index|
+      index.as :stored_searchable
+    end
     map.doi(to: "identifier#doi", in: RDF::QualifiedDC) do |index|
       index.as :stored_searchable
     end

--- a/app/repository_datastreams/finding_aid_rdf_datastream.rb
+++ b/app/repository_datastreams/finding_aid_rdf_datastream.rb
@@ -44,7 +44,9 @@ class FindingAidRdfDatastream < ActiveFedora::NtriplesRDFDatastream
       index.as :stored_searchable, :displayable, :facetable
     end
 
-    map.identifier({in: RDF::DC})
+    map.basic_identifier({to: 'identifier', in: RDF::DC}) do |index|
+      index.as :stored_searchable
+    end
 
     map.part(:to => "hasPart", in: RDF::DC)
 

--- a/app/repository_datastreams/generic_file_rdf_datastream.rb
+++ b/app/repository_datastreams/generic_file_rdf_datastream.rb
@@ -43,7 +43,10 @@ class GenericFileRdfDatastream < ActiveFedora::NtriplesRDFDatastream
     map.language(:in => RDF::DC) do |index|
       index.as :stored_searchable, :facetable
     end
-    map.identifier(:in => RDF::DC) do |index|
+    map.basic_identifier({to: 'identifier', in: RDF::DC}) do |index|
+      index.as :stored_searchable
+    end
+    map.doi(to: "identifier#doi", in: RDF::QualifiedDC) do |index|
       index.as :stored_searchable
     end
     map.based_near(:in => RDF::FOAF) do |index|

--- a/app/repository_datastreams/generic_work_rdf_datastream.rb
+++ b/app/repository_datastreams/generic_work_rdf_datastream.rb
@@ -85,7 +85,10 @@ class GenericWorkRdfDatastream < ActiveFedora::NtriplesRDFDatastream
 
     map.requires({in: RDF::DC})
 
-    map.identifier({in: RDF::DC}) do |index|
+    map.basic_identifier({to: 'identifier', in: RDF::DC}) do |index|
+      index.as :stored_searchable
+    end
+    map.doi(to: "identifier#doi", in: RDF::QualifiedDC) do |index|
       index.as :stored_searchable
     end
 

--- a/app/repository_datastreams/image_metadata.rb
+++ b/app/repository_datastreams/image_metadata.rb
@@ -64,11 +64,12 @@ class ImageMetadata < ActiveFedora::NtriplesRDFDatastream
       index.as :stored_sortable
     end
 
-    map.identifier({to: 'identifier#doi', in: RDF::QualifiedDC}) do |index|
-      index.as :stored_searchable,:facetable
+    map.basic_identifier({to: 'identifier', in: RDF::DC}) do |index|
+      index.as :stored_searchable
     end
-
-    map.doi(to: "identifier#doi", in: RDF::QualifiedDC)
+    map.doi(to: "identifier#doi", in: RDF::QualifiedDC) do |index|
+      index.as :stored_searchable
+    end
 
     map.subject(in: RDF::DC) do |index|
       index.as :stored_searchable, :facetable

--- a/app/repository_datastreams/osf_archive_datastream.rb
+++ b/app/repository_datastreams/osf_archive_datastream.rb
@@ -57,6 +57,9 @@ class OsfArchiveDatastream < ActiveFedora::NtriplesRDFDatastream
 
     map.rights(to: 'rights', in: RDF::DC)
 
+    map.basic_identifier({to: 'identifier', in: RDF::DC}) do |index|
+      index.as :stored_searchable
+    end
     map.doi(to: 'identifier#doi', in: RDF::QualifiedDC) do |index|
       index.as :stored_searchable
     end

--- a/app/repository_datastreams/senior_thesis_rdf_datastream.rb
+++ b/app/repository_datastreams/senior_thesis_rdf_datastream.rb
@@ -88,7 +88,12 @@ class SeniorThesisRdfDatastream < ActiveFedora::NtriplesRDFDatastream
 
     map.requires({in: RDF::DC})
 
-    map.identifier({in: RDF::DC})
+    map.basic_identifier({to: 'identifier', in: RDF::DC}) do |index|
+      index.as :stored_searchable
+    end
+    map.doi(to: "identifier#doi", in: RDF::QualifiedDC) do |index|
+      index.as :stored_searchable
+    end
 
     map.part(:to => "hasPart", in: RDF::DC)
 

--- a/app/repository_datastreams/sufia/generic_file_rdf_datastream.rb
+++ b/app/repository_datastreams/sufia/generic_file_rdf_datastream.rb
@@ -45,7 +45,10 @@ module Sufia
       map.language(:in => RDF::DC) do |index|
         index.as :stored_searchable, :facetable
       end
-      map.identifier(:in => RDF::DC) do |index|
+      map.basic_identifier({to: 'identifier', in: RDF::DC}) do |index|
+        index.as :stored_searchable
+      end
+      map.doi(to: "identifier#doi", in: RDF::QualifiedDC) do |index|
         index.as :stored_searchable
       end
       map.based_near(:in => RDF::FOAF) do |index|

--- a/app/repository_datastreams/video_datastream.rb
+++ b/app/repository_datastreams/video_datastream.rb
@@ -125,6 +125,9 @@ class VideoDatastream < ActiveFedora::NtriplesRDFDatastream
       index.as :stored_sortable
     end
 
+    map.basic_identifier({to: 'identifier', in: RDF::DC}) do |index|
+      index.as :stored_searchable
+    end
     map.doi(to: 'identifier#doi', in: RDF::QualifiedDC) do |index|
       index.as :stored_searchable
     end

--- a/app/repository_models/article.rb
+++ b/app/repository_models/article.rb
@@ -127,17 +127,12 @@ class Article < ActiveFedora::Base
     datastream: :descMetadata, multiple: false
   attribute :temporal_coverage,
     datastream: :descMetadata, multiple: false
-  attribute :identifier,
-    datastream: :descMetadata, multiple: false,
-    editable: false
   attribute :issn,
     datastream: :descMetadata, multiple: false,
     editable: true
   attribute :eIssn,
     hint: "The electronic ISSN, or eISSN of the publication in which the article appeared.",
     datastream: :descMetadata, multiple: false
-  attribute :doi,
-    datastream: :descMetadata, editable: true
   attribute :rights,
     datastream: :descMetadata, multiple: false,
     default: "All rights reserved",

--- a/app/repository_models/audio.rb
+++ b/app/repository_models/audio.rb
@@ -116,8 +116,6 @@ class Audio < ActiveFedora::Base
     datastream: :descMetadata, multiple: false
   attribute :date_modified,
     datastream: :descMetadata, multiple: false
-  attribute :doi,
-    datastream: :descMetadata, multiple: false
   attribute :rights,
       datastream: :descMetadata, multiple: false,
       default: "All rights reserved",
@@ -128,7 +126,4 @@ class Audio < ActiveFedora::Base
   attribute :files,
     multiple: true, form: {as: :file}, label: "Upload Files",
     hint: "CTRL-Click (Windows) or CMD-Click (Mac) to select multiple files."
-
-  alias_method :identifier, :doi
-  alias_method :identifier=, :doi=
 end

--- a/app/repository_models/catholic_document.rb
+++ b/app/repository_models/catholic_document.rb
@@ -112,8 +112,6 @@ class CatholicDocument < ActiveFedora::Base
     datastream: :descMetadata, multiple: true,
     label: "Departments and Units",
     hint: "Departments and Units that creator belong to."
-  attribute :doi,
-    datastream: :descMetadata, multiple: false
   attribute :rights,
       datastream: :descMetadata, multiple: false,
       default: "All rights reserved",
@@ -131,7 +129,4 @@ class CatholicDocument < ActiveFedora::Base
   attribute :files,
     multiple: true, form: {as: :file}, label: "Upload Files",
     hint: "CTRL-Click (Windows) or CMD-Click (Mac) to select multiple files."
-
-  alias_method :identifier, :doi
-  alias_method :identifier=, :doi=
 end

--- a/app/repository_models/curation_concern/remotely_identified_by_doi.rb
+++ b/app/repository_models/curation_concern/remotely_identified_by_doi.rb
@@ -10,18 +10,29 @@ module CurationConcern
       extend ActiveSupport::Concern
       included do
         include ActiveFedora::RegisteredAttributes
-        attribute :identifier,
+        attribute :doi,
           datastream: :descMetadata,
-          multiple: false, editable: false, displayable: true
+          multiple: false
         attribute :doi_assignment_strategy,
-          multiple: false, editable: true, displayable: false
+          multiple: false
         attribute :existing_identifier,
-          multiple: false, editable: true, displayable: false,
+          multiple: false, 
           writer: lambda {|value| normalize_identifier(value) }
 
         validate :remove_white_space_in_doi
 
+        alias_method :identifier, :doi
+        alias_method :identifier=, :doi=
+
         attr_writer :doi_remote_service
+
+        # desc_metadata__doi_tesim is added automatically to solr (via active_fedora perhaps?) 
+        # This insures that desc_metadata__identifier_tesim is also present for backward compatibility.
+        def to_solr(solr_doc = {})
+          super
+          solr_doc['desc_metadata__identifier_tesim'] = self.doi
+          solr_doc
+        end
 
         protected
 

--- a/app/repository_models/curation_concern/with_standardized_metadata.rb
+++ b/app/repository_models/curation_concern/with_standardized_metadata.rb
@@ -105,7 +105,6 @@ module CurationConcern
     # alternate_title
     # application_date
     # artist
-    # assign_doi
     # author
     # available
     # based_near

--- a/app/repository_models/dataset.rb
+++ b/app/repository_models/dataset.rb
@@ -47,8 +47,6 @@ class Dataset < ActiveFedora::Base
   attribute :temporal_coverage,       datastream: :descMetadata, multiple: true
   attribute :spatial_coverage,        datastream: :descMetadata, multiple: true
   attribute :creator,                 datastream: :descMetadata, multiple: true
-  attribute :identifier,              datastream: :descMetadata, multiple: false
-  attribute :doi,                     datastream: :descMetadata, multiple: false
   attribute :permission,
     label: "Use Permission",
     datastream: :descMetadata, multiple: false

--- a/app/repository_models/dissertation.rb
+++ b/app/repository_models/dissertation.rb
@@ -129,8 +129,6 @@ class Dissertation < ActiveFedora::Base
       multiple: true,
       label: "Coverage Spatial",
       hint: " The general region that the materials are related to when applicable."
-    ds.attribute :identifier,
-      multiple: false
     ds.attribute :format,
       multiple: false,
       editable: false
@@ -158,14 +156,6 @@ class Dissertation < ActiveFedora::Base
           allow_blank: true,
           aleph_identifier: true
       }
-  end
-
-  def doi=(doi)
-    self.identifier = doi
-  end
-
-  def doi
-    self.identifier
   end
 
   attribute :files,

--- a/app/repository_models/document.rb
+++ b/app/repository_models/document.rb
@@ -89,8 +89,6 @@ class Document < ActiveFedora::Base
   attribute :collection_name,            datastream: :descMetadata, multiple: true
   attribute :contributor_institution,    datastream: :descMetadata, multiple: true
   attribute :recommended_citation,       datastream: :descMetadata, multiple: true
-  attribute :doi,                        datastream: :descMetadata, multiple: false
-  attribute :identifier,                 datastream: :descMetadata, multiple: false
   attribute :permission,
     label: "Use Permission",
     datastream: :descMetadata, multiple: false

--- a/app/repository_models/etd.rb
+++ b/app/repository_models/etd.rb
@@ -127,8 +127,6 @@ class Etd < ActiveFedora::Base
       multiple: true,
       label: "Coverage Spatial",
       hint: " The general region that the materials are related to when applicable."
-    ds.attribute :identifier,
-      multiple: false
     ds.attribute :format,
       multiple: false,
       editable: false
@@ -157,14 +155,6 @@ class Etd < ActiveFedora::Base
           allow_blank: true,
           aleph_identifier: true
       }
-  end
-
-  def doi=(doi)
-    self.identifier = doi
-  end
-
-  def doi
-    self.identifier
   end
 
   attribute :files,

--- a/app/repository_models/finding_aid.rb
+++ b/app/repository_models/finding_aid.rb
@@ -36,7 +36,7 @@ class FindingAid < ActiveFedora::Base
     datastream: :descMetadata, multiple: true,
     label: "Departments and Units",
     hint: "Departments and Units that creator belong to."
-  attribute :identifier, datastream: :descMetadata, multiple: false
+  attribute :basic_identifier, datastream: :descMetadata, multiple: false
   attribute :date_uploaded,
     default: lambda { Date.today.to_s("%Y-%m-%d") }
   attribute :date_modified,

--- a/app/repository_models/image.rb
+++ b/app/repository_models/image.rb
@@ -130,11 +130,7 @@ class Image < ActiveFedora::Base
       label: "Use Permission",
       multiple: false
 
-    ds.attribute :identifier,
-      multiple: false,
-      editable: false
-
-    ds.attribute :doi,
+    ds.attribute :basic_identifier,
       multiple: false,
       editable: false
 

--- a/app/repository_models/osf_archive.rb
+++ b/app/repository_models/osf_archive.rb
@@ -150,16 +150,9 @@ class OsfArchive < ActiveFedora::Base
     label: "Use Permission",
     datastream: :descMetadata, multiple: false
 
-  attribute :doi,
-    datastream: :descMetadata, multiple: false
-
   attribute :alephIdentifier, datastream: :descMetadata, multiple: true,
     validates: {
         allow_blank: true,
         aleph_identifier: true
     }
-
-  alias_method :identifier, :doi
-  alias_method :identifier=, :doi=
-
 end

--- a/app/repository_models/senior_thesis.rb
+++ b/app/repository_models/senior_thesis.rb
@@ -68,11 +68,6 @@ class SeniorThesis < ActiveFedora::Base
   attribute :publisher,
     default: ["University of Notre Dame"],
     datastream: :descMetadata, multiple: true
-  attribute :assign_doi,
-    label: 'Assign Digital Object Identifier (DOI)',
-    hint: "A Digital Object Identifier (DOI) is a permanent link to your Senior Thesis. It's an easy way for other people to cite your work",
-    displayable: false, multiple: false,
-    default: true
   attribute :rights,
     datastream: :descMetadata, multiple: false,
     default: "All rights reserved",
@@ -142,9 +137,6 @@ class SeniorThesis < ActiveFedora::Base
   def citation
     @citation ||= Citation.new(self)
   end
-
-  alias_method :doi, :identifier
-  alias_method :doi=, :identifier=
 
   private
   def parse_person_names(values)

--- a/app/repository_models/video.rb
+++ b/app/repository_models/video.rb
@@ -112,8 +112,6 @@ class Video < ActiveFedora::Base
     datastream: :descMetadata, multiple: false
   attribute :date_modified,
     datastream: :descMetadata, multiple: false
-  attribute :doi,
-    datastream: :descMetadata, multiple: false
   attribute :rights,
       datastream: :descMetadata, multiple: false,
       default: "All rights reserved",
@@ -124,7 +122,4 @@ class Video < ActiveFedora::Base
   attribute :files,
     multiple: true, form: {as: :file}, label: "Upload Files",
     hint: "CTRL-Click (Windows) or CMD-Click (Mac) to select multiple files."
-
-  alias_method :identifier, :doi
-  alias_method :identifier=, :doi=
 end


### PR DESCRIPTION
Move all definitions to `remotely_identified_by_doi` module and make consistent
datastream definitions for object types which include DOIs.

1. Patents do use DOIs and also did not have identifier defined.
2. Finding aids do not use DOIs. 

All other work types which included module `remotely_identified_by_doi` will have DOI accessible via methods `doi` or alias `identifier` to access content from `identifier#doi`. Content is indexed into `desc_metadata__doi_tesim` but `desc_metadata__identifier_tesim` is also kept to minimize the extent of the changes

Method `basic_identifier` was also added to each model to map to `identifier` and is now indexed into 'desc_metadata__basic_identifier_tesim`

This resolves CURATE-344 (remediation will need to take place thru batch ingest), and prepares the way for a cleaner implementation of CURATE-337