### PR TITLE
Remove product owner names

### DIFF
--- a/app/views/static_pages/_policy_content.erb
+++ b/app/views/static_pages/_policy_content.erb
@@ -1,6 +1,6 @@
 <div class="policy-list">
   <div class="policy-explanation">
-    <p>This page documents the policies for the University of Notre Dame’s institutional repository, CurateND. All questions should be directed to the CurateND support team at <%= mail_to('curate@nd.edu', 'curate@nd.edu', subject: 'Questions about CurateND policies') %>, currently led by Don Brower and Mikala Narlock.</p>
+    <p>This page documents the policies for the University of Notre Dame’s institutional repository, CurateND. All questions should be directed to the CurateND support team at <%= mail_to('curate@nd.edu', 'curate@nd.edu', subject: 'Questions about CurateND policies') %>.</p>
     <p>CurateND’s policies were revised and adopted 02/2021.</p>
   </div>
 


### PR DESCRIPTION
Completes CURATE-395 to remove product owner names from /policies