### PR TITLE
Restrict DOI editing

### DIFF
--- a/app/helpers/curation_concern_helper.rb
+++ b/app/helpers/curation_concern_helper.rb
@@ -45,6 +45,12 @@ module CurationConcernHelper
     TemporaryAccessToken.build_renewal_request_for(token_sha)
   end
 
+  def not_curate_minted_doi?(doi)
+    # Is this the best way to identify a curate-minted doi?
+    return false if doi.include?(Figaro.env.doi_shoulder)
+    true
+  end
+
   private
 
   def request_recipient

--- a/app/views/curation_concern/base/_form_supplementary_fields.html.erb
+++ b/app/views/curation_concern/base/_form_supplementary_fields.html.erb
@@ -6,7 +6,7 @@
   <div class="span12">
     <% if curation_concern.respond_to?(:doi) %>
       <%= render "form_doi", curation_concern: curation_concern, f: f %>
-      <% if curation_concern.respond_to?(:doi) && curation_concern.doi.present? %>
+      <% if curation_concern.respond_to?(:doi) && curation_concern.doi.present? && not_curate_minted_doi?(curation_concern.doi) %>
         <%= f.input :doi, label: 'Changes to DOI can be made here', input_html: { class: 'input-xlarge' } %>
       <% end %>
     <% end %>

--- a/app/views/curation_concern/senior_theses/_form.html.erb
+++ b/app/views/curation_concern/senior_theses/_form.html.erb
@@ -70,7 +70,7 @@
     <div class="span12">
       <% if curation_concern.respond_to?(:doi) %>
         <%= render "form_doi", curation_concern: curation_concern, f: f %>
-        <% if curation_concern.identifier.present? %>
+        <% if curation_concern.doi.present? && not_curate_minted_doi?(curation_concern.doi) %>
           <%= f.input :identifier, label: 'Changes to DOI can be made here', input_html: { class: 'input-xxlarge' } %>
         <% end %>
       <% end %>

--- a/config/application.yml
+++ b/config/application.yml
@@ -22,7 +22,7 @@ ORCID_APP_SECRET: "e1ff26a2-d889-40be-bd41-acac09214cae"
 
 DOI_USERNAME: "ADD THIS TO YOUR ENV"
 DOI_PASSWORD: "ADD THIS TO YOUR ENV"
-DOI_SHOULDER: "doi:10.5072/FK2"
+DOI_SHOULDER: "doi:10.7274"
 DOI_HOST: "ez.test.datacite.org"
 DOI_RESOLVER: "https://handle.test.datacite.org"
 DOI_PORT: "443"


### PR DESCRIPTION
Don't allow Curate-minted DOIs to be changed. Identified via the "doi_shoulder" variable.

Completes curate-50