### PR TITLE
Lock Browser Gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ group :default do
   gem 'breach-mitigation-rails'
   gem 'breadcrumbs_on_rails'
   gem 'bundler', '< 2.0'
-  gem 'browser'
+  gem 'browser', '< 5.2.0' # lock version to avoid NoMethodError - undefined method `match?' for Hash
   gem 'chronic', '>= 0.10.2'
   gem 'citeproc-ruby', '~> 1.1.0'
   gem 'citeproc'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,7 +155,7 @@ GEM
       activesupport
       rack
     breadcrumbs_on_rails (3.0.1)
-    browser (5.3.1)
+    browser (5.1.0)
     builder (3.2.4)
     byebug (9.0.6)
     cancan (1.6.10)
@@ -725,7 +725,7 @@ DEPENDENCIES
   brakeman
   breach-mitigation-rails
   breadcrumbs_on_rails
-  browser
+  browser (< 5.2.0)
   bundler (< 2.0)
   byebug (~> 9.0.6)
   capistrano (~> 2.15)


### PR DESCRIPTION
Help Requests were throwing an error originating in Browser gem.
`NoMethodError - undefined method 'match?'`

Locked gem to version prior to this error.

Completes CURATE-378

Created CURATE-384 ticket to address investigating the underlying error.