### PR TITLE
Remove "Citation" option for generic files

### DIFF
--- a/app/repository_models/etd.rb
+++ b/app/repository_models/etd.rb
@@ -194,7 +194,8 @@ class Etd < ActiveFedora::Base
     # Program acronyms are no longer used as the primary degree discipline content. This adds indexes to acronyms mapped from the name (where available) to retain the ability to search by acronym.
     department_acronyms = []
     degree_disciplines.each do |disc|
-      discipline = ControlledVocabularyService.item_for_predicate_name(name: 'program_name', term_key: 'term_label', term_value: disc)
+      ignore_not_found = (disc.blank? ? true : false)
+      discipline = ControlledVocabularyService.item_for_predicate_name(name: 'program_name', term_key: 'term_label', term_value: disc, ignore_not_found: ignore_not_found)
       department_acronyms << discipline.acronym unless discipline.nil?
     end
     department_acronyms.compact

--- a/app/views/common_objects/show.html.erb
+++ b/app/views/common_objects/show.html.erb
@@ -18,7 +18,7 @@
 
 <% content_for :page_actions do %>
   <% unless controller.is_orphan_file? %>
-    <% if display_citation_generation? %>
+    <% if display_citation_generation? && !curation_concern.kind_of?(GenericFile) %>
       <%= link_to 'Generate Citation', citation_path(curation_concern) , class: 'btn citation-modal-js' %>
     <% end %>
     <%= link_to 'Usage Details', metrics_usage_path(id: curation_concern.noid) , class: 'btn btn-default' %>

--- a/app/views/curation_concern/base/show.html.erb
+++ b/app/views/curation_concern/base/show.html.erb
@@ -7,7 +7,7 @@
 
 <% content_for :page_actions do %>
   <% unless controller.is_orphan_file? %>
-    <% if display_citation_generation? %>
+    <% if display_citation_generation? && !curation_concern.kind_of?(GenericFile) %>
       <%= link_to 'Generate Citation', citation_path(curation_concern) , class: 'btn citation-modal-js' %>
     <% end %>
   <% end %>


### PR DESCRIPTION
Removes the citation button from the view for generic files.

Also stops a locabulary error message from sending to Sentry when unnecessary.

Fixes DAS-3016