### PR TITLE
Standardize doi format

### DIFF
--- a/app/repository_models/curation_concern/remotely_identified_by_doi.rb
+++ b/app/repository_models/curation_concern/remotely_identified_by_doi.rb
@@ -19,7 +19,7 @@ module CurationConcern
           multiple: false, 
           writer: lambda {|value| normalize_identifier(value) }
 
-        validate :remove_white_space_in_doi
+        validate :remove_white_space_and_normalize_doi
 
         alias_method :identifier, :doi
         alias_method :identifier=, :doi=
@@ -54,8 +54,10 @@ module CurationConcern
 
         private
 
-        def remove_white_space_in_doi
-          self.doi.gsub!(' ', '') if self.respond_to?(:doi) && self.doi.present?
+        def remove_white_space_and_normalize_doi
+          if self.respond_to?(:doi) && self.doi.present?
+            self.doi = normalize_identifier(self.doi)
+          end
         end
       end
     end

--- a/app/services/doi/datacite.rb
+++ b/app/services/doi/datacite.rb
@@ -14,7 +14,7 @@ module Doi
     def self.normalize_identifier(value)
       value.to_s.strip
            .gsub(' ', '')
-           .sub(/\A.*10\./, 'doi:10.')
+           .sub(/\A.*?10\./, 'doi:10.')
     end
 
     def self.remote_uri_for(identifier)

--- a/spec/services/doi/datacite_spec.rb
+++ b/spec/services/doi/datacite_spec.rb
@@ -41,7 +41,9 @@ module Doi
         ["doi: 10.25626/abc123", 'doi:10.25626/abc123'],
         ["doi: 10.25626 / abc123", 'doi:10.25626/abc123'],
         ['https://doi:10.123/abc', 'doi:10.123/abc'],
-        ["https://doi.org/10.1002/ppsc.201700420", "doi:10.1002/ppsc.201700420"]
+        ["https://doi.org/10.1002/ppsc.201700420", "doi:10.1002/ppsc.201700420"],
+        ["https://doi.org/10.1002/ppsc.201700420", "doi:10.1002/ppsc.201700420"],
+        ["https://doi.org/10.1002/12310.56789/abc", "doi:10.1002/12310.56789/abc"]
       ].each do |given, expected|
         it "normalizes a doi" do
           expect(subject.normalize_identifier(given)).to eq(expected)


### PR DESCRIPTION
All doi values are sent through a method to standardize the format to `doi:10.xxxxxxxxxxx` when a work is saved in the Curate UI. 

Completes https://jira.library.nd.edu/browse/CURATE-372