### PR TITLE
Add organization to ui

### DIFF
--- a/app/repository_models/article.rb
+++ b/app/repository_models/article.rb
@@ -32,8 +32,8 @@ class Article < ActiveFedora::Base
   attribute :affiliation,datastream: :descMetadata, hint: "Creator's Affiliation to the Institution.", multiple: false
   attribute :organization,
     datastream: :descMetadata, multiple: true,
-    label: "School & Department",
-    hint: "School and Department that creator belong to."
+    label: "Organization",
+    hint: "Organizations which creators belong to."
   attribute :administrative_unit,
     datastream: :descMetadata, multiple: true,
     label: "Departments and Units",

--- a/app/repository_models/dataset.rb
+++ b/app/repository_models/dataset.rb
@@ -29,8 +29,8 @@ class Dataset < ActiveFedora::Base
   attribute :affiliation,datastream: :descMetadata, hint: "Creator's Affiliation to the Institution.", multiple: false
   attribute :organization,
             datastream: :descMetadata, multiple: true,
-            label: "Departments and Units",
-            hint: "Departments and Units that creator belong to."
+            label: "Organization",
+            hint: "Organizations which creators belong to."
   attribute :administrative_unit,
             datastream: :descMetadata, multiple: true,
             label: "School & Department",

--- a/app/repository_models/dissertation.rb
+++ b/app/repository_models/dissertation.rb
@@ -60,8 +60,8 @@ class Dissertation < ActiveFedora::Base
     ds.attribute :affiliation,datastream: :descMetadata, hint: "Creator's Affiliation to the Institution.", multiple: false
     ds.attribute :organization,
               datastream: :descMetadata, multiple: true,
-              label: "School & Department",
-              hint: "School and Department that creator belong to."
+              label: "Organization",
+              hint: "Organizations which creators belong to."
     ds.attribute :administrative_unit,
               datastream: :descMetadata, multiple: true,
               label: "Departments and Units",

--- a/app/repository_models/document.rb
+++ b/app/repository_models/document.rb
@@ -155,8 +155,8 @@ class Document < ActiveFedora::Base
   # apparently unused(?)
   attribute :format,                     datastream: :descMetadata, multiple: false
   attribute :organization,               datastream: :descMetadata, multiple: true,
-            label: 'School & Department',
-            hint: 'School and Department that creator belong to.'
+            label: "Organization",
+            hint: "Organizations which creators belong to."
   attribute :alephIdentifier,         datastream: :descMetadata, multiple: true,
             validates: {
                 allow_blank: true,

--- a/app/repository_models/etd.rb
+++ b/app/repository_models/etd.rb
@@ -54,8 +54,8 @@ class Etd < ActiveFedora::Base
     ds.attribute :affiliation,datastream: :descMetadata, hint: "Creator's Affiliation to the Institution.", multiple: false
     ds.attribute :organization,
               datastream: :descMetadata, multiple: true,
-              label: "School & Department",
-              hint: "School and Department that creator belong to."
+              label: "Organization",
+              hint: "Organizations which creators belong to."
     ds.attribute :administrative_unit,
               datastream: :descMetadata, multiple: true,
               label: "Departments and Units",

--- a/app/repository_models/generic_work.rb
+++ b/app/repository_models/generic_work.rb
@@ -34,8 +34,8 @@ class GenericWork < ActiveFedora::Base
   attribute :affiliation,datastream: :descMetadata, hint: "Creator's Affiliation to the Institution.", multiple: false
   attribute :organization,
             datastream: :descMetadata, multiple: true,
-            label: "School & Department",
-            hint: "School and Department that creator belong to."
+            label: "Organization",
+            hint: "Organizations which creators belong to."
   attribute :administrative_unit,
             datastream: :descMetadata, multiple: true,
             label: "Departments and Units",

--- a/app/repository_models/image.rb
+++ b/app/repository_models/image.rb
@@ -41,8 +41,8 @@ class Image < ActiveFedora::Base
 
     ds.attribute :organization,
               datastream: :descMetadata, multiple: true,
-              label: "School & Department",
-              hint: "School and Department that creator belong to."
+              label: "Organization",
+              hint: "Organizations which creators belong to."
 
     ds.attribute :administrative_unit,
               datastream: :descMetadata, multiple: true,

--- a/app/views/curation_concern/articles/_attributes.html.erb
+++ b/app/views/curation_concern/articles/_attributes.html.erb
@@ -42,6 +42,7 @@
             "Catalog Record"
         ) %>
     <%= decode_administrative_unit(curation_concern, :administrative_unit, "Departments and Units") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :organization, "Creator Organization(s)") %>
     <%= curation_concern_attribute_to_html(curation_concern, :library_collections, "Member of") %>
     <%= curation_concern_attribute_to_html(curation_concern, :spatial_coverage, "Spatial Coverage") %>
     <%= curation_concern_attribute_to_html(curation_concern, :temporal_coverage, "Temporal Coverage") %>

