### PR TITLE
Documentation re: document subtypes

### DIFF
--- a/app/repository_models/document.rb
+++ b/app/repository_models/document.rb
@@ -20,6 +20,7 @@ class Document < ActiveFedora::Base
   self.indefinite_article = 'an'
   self.contributor_label = 'Author'
 
+  # the list of valid document types. Changes will require a change to the type mapping on the Primo pipe 
   DOCUMENT_TYPES = [
     'Book Chapter',
     'Book',


### PR DESCRIPTION
A new document subtype requires mapping for the Primo pipe which uses the OAI endpoint. Add note to model so this is not forgotten in the future.