### PR TITLE
Build valid remote URI

### DIFF
--- a/app/services/doi/datacite.rb
+++ b/app/services/doi/datacite.rb
@@ -18,13 +18,17 @@ module Doi
     end
 
     def self.remote_uri_for(identifier)
-      URI.parse(File.join(resolver_url, identifier))
+      URI.parse(URI.encode(File.join(resolver_url, clean_identifier(identifier))))
     rescue URI::InvalidURIError => e
       Sentry.capture_exception(e)
       nil
     end
 
 private
+
+    def self.clean_identifier(value)
+      normalize_identifier(value).sub(/\A.*?10\./, '10.')
+    end
 
     # Concatenate user:password for basic authentication
     def self.auth_details

--- a/spec/services/doi/datacite_spec.rb
+++ b/spec/services/doi/datacite_spec.rb
@@ -53,7 +53,7 @@ module Doi
 
     describe '#remote_uri_for' do
       it 'concatenates the resolver url defined in the env with the identifier given' do
-        expect(subject.remote_uri_for('doi:10.25626/abc123').to_s).to eq("#{ENV.fetch('DOI_RESOLVER')}/doi:10.25626/abc123")
+        expect(subject.remote_uri_for('doi:10.25626/abc123').to_s).to eq("#{ENV.fetch('DOI_RESOLVER')}/10.25626/abc123")
       end
     end
   end


### PR DESCRIPTION
URI in prep doesn't work with `doi:` prefix on doi.
Prep URI was receiving an invalid URI error, and was returning nil for the URI.

URI in prod will work without the `doi:` prefix, so I removed `doi:` from the URI being built.
I also added URI.encode to make sure we have a valid URI.

Completes issue DAS-3018