--- a/app/views/curation_concern/articles/_form_additional_information.html.erb
+++ b/app/views/curation_concern/articles/_form_additional_information.html.erb
@@ -21,6 +21,7 @@
   <%= f.input :date_created,            input_html: { class: 'input-xxlarge datepicker' } %>
   <%= f.input :subject,                 as: :multi_value, input_html: { class: 'input-xxlarge' } %>
   <%= f.input :publisher,               as: :multi_value, label: 'Publisher', input_html: { class: 'input-xxlarge', id: 'publisher' } %>
+  <%= f.input :organization,            as: :multi_value, input_html: { class: 'input-xxlarge' } %>
   <%= f.input :recommended_citation,    as: :multi_value, input_html: { class: 'input-xxlarge' } %>
   <%= f.input :language,                as: :multi_value, input_html: { class: 'input-xxlarge' } %>
   <%= f.input :source,                  as: :multi_value, input_html: { class: 'input-xxlarge' } %>

--- a/app/views/curation_concern/datasets/_attributes.html.erb
+++ b/app/views/curation_concern/datasets/_attributes.html.erb
@@ -21,6 +21,7 @@
     <%= curation_concern_attribute_to_html(curation_concern, :relation, "Related Resource(s)") %>
     <%= curation_concern_attribute_to_html(curation_concern, :language, "Language") %>
     <%= decode_administrative_unit(curation_concern, :administrative_unit, "Departments and Units") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :organization, "Creator Organization(s)") %>
     <%= curation_concern_attribute_to_html(curation_concern, :library_collections, "Member of") %>
     <%= curation_concern_attribute_to_html(
             curation_concern,

--- a/app/views/curation_concern/datasets/_form_additional_information.html.erb
+++ b/app/views/curation_concern/datasets/_form_additional_information.html.erb
@@ -10,6 +10,7 @@
   <%= f.input :date_created,            input_html: { class: 'input-xxlarge datepicker' } %>
   <%= f.input :subject,                 as: :multi_value, input_html: { class: 'input-xxlarge' } %>
   <%= f.input :publisher,               as: :multi_value, label: "Publisher", input_html: { class: 'input-xxlarge', id: 'publisher' } %>
+  <%= f.input :organization,            as: :multi_value, input_html: { class: 'input-xxlarge' } %>
   <%= f.input :recommended_citation,    as: :multi_value, input_html: { class: 'input-xxlarge' } %>
   <%= f.input :language,                as: :multi_value, input_html: { class: 'input-xxlarge' } %>
   <%= f.input :source,                  as: :multi_value, input_html: { class: 'input-xxlarge' } %>

--- a/app/views/curation_concern/dissertations/_attributes.html.erb
+++ b/app/views/curation_concern/dissertations/_attributes.html.erb
@@ -46,6 +46,7 @@
   <%= curation_concern_attribute_to_html(curation_concern, :permission, "Use Permissions") %>
   <%= curation_concern_attribute_to_html(curation_concern, :degree_discipline, "Degree Discipline") %>
   <%= decode_administrative_unit(curation_concern, :administrative_unit, "Departments and Units") %>
+  <%= curation_concern_attribute_to_html(curation_concern, :organization, "Creator Organization(s)") %>
   <%= curation_concern_attribute_to_html(curation_concern, :library_collections, "Member of") %>
   <%= curation_concern_attribute_to_html(
           curation_concern,

--- a/app/views/curation_concern/dissertations/_form_additional_information.html.erb
+++ b/app/views/curation_concern/dissertations/_form_additional_information.html.erb
@@ -81,6 +81,6 @@
     as: :multi_value,
     input_html: { class: 'input-xxlarge' }
   %>
-
+  <%= f.input :organization,            as: :multi_value, input_html: { class: 'input-xxlarge' } %>
   <%= render partial: 'curation_concern/base/contributor', locals: {f: f, curation_concern: curation_concern} %>
 </fieldset>

--- a/app/views/curation_concern/documents/_attributes.html.erb
+++ b/app/views/curation_concern/documents/_attributes.html.erb
@@ -58,7 +58,6 @@
   <%= curation_concern_attribute_to_html(curation_concern, :contributor_institution,    'Contributor Institution') %>
   <%= curation_concern_attribute_to_html(curation_concern, :recommended_citation,       'Recommended Citation') %>
   <%= curation_concern_attribute_to_html(curation_concern, :local_identifier,           'Local Identifier') %>
-
   <tr>
     <th>Record Visibility</th>
     <td>
@@ -73,6 +72,7 @@
     <%= curation_concern_attribute_to_html(curation_concern, :license, 'License Agreement') %>
   <% end %>
   <%= decode_administrative_unit(curation_concern, :administrative_unit, 'Departments and Units') %>
+  <%= curation_concern_attribute_to_html(curation_concern, :organization, "Creator Organization(s)") %>
   <%= curation_concern_attribute_to_html(curation_concern, :library_collections, "Member of") %>
   </tbody>
 </table>

--- a/app/views/curation_concern/documents/_form_additional_information.html.erb
+++ b/app/views/curation_concern/documents/_form_additional_information.html.erb
@@ -43,4 +43,5 @@
   <%= f.input :repository_name,            label: 'Repository Name', as: :multi_value, input_html: { class: 'input-xxlarge' } %>
   <%= f.input :collection_name,            label: 'Collection Name', as: :multi_value, input_html: { class: 'input-xxlarge' } %>
   <%= f.input :recommended_citation,       label: 'Recommended Citation', as: :multi_value, input_html: { class: 'input-xxlarge' } %>
+  <%= f.input :organization,            as: :multi_value, input_html: { class: 'input-xxlarge' } %>
 </fieldset>

--- a/app/views/curation_concern/etds/_attributes.html.erb
+++ b/app/views/curation_concern/etds/_attributes.html.erb
@@ -62,6 +62,7 @@
   <%= curation_concern_attribute_to_html(curation_concern, :permission, "Use Permissions") %>
   <%= curation_concern_attribute_to_html(curation_concern, :note, "Note") %>
   <%= decode_administrative_unit(curation_concern, :administrative_unit, "Departments and Units") %>
+  <%= curation_concern_attribute_to_html(curation_concern, :organization, "Creator Organization(s)") %>
   <%= curation_concern_attribute_to_html(curation_concern, :library_collections, "Member of") %>
   <%= curation_concern_attribute_to_html(
           curation_concern,

--- a/app/views/curation_concern/etds/_form_descriptive_fields.erb
+++ b/app/views/curation_concern/etds/_form_descriptive_fields.erb
@@ -91,6 +91,7 @@
     as: :multi_value,
     input_html: { class: 'input-xxlarge' }
   %>
+  <%= f.input :organization,            as: :multi_value, input_html: { class: 'input-xxlarge' } %>
   <%= render partial: 'curation_concern/base/contributor', locals: {f: f, curation_concern: curation_concern} %>
   <%= f.input :note,
     as: :text,

--- a/app/views/curation_concern/generic_works/_attributes.html.erb
+++ b/app/views/curation_concern/generic_works/_attributes.html.erb
@@ -28,6 +28,7 @@
   <%= curation_concern_attribute_to_html(curation_concern, :rights, "Content License") %>
   <%= curation_concern_attribute_to_html(curation_concern, :permission, "Use Permissions") %>
   <%= decode_administrative_unit(curation_concern, :administrative_unit, "Departments and Units") %>
+  <%= curation_concern_attribute_to_html(curation_concern, :organization, "Creator Organization(s)") %>
   <%= curation_concern_attribute_to_html(curation_concern, :library_collections, "Member of") %>
   </tbody>
 </table>

--- a/app/views/curation_concern/images/_attributes.html.erb
+++ b/app/views/curation_concern/images/_attributes.html.erb
@@ -68,6 +68,7 @@
     <%= curation_concern_attribute_to_html(curation_concern, :vra_place_of_repository, "Place of Repository") %>
     <%= curation_concern_attribute_to_html(curation_concern, :vra_place_of_site, "Place of Site") %>
     <%= decode_administrative_unit(curation_concern, :administrative_unit, "Departments and Units") %>
+    <%= curation_concern_attribute_to_html(curation_concern, :organization, "Creator Organization(s)") %>
     <%= curation_concern_attribute_to_html(curation_concern, :library_collections, "Member of") %>
     <%= curation_concern_attribute_to_html(
             curation_concern,

--- a/app/views/curation_concern/images/_form_descriptive_fields.erb
+++ b/app/views/curation_concern/images/_form_descriptive_fields.erb
@@ -352,7 +352,7 @@
                   label: "Spatial Coverage",
                   input_html: { class: 'input-xxlarge' }
       %>
-
+      <%= f.input :organization,            as: :multi_value, input_html: { class: 'input-xxlarge' } %>
     </div>
   </div>
 </fieldset>


### PR DESCRIPTION
Creator#organization is defined in curate models for work types:
* Article
* Dataset
* Dissertation
* Document
* Etd
* GenericWork
* Image

It does not display in the model. It appears that it was used in 11 works from 1985 as sort of a predecessor to Administrative Unit.

This pull request updates the title and hint text and adds it back to the UI for both display and edit.

https://jira.library.nd.edu/browse/CURATE-397